### PR TITLE
chore(auto-edit): capture request/response metadata from auto-edit API adapters

### DIFF
--- a/lib/shared/src/inferenceClient/misc.ts
+++ b/lib/shared/src/inferenceClient/misc.ts
@@ -42,6 +42,18 @@ export type CompletionResponseWithMetaData = {
          * extract metadata required for analytics in one place.
          */
         response?: BrowserOrNodeResponse
+        /**
+         * Optional request headers sent to the model API
+         */
+        requestHeaders?: Record<string, string>
+        /**
+         * URL used to make the request to the model API
+         */
+        requestUrl?: string
+        /**
+         * Optional request body sent to the model API
+         */
+        requestBody?: any
     }
 }
 

--- a/vscode/src/autoedits/adapters/base.ts
+++ b/vscode/src/autoedits/adapters/base.ts
@@ -1,7 +1,28 @@
-import type { PromptString } from '@sourcegraph/cody-shared'
+import type { CodeCompletionsParams, PromptString } from '@sourcegraph/cody-shared'
+import type { AutoeditsRequestBody } from './utils'
+
+export interface ModelResponse {
+    prediction: string
+    /** URL used to make the request to the model API */
+    requestUrl: string
+    /** Response headers received from the model API */
+    responseHeaders: Record<string, string>
+    /** Optional request headers sent to the model API */
+    requestHeaders?: Record<string, string>
+    /**
+     * Optional request body sent to the model API
+     * TODO: update to proper types from different adapters.
+     */
+    requestBody?: AutoeditsRequestBody | CodeCompletionsParams
+    /**
+     * Optional full response body received from the model API
+     * This is propagated to the analytics logger for debugging purposes
+     */
+    responseBody?: any
+}
 
 export interface AutoeditsModelAdapter {
-    getModelResponse(args: AutoeditModelOptions): Promise<string>
+    getModelResponse(args: AutoeditModelOptions): Promise<ModelResponse>
 }
 
 /**

--- a/vscode/src/autoedits/adapters/cody-gateway.test.ts
+++ b/vscode/src/autoedits/adapters/cody-gateway.test.ts
@@ -50,6 +50,7 @@ describe('CodyGatewayAdapter', () => {
         // Mock successful response
         mockFetch.mockResolvedValueOnce({
             status: 200,
+            headers: new Headers(),
             json: () => Promise.resolve({ choices: [{ message: { content: 'response' } }] }),
         })
 
@@ -90,6 +91,7 @@ describe('CodyGatewayAdapter', () => {
 
         mockFetch.mockResolvedValueOnce({
             status: 200,
+            headers: new Headers(),
             json: () => Promise.resolve({ choices: [{ text: 'response' }] }),
         })
 
@@ -116,6 +118,7 @@ describe('CodyGatewayAdapter', () => {
     it('handles error responses correctly', async () => {
         mockFetch.mockResolvedValueOnce({
             status: 400,
+            headers: new Headers(),
             text: () => Promise.resolve('Bad Request'),
         })
 

--- a/vscode/src/autoedits/adapters/fireworks.test.ts
+++ b/vscode/src/autoedits/adapters/fireworks.test.ts
@@ -45,6 +45,7 @@ describe('FireworksAdapter', () => {
     it('sends correct request parameters for chat model', async () => {
         mockFetch.mockResolvedValueOnce({
             status: 200,
+            headers: new Headers(),
             json: () => Promise.resolve({ choices: [{ message: { content: 'response' } }] }),
         })
 
@@ -82,6 +83,7 @@ describe('FireworksAdapter', () => {
 
         mockFetch.mockResolvedValueOnce({
             status: 200,
+            headers: new Headers(),
             json: () => Promise.resolve({ choices: [{ text: 'response' }] }),
         })
 
@@ -108,6 +110,7 @@ describe('FireworksAdapter', () => {
     it('handles error responses correctly', async () => {
         mockFetch.mockResolvedValueOnce({
             status: 400,
+            headers: new Headers(),
             text: () => Promise.resolve('Bad Request'),
         })
 
@@ -118,11 +121,12 @@ describe('FireworksAdapter', () => {
         const expectedResponse = 'modified code'
         mockFetch.mockResolvedValueOnce({
             status: 200,
+            headers: new Headers(),
             json: () => Promise.resolve({ choices: [{ message: { content: expectedResponse } }] }),
         })
 
         const response = await adapter.getModelResponse(options)
-        expect(response).toBe(expectedResponse)
+        expect(response.prediction).toBe(expectedResponse)
     })
 
     it('returns correct response for completions model', async () => {
@@ -131,10 +135,11 @@ describe('FireworksAdapter', () => {
 
         mockFetch.mockResolvedValueOnce({
             status: 200,
+            headers: new Headers(),
             json: () => Promise.resolve({ choices: [{ text: expectedResponse }] }),
         })
 
         const response = await adapter.getModelResponse(nonChatOptions)
-        expect(response).toBe(expectedResponse)
+        expect(response.prediction).toBe(expectedResponse)
     })
 })

--- a/vscode/src/autoedits/adapters/openai.ts
+++ b/vscode/src/autoedits/adapters/openai.ts
@@ -1,11 +1,11 @@
 import { autoeditsProviderConfig } from '../autoedits-config'
 import { autoeditsOutputChannelLogger } from '../output-channel-logger'
 
-import type { AutoeditModelOptions, AutoeditsModelAdapter } from './base'
+import type { AutoeditModelOptions, AutoeditsModelAdapter, ModelResponse } from './base'
 import { getModelResponse, getOpenaiCompatibleChatPrompt } from './utils'
 
 export class OpenAIAdapter implements AutoeditsModelAdapter {
-    async getModelResponse(options: AutoeditModelOptions): Promise<string> {
+    async getModelResponse(options: AutoeditModelOptions): Promise<ModelResponse> {
         try {
             const apiKey = autoeditsProviderConfig.experimentalAutoeditsConfigOverride?.apiKey
 
@@ -17,7 +17,7 @@ export class OpenAIAdapter implements AutoeditsModelAdapter {
                 throw new Error('No api key provided in the config override')
             }
 
-            const response = await getModelResponse(
+            const { data, requestHeaders, responseHeaders, url } = await getModelResponse(
                 options.url,
                 JSON.stringify({
                     model: options.model,
@@ -33,7 +33,13 @@ export class OpenAIAdapter implements AutoeditsModelAdapter {
                 }),
                 apiKey
             )
-            return response.choices[0].message.content
+
+            return {
+                prediction: data.choices[0].message.content,
+                responseHeaders,
+                requestHeaders,
+                requestUrl: url,
+            }
         } catch (error) {
             autoeditsOutputChannelLogger.logError('getModelResponse', 'Error calling OpenAI API:', {
                 verbose: error,

--- a/vscode/src/autoedits/adapters/sourcegraph-chat.test.ts
+++ b/vscode/src/autoedits/adapters/sourcegraph-chat.test.ts
@@ -84,7 +84,7 @@ describe('SourcegraphChatAdapter', () => {
         mockChatClient.chat = mockChat
 
         const response = await adapter.getModelResponse(options)
-        expect(response).toBe('part1part2')
+        expect(response.prediction).toBe('part1part2')
     })
 
     it('handles errors correctly', async () => {

--- a/vscode/src/autoedits/adapters/sourcegraph-completions.test.ts
+++ b/vscode/src/autoedits/adapters/sourcegraph-completions.test.ts
@@ -79,7 +79,7 @@ describe('SourcegraphCompletionsAdapter', () => {
         adapter.client = { complete: mockComplete }
 
         const response = await adapter.getModelResponse(options)
-        expect(response).toBe('part1part2')
+        expect(response.prediction).toBe('part1part2')
     })
 
     it('handles errors correctly', async () => {

--- a/vscode/src/autoedits/autoedits-provider.test.ts
+++ b/vscode/src/autoedits/autoedits-provider.test.ts
@@ -465,7 +465,14 @@ describe('AutoeditsProvider', () => {
             const customGetModelResponse = async () => {
                 // Record the current fake timer time when getModelResponse is called
                 getModelResponseCalledAt = Date.now()
-                return { choices: [{ text: 'const x = 1\n' }] }
+                return {
+                    data: {
+                        choices: [{ text: 'const x = 1\n' }],
+                    },
+                    url: 'test-url.com/completions',
+                    requestHeaders: {},
+                    responseHeaders: {},
+                }
             }
 
             const startTime = Date.now()
@@ -489,7 +496,12 @@ describe('AutoeditsProvider', () => {
             let modelResponseCalled = false
             const customGetModelResponse = async () => {
                 modelResponseCalled = true
-                return { choices: [{ text: 'const x = 1\n' }] }
+                return {
+                    data: { choices: [{ text: 'const x = 1\n' }] },
+                    url: 'test-url.com/completions',
+                    requestHeaders: {},
+                    responseHeaders: {},
+                }
             }
 
             const tokenSource = new vscode.CancellationTokenSource()

--- a/vscode/src/autoedits/test-helpers.ts
+++ b/vscode/src/autoedits/test-helpers.ts
@@ -47,7 +47,12 @@ export async function autoeditResultFor(
             body: string,
             apiKey: string,
             customHeaders?: Record<string, string>
-        ) => Promise<unknown>
+        ) => Promise<{
+            data: any
+            requestHeaders: Record<string, string>
+            responseHeaders: Record<string, string>
+            url: string
+        }>
         isAutomaticTimersAdvancementDisabled?: boolean
     }
 ): Promise<{
@@ -63,11 +68,16 @@ export async function autoeditResultFor(
         vi.advanceTimersByTime(100)
 
         return {
-            choices: [
-                {
-                    text: prediction,
-                },
-            ],
+            data: {
+                choices: [
+                    {
+                        text: prediction,
+                    },
+                ],
+            },
+            requestHeaders: {},
+            responseHeaders: {},
+            url: 'test-url.com/completions',
         }
     }
 

--- a/vscode/src/completions/default-client.ts
+++ b/vscode/src/completions/default-client.ts
@@ -87,6 +87,12 @@ class DefaultCodeCompletionsClient implements CodeCompletionsClient {
                     throw recordErrorToSpan(span, error)
                 }
 
+                // Convert Headers to Record<string, string> for requestHeaders
+                const requestHeaders: Record<string, string> = {}
+                headers.forEach((value, key) => {
+                    requestHeaders[key] = value
+                })
+
                 // We enable streaming only for Node environments right now because it's hard to make
                 // the polyfilled fetch API work the same as it does in the browser.
                 //
@@ -165,7 +171,12 @@ class DefaultCodeCompletionsClient implements CodeCompletionsClient {
 
                 const result: CompletionResponseWithMetaData = {
                     completionResponse: undefined,
-                    metadata: { response },
+                    metadata: {
+                        response,
+                        requestHeaders,
+                        requestUrl: url.toString(),
+                        requestBody: serializedParams,
+                    },
                 }
 
                 try {


### PR DESCRIPTION
- Bubbles up request/response metadata from auto-edit API adapters to the autoedit provider so we can later propagate this data to the auto-edit debug panel. It would allow us to quickly inspect the network traffic from the debug panel and know precisely what goes in and out without attaching the debugger to the extension. 
- Only Cody Gateway and Sourcegraph completions providers are updated to fully support newly added optional metadata properties since we use them the most (enterprise and PLG setups). We can update the rest of the adapters if needed in a follow-up.

## Test plan

CI
