### PR TITLE
feat(webview): Persist Thinking Space state using local storage

### DIFF
--- a/vscode/webviews/chat/ChatMessageContent/ChatMessageContent.tsx
+++ b/vscode/webviews/chat/ChatMessageContent/ChatMessageContent.tsx
@@ -10,6 +10,7 @@ import type { FixupTaskID } from '../../../src/non-stop/FixupTask'
 import { CodyTaskState } from '../../../src/non-stop/state'
 import { type ClientActionListener, useClientActionListener } from '../../client/clientState'
 import { MarkdownFromCody } from '../../components/MarkdownFromCody'
+import { useLocalStorage } from '../../components/hooks'
 import { useConfig } from '../../utils/useConfig'
 import type { PriorHumanMessageInfo } from '../cells/messageCell/assistant/AssistantMessageCell'
 import styles from './ChatMessageContent.module.css'
@@ -223,7 +224,7 @@ export const ChatMessageContent: React.FunctionComponent<ChatMessageContentProps
         [displayMarkdown]
     )
 
-    const [isOpen, setIsOpen] = useState(true)
+    const [isOpen, setIsOpen] = useLocalStorage('cody.thinking-space.open', true)
 
     return (
         <div ref={rootRef} data-testid="chat-message-content">
@@ -231,7 +232,7 @@ export const ChatMessageContent: React.FunctionComponent<ChatMessageContentProps
                 <details
                     open={isOpen}
                     onToggle={e => setIsOpen((e.target as HTMLDetailsElement).open)}
-                    className="tw-container tw-mb-4 tw-border tw-border-gray-500/20 dark:tw-border-gray-600/40 tw-rounded-lg tw-overflow-hidden tw-backdrop-blur-sm"
+                    className="tw-container tw-mb-4 tw-border tw-border-gray-500/20 dark:tw-border-gray-600/40 tw-rounded-lg tw-overflow-hidden tw-backdrop-blur-sm tw-min-w-full"
                     title="Thinking & Reasoning Space"
                 >
                     <summary


### PR DESCRIPTION
This commit introduces local storage to persist the open/closed state of the "Thinking & Reasoning Space" in the chat message content.

Key changes:

-   Replaced `useState` with `useLocalStorage` hook to manage the `isOpen` state, persisting it across sessions.
-   Added `tw-min-w-full` class to the details element to ensure it takes up the full width of its container.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

1. Ask 3.7 Sonent a question and expect it to have the Thought Process expanded by default
2. Collapse the Thought Process 
3. Open a new chat and ask another question
4. The Thought Process should be now collapsed as your last selected
