### PR TITLE
refactor(webview): relocate model selector

### DIFF
--- a/vscode/webviews/CodyPanel.tsx
+++ b/vscode/webviews/CodyPanel.tsx
@@ -121,6 +121,7 @@ export const CodyPanel: FunctionComponent<CodyPanelProps> = ({
                 {/* Hide tab bar in editor chat panels. */}
                 {config.webviewType !== 'editor' && (
                     <TabsBar
+                        models={chatModels}
                         user={user}
                         currentView={view}
                         setView={setView}

--- a/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/ModeSelectorButton.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/ModeSelectorButton.tsx
@@ -1,0 +1,204 @@
+import type { ChatMessage } from '@sourcegraph/cody-shared'
+import { CodyIDE } from '@sourcegraph/cody-shared'
+import { BetweenHorizonalEnd, InfoIcon, MessageSquare, Pencil, Search } from 'lucide-react'
+import type { FC } from 'react'
+import { useCallback, useMemo, useState } from 'react'
+import { Kbd } from '../../../../../../components/Kbd'
+import { Badge } from '../../../../../../components/shadcn/ui/badge'
+import { Command, CommandItem, CommandList } from '../../../../../../components/shadcn/ui/command'
+import { ToolbarPopoverItem } from '../../../../../../components/shadcn/ui/toolbar'
+import { cn } from '../../../../../../components/shadcn/utils'
+import { useConfig } from '../../../../../../utils/useConfig'
+
+enum IntentEnum {
+    Chat = 'Chat',
+    Search = 'Search',
+    Edit = 'Edit',
+    Insert = 'Insert',
+}
+
+// Mapping between ChatMessage intent and IntentEnum for faster lookups
+const INTENT_MAPPING: Record<string, IntentEnum> = {
+    chat: IntentEnum.Chat,
+    search: IntentEnum.Search,
+    edit: IntentEnum.Edit,
+    insert: IntentEnum.Insert,
+}
+
+interface IntentOption {
+    title: string | React.ReactElement
+    icon: React.FC<{ className?: string }>
+    intent: ChatMessage['intent']
+    shortcut?: React.ReactNode
+    hidden?: boolean
+    disabled?: boolean
+}
+
+const defaultIntent: IntentOption = {
+    title: 'Run as chat',
+    icon: MessageSquare,
+    intent: 'chat',
+    shortcut: <Kbd macOS="return" linuxAndWindows="return" />,
+}
+
+// Memoize the enterprise badge and keyboard shortcuts to avoid recreating React elements
+const ENTERPRISE_BADGE = (
+    <Badge>
+        Enterprise <InfoIcon className="tw-size-4 tw-ml-1" />
+    </Badge>
+)
+
+const SEARCH_SHORTCUT = (
+    <>
+        <Kbd macOS="cmd" linuxAndWindows="ctrl" />
+        <Kbd macOS="opt" linuxAndWindows="alt" />
+        <Kbd macOS="return" linuxAndWindows="return" />
+    </>
+)
+
+// Optimization: memoize search title to avoid recreation
+const SEARCH_TITLE = (
+    <span className="tw-inline-flex tw-items-center tw-gap-4">
+        <span>Run as search</span>
+        <Badge>Beta</Badge>
+    </span>
+)
+
+function getIntentOptions({
+    isCodyWeb,
+    isDotComUser,
+    omniBoxEnabled,
+}: {
+    isCodyWeb: boolean
+    isDotComUser: boolean
+    omniBoxEnabled: boolean
+}): IntentOption[] {
+    return [
+        defaultIntent,
+        {
+            title: SEARCH_TITLE,
+            icon: Search,
+            intent: 'search',
+            hidden: !omniBoxEnabled,
+            disabled: isDotComUser,
+            shortcut: isDotComUser ? ENTERPRISE_BADGE : SEARCH_SHORTCUT,
+        },
+        {
+            title: 'Edit Code',
+            icon: Pencil,
+            intent: 'edit',
+            hidden: true,
+            disabled: isCodyWeb,
+        },
+        {
+            title: 'Insert Code',
+            icon: BetweenHorizonalEnd,
+            intent: 'insert',
+            hidden: true,
+            disabled: isCodyWeb,
+        },
+    ]
+}
+
+export const ModeSelectorField: React.FunctionComponent<{
+    omniBoxEnabled: boolean
+    onClick: (intent?: ChatMessage['intent']) => void
+    detectedIntent?: ChatMessage['intent']
+    className?: string
+    manuallySelectIntent: (intent?: ChatMessage['intent']) => void
+}> = ({ className, omniBoxEnabled, onClick, manuallySelectIntent }) => {
+    const {
+        clientCapabilities: { agentIDE },
+        isDotComUser,
+    } = useConfig()
+
+    const intentOptions = useMemo(
+        () =>
+            getIntentOptions({
+                isCodyWeb: agentIDE === CodyIDE.Web,
+                isDotComUser,
+                omniBoxEnabled,
+            }).filter(option => !option.hidden),
+        [agentIDE, isDotComUser, omniBoxEnabled]
+    )
+
+    const [selectedIntent, setSelectedIntent] = useState<IntentEnum>(IntentEnum.Chat)
+
+    // Optimized: replaced nested ternaries with direct mapping lookup
+    const onSelectedIntentChange = useCallback(
+        (intent: ChatMessage['intent']) => {
+            // Get the enum value from mapping or default to Chat
+            const displayedIntent = INTENT_MAPPING[intent || 'chat'] || IntentEnum.Chat
+            setSelectedIntent(displayedIntent)
+            manuallySelectIntent(intent)
+            onClick(intent)
+        },
+        [manuallySelectIntent, onClick]
+    )
+
+    // Memoize the handler to avoid recreating on each render
+    const handleItemClick = useCallback(
+        (close: () => void) => (item: ChatMessage['intent']) => {
+            onSelectedIntentChange(item)
+            close()
+        },
+        [onSelectedIntentChange]
+    )
+
+    return (
+        <ToolbarPopoverItem
+            role="combobox"
+            iconEnd="chevron"
+            className={cn('tw-justify-between', className)}
+            tooltip="Select a mode"
+            aria-label="Select mode"
+            popoverContent={close => (
+                <div className="tw-flex tw-flex-col tw-max-h-[500px] tw-overflow-auto">
+                    <ModeList onClick={handleItemClick(close)} intentOptions={intentOptions} />
+                </div>
+            )}
+            popoverContentProps={{
+                className: 'tw-min-w-[200px] tw-w-[75vw] tw-max-w-[300px] !tw-p-0',
+                onCloseAutoFocus: event => {
+                    event.preventDefault()
+                },
+            }}
+        >
+            {selectedIntent.charAt(0).toUpperCase() + selectedIntent.slice(1)}
+        </ToolbarPopoverItem>
+    )
+}
+
+export const ModeList: FC<{
+    onClick: (intent?: ChatMessage['intent']) => void
+    intentOptions: IntentOption[]
+}> = ({ onClick, intentOptions }) => {
+    // Create a memoized handler for each item to prevent unnecessary recreations
+    const createItemHandler = useCallback(
+        (intent: ChatMessage['intent']) => () => {
+            onClick(intent)
+        },
+        [onClick]
+    )
+
+    return (
+        <Command>
+            <CommandList className="tw-p-2">
+                {intentOptions.map(option => (
+                    <CommandItem
+                        key={option.intent || 'auto'}
+                        onSelect={createItemHandler(option.intent)}
+                        disabled={option.disabled}
+                        className="tw-flex tw-text-left tw-justify-between tw-rounded-sm tw-cursor-pointer tw-px-4"
+                    >
+                        <div className="tw-flex tw-gap-4">
+                            <option.icon className="tw-size-8 tw-mt-1" />
+                            {option.title}
+                        </div>
+                        {option.shortcut && <div className="tw-flex tw-gap-2">{option.shortcut}</div>}
+                    </CommandItem>
+                ))}
+            </CommandList>
+        </Command>
+    )
+}

--- a/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/ModeSelectorButton.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/ModeSelectorButton.tsx
@@ -2,7 +2,7 @@ import type { ChatMessage } from '@sourcegraph/cody-shared'
 import { CodyIDE } from '@sourcegraph/cody-shared'
 import { BetweenHorizonalEnd, InfoIcon, MessageSquare, Pencil, Search } from 'lucide-react'
 import type { FC } from 'react'
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useMemo } from 'react'
 import { Kbd } from '../../../../../../components/Kbd'
 import { Badge } from '../../../../../../components/shadcn/ui/badge'
 import { Command, CommandItem, CommandList } from '../../../../../../components/shadcn/ui/command'
@@ -10,7 +10,7 @@ import { ToolbarPopoverItem } from '../../../../../../components/shadcn/ui/toolb
 import { cn } from '../../../../../../components/shadcn/utils'
 import { useConfig } from '../../../../../../utils/useConfig'
 
-enum IntentEnum {
+export enum IntentEnum {
     Chat = 'Chat',
     Search = 'Search',
     Edit = 'Edit',
@@ -18,7 +18,7 @@ enum IntentEnum {
 }
 
 // Mapping between ChatMessage intent and IntentEnum for faster lookups
-const INTENT_MAPPING: Record<string, IntentEnum> = {
+export const INTENT_MAPPING: Record<string, IntentEnum> = {
     chat: IntentEnum.Chat,
     search: IntentEnum.Search,
     edit: IntentEnum.Edit,
@@ -102,11 +102,10 @@ function getIntentOptions({
 
 export const ModeSelectorField: React.FunctionComponent<{
     omniBoxEnabled: boolean
-    onClick: (intent?: ChatMessage['intent']) => void
-    detectedIntent?: ChatMessage['intent']
+    intent: ChatMessage['intent']
     className?: string
     manuallySelectIntent: (intent?: ChatMessage['intent']) => void
-}> = ({ className, omniBoxEnabled, onClick, manuallySelectIntent }) => {
+}> = ({ className, intent, omniBoxEnabled, manuallySelectIntent }) => {
     const {
         clientCapabilities: { agentIDE },
         isDotComUser,
@@ -122,27 +121,15 @@ export const ModeSelectorField: React.FunctionComponent<{
         [agentIDE, isDotComUser, omniBoxEnabled]
     )
 
-    const [selectedIntent, setSelectedIntent] = useState<IntentEnum>(IntentEnum.Chat)
-
-    // Optimized: replaced nested ternaries with direct mapping lookup
-    const onSelectedIntentChange = useCallback(
-        (intent: ChatMessage['intent']) => {
-            // Get the enum value from mapping or default to Chat
-            const displayedIntent = INTENT_MAPPING[intent || 'chat'] || IntentEnum.Chat
-            setSelectedIntent(displayedIntent)
-            manuallySelectIntent(intent)
-            onClick(intent)
-        },
-        [manuallySelectIntent, onClick]
-    )
+    const displayedIntent = INTENT_MAPPING[intent || 'chat'] || IntentEnum.Chat
 
     // Memoize the handler to avoid recreating on each render
     const handleItemClick = useCallback(
         (close: () => void) => (item: ChatMessage['intent']) => {
-            onSelectedIntentChange(item)
+            manuallySelectIntent(item)
             close()
         },
-        [onSelectedIntentChange]
+        [manuallySelectIntent]
     )
 
     return (
@@ -164,7 +151,7 @@ export const ModeSelectorField: React.FunctionComponent<{
                 },
             }}
         >
-            {selectedIntent.charAt(0).toUpperCase() + selectedIntent.slice(1)}
+            {displayedIntent}
         </ToolbarPopoverItem>
     )
 }

--- a/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/SubmitButton.story.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/SubmitButton.story.tsx
@@ -25,7 +25,6 @@ const meta: Meta<typeof SubmitButton> = {
                         state: args.state === 'submittable' ? 'waitingResponseComplete' : 'submittable',
                     })
                 }}
-                manuallySelectIntent={() => {}}
             />
         )
     },

--- a/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/SubmitButton.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/SubmitButton.tsx
@@ -9,16 +9,15 @@ export const SubmitButton: FC<{
     onClick: (intent?: ChatMessage['intent']) => void
     isEditorFocused?: boolean
     state?: SubmitButtonState
-    detectedIntent?: ChatMessage['intent']
-    manuallySelectIntent: (intent?: ChatMessage['intent']) => void
-}> = ({ onClick, state = 'submittable', detectedIntent, manuallySelectIntent }) => {
+    intent?: ChatMessage['intent']
+}> = ({ onClick, state = 'submittable', intent }) => {
     const inProgress = state === 'waitingResponseComplete'
 
     return (
         <div className="tw-flex">
             <button
                 type="submit"
-                onClick={() => onClick()}
+                onClick={() => onClick(intent)}
                 className={clsx(
                     'tw-px-6 tw-py-1',
                     'tw-rounded-full',

--- a/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/SubmitButton.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/SubmitButton.tsx
@@ -1,105 +1,9 @@
-import {
-    Popover,
-    PopoverContent,
-    type PopoverContentProps,
-    type PopoverProps,
-    PopoverTrigger,
-} from '@radix-ui/react-popover'
 import type { ChatMessage } from '@sourcegraph/cody-shared'
-import { CodyIDE } from '@sourcegraph/cody-shared'
 import clsx from 'clsx'
-import {
-    BetweenHorizonalEnd,
-    ChevronDown,
-    InfoIcon,
-    MessageSquare,
-    Pencil,
-    Play,
-    Search,
-    Square,
-} from 'lucide-react'
-import type { FC, FunctionComponent, KeyboardEventHandler, PropsWithChildren } from 'react'
-import { useCallback, useMemo, useRef, useState } from 'react'
-import { Kbd } from '../../../../../../components/Kbd'
-import { Badge } from '../../../../../../components/shadcn/ui/badge'
-import { Command, CommandItem, CommandList } from '../../../../../../components/shadcn/ui/command'
-import { useConfig } from '../../../../../../utils/useConfig'
-import { useOmniBox } from '../../../../../../utils/useOmniBox'
+import { Play, Square } from 'lucide-react'
+import type { FC } from 'react'
 
 export type SubmitButtonState = 'submittable' | 'emptyEditorValue' | 'waitingResponseComplete'
-
-interface IntentOption {
-    title: string | React.ReactElement
-    icon: React.FC<{ className?: string }>
-    intent: ChatMessage['intent']
-    shortcut?: React.ReactNode
-    hidden?: boolean
-    disabled?: boolean
-}
-
-function getIntentOptions({
-    ide,
-    isDotComUser,
-    omniBoxEnabled,
-}: {
-    ide: CodyIDE
-    isDotComUser: boolean
-    omniBoxEnabled: boolean
-}): IntentOption[] {
-    const standardOneBoxIntents: IntentOption[] = [
-        {
-            title: 'Run as chat',
-            icon: MessageSquare,
-            intent: 'chat',
-            shortcut: <Kbd macOS="return" linuxAndWindows="return" />,
-        },
-    ]
-
-    if (omniBoxEnabled) {
-        standardOneBoxIntents.push({
-            title: (
-                <span className="tw-inline-flex tw-items-center tw-gap-4">
-                    <span>Run as search</span>
-                    <Badge>Beta</Badge>
-                </span>
-            ),
-            icon: Search,
-            intent: 'search',
-            disabled: isDotComUser,
-            shortcut: isDotComUser ? (
-                <Badge>
-                    Enterprise <InfoIcon className="tw-size-4 tw-ml-1" />
-                </Badge>
-            ) : (
-                <>
-                    <Kbd macOS="cmd" linuxAndWindows="ctrl" />
-                    <Kbd macOS="opt" linuxAndWindows="alt" />
-                    <Kbd macOS="return" linuxAndWindows="return" />
-                </>
-            ),
-        })
-    }
-
-    if (ide === CodyIDE.Web) {
-        return standardOneBoxIntents
-    }
-
-    return [
-        ...standardOneBoxIntents,
-        {
-            title: 'Edit Code',
-            icon: Pencil,
-            intent: 'edit',
-            hidden: true,
-        },
-        {
-            title: 'Insert Code',
-            icon: BetweenHorizonalEnd,
-            intent: 'insert',
-            hidden: true,
-        },
-    ]
-}
 
 export const SubmitButton: FC<{
     onClick: (intent?: ChatMessage['intent']) => void
@@ -108,223 +12,28 @@ export const SubmitButton: FC<{
     detectedIntent?: ChatMessage['intent']
     manuallySelectIntent: (intent?: ChatMessage['intent']) => void
 }> = ({ onClick, state = 'submittable', detectedIntent, manuallySelectIntent }) => {
-    const {
-        clientCapabilities: { agentIDE },
-        isDotComUser,
-    } = useConfig()
-    const omniBoxEnabled = useOmniBox()
-
-    const { intentOptions, availableIntentOptions, disabledIntentOptions } = useMemo(() => {
-        const intentOptions = getIntentOptions({
-            ide: agentIDE,
-            isDotComUser,
-            omniBoxEnabled,
-        }).filter(option => !option.hidden)
-
-        return {
-            intentOptions,
-            availableIntentOptions: intentOptions.filter(option => !option.disabled),
-            disabledIntentOptions: intentOptions.filter(option => option.disabled),
-        }
-    }, [agentIDE, isDotComUser, omniBoxEnabled])
-
     const inProgress = state === 'waitingResponseComplete'
 
-    const detectedIntentOption = intentOptions.find(option => option.intent === detectedIntent)
-
-    const Icon = detectedIntentOption?.intent ? detectedIntentOption.icon : Play
-    const iconClassName = `tw-size-6 ${
-        detectedIntentOption?.intent === 'search' ? '' : 'tw-fill-current'
-    }`
-
-    if (!omniBoxEnabled || inProgress) {
-        return (
-            <div className="tw-flex">
-                <button
-                    type="submit"
-                    onClick={() => onClick()}
-                    className={clsx(
-                        'tw-px-6 tw-py-1',
-                        'tw-rounded-full',
-                        'tw-w-full tw-relative tw-border tw-border-button-border tw-box-content tw-bg-button-background hover:tw-bg-button-background-hover tw-text-button-foreground',
-
-                        'disabled:tw-bg-button-secondary-background disabled:tw-text-muted-foreground'
-                    )}
-                    title={inProgress ? 'Stop' : 'Send'}
-                >
-                    {inProgress ? (
-                        <Square className="tw-size-6 tw-fill-current" />
-                    ) : (
-                        <Play className="tw-size-6 tw-fill-current" />
-                    )}
-                </button>
-            </div>
-        )
-    }
-
     return (
-        <div className="tw-flex tw-items-center">
+        <div className="tw-flex">
             <button
                 type="submit"
                 onClick={() => onClick()}
                 className={clsx(
-                    'tw-px-3 tw-py-1 md:twpx-4 md:tw-py-2',
-                    'tw-rounded-tl-full tw-rounded-bl-full',
+                    'tw-px-6 tw-py-1',
+                    'tw-rounded-full',
                     'tw-w-full tw-relative tw-border tw-border-button-border tw-box-content tw-bg-button-background hover:tw-bg-button-background-hover tw-text-button-foreground',
 
                     'disabled:tw-bg-button-secondary-background disabled:tw-text-muted-foreground'
                 )}
-                title="Send"
+                title={inProgress ? 'Stop' : 'Send'}
             >
-                <Icon className={iconClassName} />
+                {inProgress ? (
+                    <Square className="tw-size-6 tw-fill-current" />
+                ) : (
+                    <Play className="tw-size-6 tw-fill-current" />
+                )}
             </button>
-            <PopoverItem
-                aria-label="Insert prompt"
-                popoverContent={close => (
-                    <Command>
-                        <CommandList className="tw-p-2">
-                            {availableIntentOptions.map(option => (
-                                <CommandItem
-                                    key={option.intent || 'auto'}
-                                    onSelect={() => {
-                                        manuallySelectIntent(option.intent)
-                                        close()
-                                    }}
-                                    className="tw-flex tw-text-left tw-justify-between tw-rounded-sm tw-cursor-pointer tw-px-4"
-                                >
-                                    <div className="tw-flex tw-gap-4">
-                                        <option.icon className="tw-size-8 tw-mt-1" />
-                                        {option.title}
-                                    </div>
-                                    {option.shortcut && (
-                                        <div className="tw-flex tw-gap-2">{option.shortcut}</div>
-                                    )}
-                                </CommandItem>
-                            ))}
-                            {disabledIntentOptions.map(option => (
-                                <CommandItem
-                                    key={option.intent || 'auto'}
-                                    onSelect={() => {
-                                        onClick(option.intent)
-                                        close()
-                                    }}
-                                    disabled={true}
-                                    className="tw-flex tw-text-left tw-justify-between tw-rounded-sm tw-cursor-pointer"
-                                >
-                                    <div className="tw-flex tw-gap-2">
-                                        <option.icon className="tw-size-8 tw-mt-1" />
-                                        {option.title}
-                                    </div>
-                                    {option.shortcut && (
-                                        <div className="tw-flex tw-gap-2">{option.shortcut}</div>
-                                    )}
-                                </CommandItem>
-                            ))}
-                        </CommandList>
-                    </Command>
-                )}
-                popoverContentProps={{
-                    className: 'tw-w-[350px] !tw-p-0 tw-z-10 tw-my-2',
-                    onCloseAutoFocus: event => {
-                        // Prevent the popover trigger from stealing focus after the user selects an
-                        // item. We want the focus to return to the editor.
-                        event.preventDefault()
-                    },
-                }}
-            >
-                <button
-                    type="button"
-                    className={clsx(
-                        'tw-pl-1 tw-pr-2 tw-py-1 md:pl-2 md:tw-pr-3 md:tw-py-2',
-                        'tw-rounded-tr-full tw-rounded-br-full tw-border-l-0',
-                        'tw-w-full tw-relative tw-border tw-border-button-border tw-box-content tw-bg-button-background hover:tw-bg-button-background-hover tw-text-button-foreground',
-                        'disabled:tw-bg-button-secondary-background disabled:tw-text-muted-foreground'
-                    )}
-                    title="Send"
-                >
-                    <ChevronDown className="tw-size-6" />
-                </button>
-            </PopoverItem>
         </div>
-    )
-}
-
-const PopoverItem: FunctionComponent<
-    PropsWithChildren<{
-        popoverContent: (close: () => void) => React.ReactNode
-
-        defaultOpen?: boolean
-
-        onCloseByEscape?: () => void
-
-        popoverRootProps?: Pick<PopoverProps, 'onOpenChange'>
-        popoverContentProps?: Omit<PopoverContentProps, 'align'>
-    }>
-> = ({
-    popoverContent,
-    defaultOpen,
-    onCloseByEscape,
-    popoverRootProps,
-    popoverContentProps,
-    children,
-}) => {
-    const [isOpen, setIsOpen] = useState(defaultOpen)
-    const anchorRef = useRef<HTMLButtonElement>(null)
-
-    const popoverContentRef = useRef<HTMLDivElement>(null)
-
-    const onOpenChange = useCallback(
-        (open: boolean): void => {
-            popoverRootProps?.onOpenChange?.(open)
-
-            setIsOpen(open)
-
-            // Ensure we blur the popover content if it was focused, because React's `onBlur`
-            // doesn't get called when the focused event is unmounted (see
-            // https://github.com/facebook/react/issues/12363#issuecomment-1988608527). This causes
-            // a bug in our HumanMessageEditor where if you interact with any toolbar items that
-            // steal focus for their menu, then the HumanMessageRow stays with partial focus
-            // styling. See the "chat toolbar and row UI" e2e test.
-            if (
-                document.activeElement instanceof HTMLElement &&
-                popoverContentRef.current?.contains(document.activeElement)
-            ) {
-                anchorRef.current?.focus()
-            }
-        },
-        [popoverRootProps?.onOpenChange]
-    )
-
-    const close = useCallback(() => {
-        onOpenChange(false)
-    }, [onOpenChange])
-
-    // After pressing Escape, return focus to the given component.
-    const onKeyDownInPopoverContent = useCallback<KeyboardEventHandler<HTMLDivElement>>(
-        event => {
-            if (event.key === 'Escape') {
-                onCloseByEscape?.()
-            }
-            popoverContentProps?.onKeyDown?.(event)
-        },
-        [onCloseByEscape, popoverContentProps?.onKeyDown]
-    )
-
-    return (
-        <Popover open={isOpen} onOpenChange={onOpenChange} defaultOpen={defaultOpen}>
-            <PopoverTrigger asChild={true}>{children}</PopoverTrigger>
-            <PopoverContent
-                align="end"
-                onKeyDown={onKeyDownInPopoverContent}
-                ref={popoverContentRef}
-                {...popoverContentProps}
-                className={clsx(
-                    'tw-w-[350px] !tw-p-0 tw-z-10 tw-my-2 tw-shadow-lg tw-border tw-border-button-border tw-rounded-md',
-                    popoverContentProps?.className
-                )}
-            >
-                {popoverContent(close)}
-            </PopoverContent>
-        </Popover>
     )
 }

--- a/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/Toolbar.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/Toolbar.tsx
@@ -5,10 +5,9 @@ import { type FunctionComponent, useCallback } from 'react'
 import type { UserAccountInfo } from '../../../../../../Chat'
 import { ModelSelectField } from '../../../../../../components/modelSelectField/ModelSelectField'
 import { PromptSelectField } from '../../../../../../components/promptSelectField/PromptSelectField'
-import toolbarStyles from '../../../../../../components/shadcn/ui/toolbar.module.css'
 import { useActionSelect } from '../../../../../../prompts/PromptsTab'
 import { useClientConfig } from '../../../../../../utils/useClientConfig'
-import { AddContextButton } from './AddContextButton'
+import { ModeSelectorField } from './ModeSelectorButton'
 import { SubmitButton, type SubmitButtonState } from './SubmitButton'
 
 /**
@@ -38,7 +37,6 @@ export const Toolbar: FunctionComponent<{
 }> = ({
     userInfo,
     isEditorFocused,
-    onMentionClick,
     onSubmitClick,
     submitState,
     onGapClick,
@@ -64,7 +62,7 @@ export const Toolbar: FunctionComponent<{
         },
         [onGapClick]
     )
-
+    // const omniBoxEnabled = useOmniBox()
     return (
         // biome-ignore lint/a11y/useKeyWithClickEvents: only relevant to click areas
         <menu
@@ -80,19 +78,13 @@ export const Toolbar: FunctionComponent<{
             data-testid="chat-editor-toolbar"
         >
             <div className="tw-flex tw-items-center">
-                {/* Can't use tw-gap-1 because the popover creates an empty element when open. */}
-                {onMentionClick && (
-                    <AddContextButton
-                        onClick={onMentionClick}
-                        className={`tw-opacity-60 focus-visible:tw-opacity-100 hover:tw-opacity-100 tw-mr-2 tw-gap-0.5 ${toolbarStyles.button} ${toolbarStyles.buttonSmallIcon}`}
-                    />
-                )}
                 <PromptSelectFieldToolbarItem focusEditor={focusEditor} className="tw-ml-1 tw-mr-1" />
-                <ModelSelectFieldToolbarItem
-                    models={models}
-                    userInfo={userInfo}
-                    focusEditor={focusEditor}
-                    className="tw-mr-1"
+                <ModeSelectorField
+                    className={className}
+                    omniBoxEnabled={true}
+                    onClick={onSubmitClick}
+                    detectedIntent={intent}
+                    manuallySelectIntent={manuallySelectIntent}
                 />
             </div>
             <div className="tw-flex-1 tw-flex tw-justify-end">

--- a/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/Toolbar.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/Toolbar.tsx
@@ -1,12 +1,9 @@
 import type { Action, ChatMessage, Model } from '@sourcegraph/cody-shared'
-import { useExtensionAPI } from '@sourcegraph/prompt-editor'
 import clsx from 'clsx'
 import { type FunctionComponent, useCallback, useState } from 'react'
 import type { UserAccountInfo } from '../../../../../../Chat'
-import { ModelSelectField } from '../../../../../../components/modelSelectField/ModelSelectField'
 import { PromptSelectField } from '../../../../../../components/promptSelectField/PromptSelectField'
 import { useActionSelect } from '../../../../../../prompts/PromptsTab'
-import { useClientConfig } from '../../../../../../utils/useClientConfig'
 import { useOmniBox } from '../../../../../../utils/useOmniBox'
 import { ModeSelectorField } from './ModeSelectorButton'
 import { SubmitButton, type SubmitButtonState } from './SubmitButton'
@@ -91,19 +88,13 @@ export const Toolbar: FunctionComponent<{
             data-testid="chat-editor-toolbar"
         >
             <div className="tw-flex tw-items-center">
-                <PromptSelectFieldToolbarItem focusEditor={focusEditor} className="tw-ml-1 tw-mr-1" />
-                <ModelSelectFieldToolbarItem
-                    models={models}
-                    userInfo={userInfo}
-                    focusEditor={focusEditor}
-                    className="tw-mr-1"
-                />
                 <ModeSelectorField
                     className={className}
                     omniBoxEnabled={omniBoxEnabled}
                     intent={selectedIntent}
                     manuallySelectIntent={onSelectedIntentChange}
                 />
+                <PromptSelectFieldToolbarItem focusEditor={focusEditor} className="tw-ml-1 tw-mr-1" />
             </div>
             <div className="tw-flex-1 tw-flex tw-justify-end">
                 <SubmitButton
@@ -132,41 +123,4 @@ const PromptSelectFieldToolbarItem: FunctionComponent<{
     )
 
     return <PromptSelectField onSelect={onSelect} onCloseByEscape={focusEditor} className={className} />
-}
-
-const ModelSelectFieldToolbarItem: FunctionComponent<{
-    models: Model[]
-    userInfo: UserAccountInfo
-    focusEditor?: () => void
-    className?: string
-}> = ({ userInfo, focusEditor, className, models }) => {
-    const clientConfig = useClientConfig()
-    const serverSentModelsEnabled = !!clientConfig?.modelsAPIEnabled
-
-    const api = useExtensionAPI()
-
-    const onModelSelect = useCallback(
-        (model: Model) => {
-            api.setChatModel(model.id).subscribe({
-                error: error => console.error('setChatModel:', error),
-            })
-            focusEditor?.()
-        },
-        [api.setChatModel, focusEditor]
-    )
-
-    return (
-        !!models?.length &&
-        (userInfo.isDotComUser || serverSentModelsEnabled) && (
-            <ModelSelectField
-                models={models}
-                onModelSelect={onModelSelect}
-                serverSentModelsEnabled={serverSentModelsEnabled}
-                userInfo={userInfo}
-                onCloseByEscape={focusEditor}
-                className={className}
-                data-testid="chat-model-selector"
-            />
-        )
-    )
 }

--- a/vscode/webviews/tabs/utils.ts
+++ b/vscode/webviews/tabs/utils.ts
@@ -15,11 +15,7 @@ interface NewChatCommandInput {
  * complexity about exact command that would be run.
  */
 export function getCreateNewChatCommand(options: NewChatCommandInput): string {
-    const { IDE, webviewType, multipleWebviewsEnabled } = options
+    const { IDE } = options
 
-    return IDE === CodyIDE.Web
-        ? 'cody.chat.new'
-        : webviewType === 'sidebar' || !multipleWebviewsEnabled
-          ? 'cody.chat.newPanel'
-          : 'cody.chat.newEditorPanel'
+    return IDE === CodyIDE.Web ? 'cody.chat.new' : 'cody.chat.newPanel'
 }


### PR DESCRIPTION
Context: https://sourcegraph.slack.com/archives/C08DP4R5CG0/p1740789400315269

part of https://linear.app/sourcegraph/issue/CODY-5194/move-model-selector-to-the-top-nav-bar

![image](https://github.com/user-attachments/assets/199be697-903e-4280-ad83-66aed6fc4ec6)


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

@julialeex to take over

![image](https://github.com/user-attachments/assets/5c9c3955-510e-4ef6-b507-5cc0514b39e5)
