### PR TITLE
fix: Fix at-mentions menu in prompt template

### DIFF
--- a/web/lib/components/CodyPromptTemplate.tsx
+++ b/web/lib/components/CodyPromptTemplate.tsx
@@ -81,6 +81,15 @@ export const CodyPromptTemplate: FunctionComponent<CodyPromptTemplateProps> = ({
 }) => {
     const agent = useCodyWebAgent(agentConfig)
 
+    useEffect(() => {
+        if (agent && !isErrorLike(agent)) {
+            // Without calling this function the at-mentions menu isn't properly populated.
+            // TODO(@fkling): Find a way to make at-mentions work without having to call this function,
+            // since it seems odd that we have to 'create a chat' if all we want to is to use the input.
+            agent.createNewChat()
+        }
+    }, [agent])
+
     if (isErrorLike(agent)) {
         return <p>Cody Web client agent error: {agent.message}</p>
     }


### PR DESCRIPTION
Contributes to https://linear.app/sourcegraph/issue/CODY-5192/fix-broken-referencing-for-prompts-on-s2

Without calling createNewChat the at-mentions menu is not properly
populuated in prompt templates. That's because we don't have a valid
panel ID.
Calling createNewChat solves this but feels like the wrong solution
since we do not actually want to create a new chat.
I think it's fine as a stop-gap solution, since that's what the previous
code this as well, but we should find a more reasonable solution.


> [!NOTE]
> We'll have to create and publish a new cody web release after this.

## Test plan

Created a package locally, installed it into sg client/web and verified that the at-mentions
menu is now properly populated.
