### PR TITLE
Allow to open devtools as action for an instant debugging caability

### DIFF
--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowFactory.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowFactory.kt
@@ -23,7 +23,7 @@ class CodyToolWindowFactory : ToolWindowFactory, DumbAware {
       customCodySettings.addSeparator()
 
       if (isFeatureFlagEnabled("cody.feature.internals-menu")) {
-        customCodySettings.add(OpenWebviewDevToolsAction(this))
+        customCodySettings.add(OpenWebviewDevToolsAction())
       }
 
       toolWindow.setAdditionalGearActions(customCodySettings)

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/OpenWebviewDevToolsAction.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/OpenWebviewDevToolsAction.kt
@@ -3,9 +3,8 @@ package com.sourcegraph.cody
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.sourcegraph.common.ui.DumbAwareEDTAction
 
-class OpenWebviewDevToolsAction(val toolWindowContent: CodyToolWindowContent) :
-    DumbAwareEDTAction("Open WebView DevTools") {
+class OpenWebviewDevToolsAction : DumbAwareEDTAction("Open WebView DevTools") {
   override fun actionPerformed(e: AnActionEvent) {
-    toolWindowContent.openDevTools()
+    CodyToolWindowContent.executeOnInstanceIfNotDisposed(e.project ?: return) { openDevTools() }
   }
 }

--- a/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -399,6 +399,12 @@
                         description="Enable offScreen rendering in webview">
                     <override-text place="GoToAction" text="Cody: Enable OffScreen Rendering"/>
                 </action>
+                <action id="cody.openWebviewDevToolsAction"
+                        class="com.sourcegraph.cody.OpenWebviewDevToolsAction"
+                        text="Open DevTools"
+                        description="Open DevTools to debug Cody webview">
+                    <override-text place="GoToAction" text="Cody: Open DevTools"/>
+                </action>
             </group>
         </group>
 


### PR DESCRIPTION
## Changes

Allows to open devtools at will. Sometimes we want to inspect webview behaviour in the current IDE without restarting it with special env variable. Ability to open devtools easily will be handy. 

## Test plan

1. Hit `Shift shift`
2. Start typing `cody dev`
3. Select action `Cody: Open Dev Tools` to open the devtools for the Cody webview