### PR TITLE
Set Accept header to 'application/json' for GraphQL queries

### DIFF
--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -1601,7 +1601,7 @@ export class SourcegraphGraphQLAPIClient {
         signal?.throwIfAborted()
 
         const headers = new Headers(config.configuration?.customHeaders as HeadersInit | undefined)
-        headers.set('Content-Type', 'application/json; charset=utf-8')
+
         if (config.clientState.anonymousUserID && !process.env.CODY_WEB_DONT_SET_SOME_HEADERS) {
             headers.set('X-Sourcegraph-Actor-Anonymous-UID', config.clientState.anonymousUserID)
         }
@@ -1615,6 +1615,7 @@ export class SourcegraphGraphQLAPIClient {
 
         addTraceparent(headers)
         addCodyClientIdentificationHeaders(headers)
+        setJSONAcceptContentTypeHeaders(headers)
 
         try {
             await addAuthHeaders(config.auth, headers, url)


### PR DESCRIPTION
## Changes

This PR fixes setting `Accept` header to `'application/json'` which is required by some proxies to work.

## Test plan

Tested with a local reverse proxy.

Prerequisites (YOUR_TOKEN is a token configured for your user at YOUR_INSTANCE):

1. Right cody_setting.json configuration:

```
{
  "cody.override.serverEndpoint":  "https://localhost:443",

  "cody.auth.externalProviders": [
    {
      "endpoint": "https://localhost:443",
      "executable": {
        "commandLine": ["echo '{ \"headers\": { \"Authorization\": \"token YOUR_TOKEN\" } }'"],
        "shell": "/bin/bash"
      }
    },
```
2. Proxy running in the console: mitmproxy -m reverse:https://YOUR_INSTANCE/ -p 443

Then you can start cody, and in the proxy console you should be able to inspect one of the graphql requests and see something like this:

![image](https://github.com/user-attachments/assets/10a2f62a-0abb-440c-ac6e-49bd1eb0de73)




