### PR TITLE
chore: agent recordings: Ensure tests are not in watch mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
     "test:e2e": "pnpm -C vscode test:e2e",
     "test:local-e2e": "RUN_LOCAL_E2E_TESTS=true pnpm test agent/src/local-e2e/template.test.ts",
     "generate-agent-kotlin-bindings": "./agent/scripts/generate-agent-kotlin-bindings.sh",
-    "update-agent-recordings": "pnpm build && CODY_KEEP_UNUSED_RECORDINGS=false CODY_RECORD_IF_MISSING=true vitest agent/src && cd jetbrains && ./gradlew :recordingIntegrationTest -PforceAgentBuild=true",
-    "update-agent-recordings-windows": "PowerShell -ExecutionPolicy Bypass -Command \"pnpm build; if ($?) { $Env:CODY_KEEP_UNUSED_RECORDINGS='false'; $Env:CODY_RECORD_IF_MISSING='true'; vitest agent/src; cd jetbrains; ./gradlew :recordingIntegrationTest -PforceAgentBuild=true }\"",
-    "update-rewrite-recordings": "rm -rf recordings && CODY_RECORD_IF_MISSING=true CODY_RECORDING_MODE=record vitest vscode/src/local-context/rewrite-keyword-query.test.ts",
+    "update-agent-recordings": "pnpm build && CODY_KEEP_UNUSED_RECORDINGS=false CODY_RECORD_IF_MISSING=true vitest run agent/src && cd jetbrains && ./gradlew :recordingIntegrationTest -PforceAgentBuild=true",
+    "update-agent-recordings-windows": "PowerShell -ExecutionPolicy Bypass -Command \"pnpm build; if ($?) { $Env:CODY_KEEP_UNUSED_RECORDINGS='false'; $Env:CODY_RECORD_IF_MISSING='true'; vitest run agent/src; cd jetbrains; ./gradlew :recordingIntegrationTest -PforceAgentBuild=true }\"",
+    "update-rewrite-recordings": "rm -rf recordings && CODY_RECORD_IF_MISSING=true CODY_RECORDING_MODE=record vitest run vscode/src/local-context/rewrite-keyword-query.test.ts",
     "openctx:link": "cd ../openctx && pnpm -C lib/client link --global && pnpm -C lib/schema link --global && pnpm -C lib/protocol link --global && pnpm -C client/vscode-lib link --global && cd ../cody && pnpm link --global @openctx/client && pnpm link --global @openctx/schema &&  pnpm link --global @openctx/protocol && cd vscode && pnpm link --global @openctx/vscode-lib",
     "openctx:unlink": "pnpm unlink --global @openctx/client && pnpm unlink --global @openctx/schema &&  pnpm unlink --global @openctx/protocol && cd vscode && pnpm unlink --global @openctx/vscode-lib"
   },


### PR DESCRIPTION
## Description

1. Run `pnpm update-agent-recordings`
2. Notice that tests get stuck in watch mode so JetBrains tests never run

## Test plan

1. Run `pnpm update-agent-recordings`
2. Notice that JetBrains tests run

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
