### PR TITLE
feat(chat): removes feature flag requirement for title generation

### DIFF
--- a/vscode/src/chat/chat-view/ChatController.test.ts
+++ b/vscode/src/chat/chat-view/ChatController.test.ts
@@ -103,7 +103,7 @@ describe('ChatController', () => {
         })
 
         // Call the method that would potentially create a new ChatBuilder
-        await chatController.clearAndRestartSession()
+        chatController.clearAndRestartSession()
 
         expect(postMessageSpy).not.toHaveBeenCalled()
 
@@ -174,12 +174,6 @@ describe('ChatController', () => {
             .mockImplementation(() => {})
         const addBotMessageSpy = vi.spyOn(chatController as any, 'addBotMessage')
 
-        mockChatClient.chat.mockReturnValue(
-            (async function* () {
-                yield { type: 'change', text: 'Test reply 1' }
-                yield { type: 'complete', text: 'Test reply 1' }
-            })() satisfies AsyncGenerator<CompletionGeneratorValue>
-        )
         mockContextRetriever.retrieveContext.mockResolvedValue([])
 
         // Send the first message in a new chat.
@@ -250,8 +244,21 @@ describe('ChatController', () => {
           [
             {
               "speaker": "human",
-              "text": "You are Cody, an AI coding assistant from Sourcegraph. Your task is to generate a concise title (in about 10 words without quotation) for <codyUserInput>Test input</codyUserInput>.
-                  RULE: Your response should only contain the concise title and nothing else.",
+              "text": "You are Cody, an AI coding assistant from Sourcegraph.If your answer contains fenced code blocks in Markdown, include the relevant full file path in the code block tag using this structure: \`\`\`$LANGUAGE:$FILEPATH\`\`\`
+          For executable terminal commands: enclose each command in individual "bash" language code block without comments and new lines inside.",
+            },
+            {
+              "speaker": "assistant",
+              "text": "I am Cody, an AI coding assistant from Sourcegraph.",
+            },
+            {
+              "agent": undefined,
+              "contextAlternatives": undefined,
+              "contextFiles": undefined,
+              "editorState": null,
+              "intent": undefined,
+              "speaker": "human",
+              "text": "Test input",
             },
           ]
         `)
@@ -319,7 +326,7 @@ describe('ChatController', () => {
 
         await vi.runOnlyPendingTimersAsync()
 
-        expect(mockChatClient.chat).toBeCalledTimes(3)
+        expect(mockChatClient.chat).toBeCalledTimes(2)
         expect(addBotMessageSpy).toBeCalled()
 
         expect(postMessageSpy.mock.calls.at(-1)?.at(0)).toStrictEqual<

--- a/vscode/src/chat/chat-view/ChatController.test.ts
+++ b/vscode/src/chat/chat-view/ChatController.test.ts
@@ -241,8 +241,9 @@ describe('ChatController', () => {
         // Make sure it was sent and the reply was received.
         await vi.runOnlyPendingTimersAsync()
 
-        // Called twince: once for custom title, once for the message
-        expect(mockChatClient.chat).toHaveBeenCalledTimes(2)
+        // Called once for the message.
+        // Chat title call is skipped due to input text less than 20 characters.
+        expect(mockChatClient.chat).toHaveBeenCalledTimes(1)
 
         // Create a snapshot of the custom title call
         expect(mockChatClient.chat.mock.calls[0][0]).toMatchInlineSnapshot(`

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -681,7 +681,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                     intent: manuallySelectedIntent,
                     agent: selectedAgent,
                 })
-                this.setCustomChatTitle(requestID, inputText, signal, model)
+                this.setCustomChatTitle(requestID, inputText, signal)
                 this.postViewTranscript({ speaker: 'assistant' })
 
                 await this.saveSession()
@@ -1270,11 +1270,13 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
     private async setCustomChatTitle(
         requestID: string,
         inputText: PromptString,
-        signal: AbortSignal,
-        chatModel?: ChatModel
+        signal: AbortSignal
     ): Promise<void> {
         return tracer.startActiveSpan('chat.setCustomChatTitle', async (span): Promise<void> => {
-            // NOTE: Only generates a custom title if the input text is long enough (starts w/ 10 chars).
+            // NOTE: Only generates a custom title if the input text is long enough.
+            // We are asking the LLM to generate a title with about 10 words, so 10 words * 2 chars/word = 20 chars
+            // would be a reasonable threshold to start generating a custom title. This is a heuristic and
+            // can be adjusted as needed.
             if (inputText.length < 20) {
                 return
             }


### PR DESCRIPTION
This commit improves the chat title generation feature with the following changes:

- Generates a custom title only if the input text is longer than 20 characters.
- Uses the latest Gemini flash-lite model (if available) or the first speedy model as the default for title generation.
- Removes the feature flag check for auto-generating chat titles.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

1. Ask a question that has less than 20 characters to confirm chat title in chat history remains unchanged.
2. Ask a question that has more than 20 characters to see if chat title was generated automatically.
3. Instance without speed model is currently not supported. Not reason to use expensive  or reasoning models for small task.
