### PR TITLE
feat/smart-apply: Add smart apply intent and refactor for custom models

### DIFF
--- a/vscode/src/edit/adapters/base.ts
+++ b/vscode/src/edit/adapters/base.ts
@@ -1,0 +1,41 @@
+import {
+    type CompletionParameters,
+    type ModelContextWindow,
+    modelsService,
+} from '@sourcegraph/cody-shared'
+import type { FixupTask } from '../../non-stop/FixupTask'
+
+export interface ModelParametersInput {
+    model: string
+    stopSequences?: string[]
+    contextWindow: ModelContextWindow
+    task: FixupTask
+}
+
+export interface ModelParameterProvider {
+    getModelParameters(args: ModelParametersInput): CompletionParameters
+}
+
+export class DefaultModelParameterProvider implements ModelParameterProvider {
+    getModelParameters(args: ModelParametersInput): CompletionParameters {
+        const params = {
+            model: args.model,
+            stopSequences: args.stopSequences,
+            maxTokensToSample: args.contextWindow.output,
+        } as CompletionParameters
+
+        if (args.model.includes('gpt-4o')) {
+            // Use Predicted Output for gpt-4o models.
+            // https://platform.openai.com/docs/guides/predicted-outputs
+            params.prediction = {
+                type: 'content',
+                content: args.task.original,
+            }
+        }
+
+        if (modelsService.isStreamDisabled(args.model)) {
+            params.stream = false
+        }
+        return params
+    }
+}

--- a/vscode/src/edit/edit-manager.ts
+++ b/vscode/src/edit/edit-manager.ts
@@ -186,6 +186,7 @@ export class EditManager implements vscode.Disposable {
                 insertionPoint: configuration.insertionPoint,
                 telemetryMetadata,
                 taskId: configuration.id,
+                smartApplyMetadata: configuration.smartApplyMetadata,
             })
         }
 

--- a/vscode/src/edit/execute.ts
+++ b/vscode/src/edit/execute.ts
@@ -9,7 +9,12 @@ import type {
     Rule,
 } from '@sourcegraph/cody-shared'
 
-import type { FixupTask, FixupTaskID, FixupTelemetryMetadata } from '../non-stop/FixupTask'
+import type {
+    FixupTask,
+    FixupTaskID,
+    FixupTelemetryMetadata,
+    SmartApplyAdditionalMetadata,
+} from '../non-stop/FixupTask'
 import type { EditIntent, EditMode } from './types'
 
 export interface ExecuteEditArguments {
@@ -50,6 +55,10 @@ export interface ExecuteEditArguments {
         // The file to write the edit to. If not provided, the edit will be applied to the current file.
         destinationFile?: vscode.Uri
         insertionPoint?: vscode.Position
+        /**
+         * Additional metadata only specific to Smart Apply Tasks.
+         */
+        smartApplyMetadata?: SmartApplyAdditionalMetadata
     }
     source?: EventSource
     telemetryMetadata?: FixupTelemetryMetadata

--- a/vscode/src/edit/prompt/context.ts
+++ b/vscode/src/edit/prompt/context.ts
@@ -112,7 +112,8 @@ const getContextFromIntent = async ({
          * Fetch context from the users' selection, use any errors/warnings in said selection, and use context from current file.
          * Non-code files are not considered as including Markdown syntax seems to lead to more hallucinations and poorer output quality.
          */
-        case 'edit': {
+        case 'edit':
+        case 'smartApply': {
             const range = selectionRange
             const diagnostics = range ? editor.getActiveTextEditorDiagnosticsForRange(range) || [] : []
             const errorsAndWarnings = diagnostics.filter(

--- a/vscode/src/edit/prompt/index.ts
+++ b/vscode/src/edit/prompt/index.ts
@@ -3,10 +3,8 @@ import * as vscode from 'vscode'
 import {
     BotResponseMultiplexer,
     type ChatMessage,
-    type CompletionParameters,
     type EditModel,
     type EditProvider,
-    type Message,
     PromptString,
     TokenCounterUtils,
     currentResolvedConfig,
@@ -15,10 +13,8 @@ import {
     modelsService,
     ps,
 } from '@sourcegraph/cody-shared'
-
-import type { VSCodeEditor } from '../../editor/vscode-editor'
-import type { FixupTask } from '../../non-stop/FixupTask'
 import type { EditIntent } from '../types'
+import type { BuildInteractionOptions, BuiltInteraction, EditPromptBuilder } from './type'
 
 import { PromptBuilder } from '../../prompt-builder'
 import { getContext } from './context'
@@ -49,98 +45,88 @@ const getInteractionArgsFromIntent = (
         case 'doc':
             return interaction.getDoc(options)
         case 'edit':
+        case 'smartApply':
             return interaction.getEdit(options)
         case 'test':
             return interaction.getTest(options)
     }
 }
 
-interface BuildInteractionOptions {
-    model: EditModel
-    codyApiVersion: number
-    contextWindow: number
-    task: FixupTask
-    editor: VSCodeEditor
-}
-
-interface BuiltInteraction extends Pick<CompletionParameters, 'stopSequences'> {
-    messages: Message[]
-    responseTopic: string
-    responsePrefix?: string
-}
-
-export const buildInteraction = async ({
-    model,
-    codyApiVersion,
-    contextWindow,
-    task,
-    editor,
-}: BuildInteractionOptions): Promise<BuiltInteraction> => {
-    const document = await vscode.workspace.openTextDocument(task.fixupFile.uri)
-    const prefixRange = new vscode.Range(
-        task.selectionRange.start.translate({
-            lineDelta: -Math.min(task.selectionRange.start.line, 50),
-        }),
-        task.selectionRange.start
-    )
-    const precedingText = PromptString.fromDocumentText(document, prefixRange)
-    const selectedText = PromptString.fromDocumentText(document, task.selectionRange)
-    const tokenCount = await TokenCounterUtils.countPromptString(selectedText)
-    if (tokenCount > contextWindow) {
-        throw new Error("The amount of text selected exceeds Cody's current capacity.")
-    }
-    task.original = selectedText.toString()
-    const suffixRange = new vscode.Range(
-        task.selectionRange.end,
-        task.selectionRange.end.translate({ lineDelta: 50 })
-    )
-    const followingText = PromptString.fromDocumentText(document, suffixRange)
-
-    const { prompt, responseTopic, stopSequences, assistantText, assistantPrefix } =
-        getInteractionArgsFromIntent(task.intent, model, {
-            uri: task.fixupFile.uri,
-            followingText,
-            precedingText,
-            selectedText,
-            instruction: task.instruction,
-            rules: task.rules,
-            document,
-        })
-    const promptBuilder = await PromptBuilder.create(modelsService.getContextWindowByID(model))
-
-    const preamble = getSimplePreamble(model, codyApiVersion, 'Default', prompt.system)
-    promptBuilder.tryAddToPrefix(preamble)
-
-    // Add pre-instruction for edit commands to end of human prompt to override the default
-    // prompt. This is used for providing additional information and guidelines by the user.
-    const preInstruction = (await currentResolvedConfig()).configuration.editPreInstruction
-    const additionalRule =
-        preInstruction && preInstruction.length > 0 ? ps`\nIMPORTANT: ${preInstruction.trim()}` : ps``
-
-    const transcript: ChatMessage[] = [
-        { speaker: 'human', text: prompt.instruction.concat(additionalRule) },
-    ]
-    if (assistantText) {
-        transcript.push({ speaker: 'assistant', text: assistantText })
-    }
-    promptBuilder.tryAddMessages(transcript.reverse())
-
-    const contextItems = await getContext({
-        intent: task.intent,
-        uri: task.fixupFile.uri,
-        selectionRange: task.selectionRange,
-        userContextItems: task.userContextItems,
+export class DefaultEditPromptBuilder implements EditPromptBuilder {
+    async buildInteraction({
+        model,
+        codyApiVersion,
+        contextWindow,
+        task,
         editor,
-        suffix: { text: followingText, range: suffixRange },
-        prefix: { text: precedingText, range: prefixRange },
-        selectedText,
-    })
-    await promptBuilder.tryAddContext('user', contextItems)
+    }: BuildInteractionOptions): Promise<BuiltInteraction> {
+        const document = await vscode.workspace.openTextDocument(task.fixupFile.uri)
+        const prefixRange = new vscode.Range(
+            task.selectionRange.start.translate({
+                lineDelta: -Math.min(task.selectionRange.start.line, 50),
+            }),
+            task.selectionRange.start
+        )
+        const precedingText = PromptString.fromDocumentText(document, prefixRange)
+        const selectedText = PromptString.fromDocumentText(document, task.selectionRange)
+        const tokenCount = await TokenCounterUtils.countPromptString(selectedText)
+        if (tokenCount > contextWindow) {
+            throw new Error("The amount of text selected exceeds Cody's current capacity.")
+        }
+        const suffixRange = new vscode.Range(
+            task.selectionRange.end,
+            task.selectionRange.end.translate({ lineDelta: 50 })
+        )
+        const followingText = PromptString.fromDocumentText(document, suffixRange)
 
-    return {
-        messages: promptBuilder.build(),
-        stopSequences,
-        responseTopic: responseTopic?.toString() || BotResponseMultiplexer.DEFAULT_TOPIC,
-        responsePrefix: assistantPrefix?.toString(),
+        const { prompt, responseTopic, stopSequences, assistantText, assistantPrefix } =
+            getInteractionArgsFromIntent(task.intent, model, {
+                uri: task.fixupFile.uri,
+                followingText,
+                precedingText,
+                selectedText,
+                instruction: task.instruction,
+                rules: task.rules,
+                document,
+            })
+        const promptBuilder = await PromptBuilder.create(modelsService.getContextWindowByID(model))
+
+        const preamble = getSimplePreamble(model, codyApiVersion, 'Default', prompt.system)
+        promptBuilder.tryAddToPrefix(preamble)
+
+        // Add pre-instruction for edit commands to end of human prompt to override the default
+        // prompt. This is used for providing additional information and guidelines by the user.
+        const preInstruction = (await currentResolvedConfig()).configuration.editPreInstruction
+        const additionalRule =
+            preInstruction && preInstruction.length > 0
+                ? ps`\nIMPORTANT: ${preInstruction.trim()}`
+                : ps``
+
+        const transcript: ChatMessage[] = [
+            { speaker: 'human', text: prompt.instruction.concat(additionalRule) },
+        ]
+        if (assistantText) {
+            transcript.push({ speaker: 'assistant', text: assistantText })
+        }
+        promptBuilder.tryAddMessages(transcript.reverse())
+
+        const contextItems = await getContext({
+            intent: task.intent,
+            uri: task.fixupFile.uri,
+            selectionRange: task.selectionRange,
+            userContextItems: task.userContextItems,
+            editor,
+            suffix: { text: followingText, range: suffixRange },
+            prefix: { text: precedingText, range: prefixRange },
+            selectedText,
+        })
+        await promptBuilder.tryAddContext('user', contextItems)
+
+        return {
+            messages: promptBuilder.build(),
+            stopSequences,
+            responseTopic: responseTopic?.toString() || BotResponseMultiplexer.DEFAULT_TOPIC,
+            responsePrefix: assistantPrefix?.toString(),
+        }
     }
 }

--- a/vscode/src/edit/prompt/models/generic.ts
+++ b/vscode/src/edit/prompt/models/generic.ts
@@ -9,30 +9,33 @@ interface PromptVariant {
     instruction: PromptString
 }
 
+const GENERIC_EDIT_INTENT_PROMPT: PromptVariant = {
+    system: psDedent`
+        - You are an AI programming assistant who is an expert in updating code to meet given instructions.
+        - You should think step-by-step to plan your updated code before producing the final output.
+        - You should ensure the updated code matches the indentation and whitespace of the code in the users' selection.
+        - Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.
+        - Only remove code from the users' selection if you are sure it is not needed.
+        - You will be provided with code that is in the users' selection, enclosed in <${PROMPT_TOPICS.SELECTED}></${PROMPT_TOPICS.SELECTED}> XML tags. You must use this code to help you plan your updated code.
+        - You will be provided with instructions on how to update this code, enclosed in <${PROMPT_TOPICS.INSTRUCTIONS}></${PROMPT_TOPICS.INSTRUCTIONS}> XML tags. You must follow these instructions carefully and to the letter.
+        - Only enclose your response in <${PROMPT_TOPICS.OUTPUT}></${PROMPT_TOPICS.OUTPUT}> XML tags. Do use any other XML tags unless they are part of the generated code.
+        - Do not provide any additional commentary about the changes you made. Only respond with the generated code.`,
+    instruction: psDedent`
+        This is part of the file: {filePath}
+
+        The user has the following code in their selection:
+        <${PROMPT_TOPICS.SELECTED}>{selectedText}</${PROMPT_TOPICS.SELECTED}>
+
+        The user wants you to replace parts of the selected code or correct a problem by following their instructions.
+        Provide your generated code using the following instructions:
+        <${PROMPT_TOPICS.INSTRUCTIONS}>
+        {instruction}
+        </${PROMPT_TOPICS.INSTRUCTIONS}>`,
+}
+
 const GENERIC_PROMPTS: Record<EditIntent, PromptVariant> = {
-    edit: {
-        system: psDedent`
-            - You are an AI programming assistant who is an expert in updating code to meet given instructions.
-            - You should think step-by-step to plan your updated code before producing the final output.
-            - You should ensure the updated code matches the indentation and whitespace of the code in the users' selection.
-            - Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.
-            - Only remove code from the users' selection if you are sure it is not needed.
-            - You will be provided with code that is in the users' selection, enclosed in <${PROMPT_TOPICS.SELECTED}></${PROMPT_TOPICS.SELECTED}> XML tags. You must use this code to help you plan your updated code.
-            - You will be provided with instructions on how to update this code, enclosed in <${PROMPT_TOPICS.INSTRUCTIONS}></${PROMPT_TOPICS.INSTRUCTIONS}> XML tags. You must follow these instructions carefully and to the letter.
-            - Only enclose your response in <${PROMPT_TOPICS.OUTPUT}></${PROMPT_TOPICS.OUTPUT}> XML tags. Do use any other XML tags unless they are part of the generated code.
-            - Do not provide any additional commentary about the changes you made. Only respond with the generated code.`,
-        instruction: psDedent`
-            This is part of the file: {filePath}
-
-            The user has the following code in their selection:
-            <${PROMPT_TOPICS.SELECTED}>{selectedText}</${PROMPT_TOPICS.SELECTED}>
-
-            The user wants you to replace parts of the selected code or correct a problem by following their instructions.
-            Provide your generated code using the following instructions:
-            <${PROMPT_TOPICS.INSTRUCTIONS}>
-            {instruction}
-            </${PROMPT_TOPICS.INSTRUCTIONS}>`,
-    },
+    edit: GENERIC_EDIT_INTENT_PROMPT,
+    smartApply: GENERIC_EDIT_INTENT_PROMPT,
     add: {
         system: psDedent`
             - You are an AI programming assistant who is an expert in adding new code by following instructions.
@@ -127,6 +130,7 @@ export const buildGenericPrompt = (
     )
     switch (intent) {
         case 'edit':
+        case 'smartApply':
             return {
                 system: GENERIC_PROMPTS.edit.system,
                 instruction: GENERIC_PROMPTS.edit.instruction

--- a/vscode/src/edit/prompt/type.ts
+++ b/vscode/src/edit/prompt/type.ts
@@ -1,5 +1,31 @@
-import type { PromptString, Rule } from '@sourcegraph/cody-shared'
+import type {
+    CompletionParameters,
+    EditModel,
+    Message,
+    PromptString,
+    Rule,
+} from '@sourcegraph/cody-shared'
 import type * as vscode from 'vscode'
+import type { VSCodeEditor } from '../../editor/vscode-editor'
+import type { FixupTask } from '../../non-stop/FixupTask'
+
+export interface BuildInteractionOptions {
+    model: EditModel
+    codyApiVersion: number
+    contextWindow: number
+    task: FixupTask
+    editor: VSCodeEditor
+}
+
+export interface BuiltInteraction extends Pick<CompletionParameters, 'stopSequences'> {
+    messages: Message[]
+    responseTopic: string
+    responsePrefix?: string
+}
+
+export interface EditPromptBuilder {
+    buildInteraction(options: BuildInteractionOptions): Promise<BuiltInteraction>
+}
 
 export interface LLMPrompt {
     system?: PromptString

--- a/vscode/src/edit/smart-apply-manager.ts
+++ b/vscode/src/edit/smart-apply-manager.ts
@@ -211,6 +211,10 @@ export class SmartApplyManager implements vscode.Disposable {
 ${replacementCode}`,
                 model,
                 intent: 'smartApply',
+                smartApplyMetadata: {
+                    chatQuery: configuration.instruction,
+                    replacementCodeBlock: replacementCode,
+                },
             },
             source: 'chat',
         })

--- a/vscode/src/edit/smart-apply-manager.ts
+++ b/vscode/src/edit/smart-apply-manager.ts
@@ -210,7 +210,7 @@ export class SmartApplyManager implements vscode.Disposable {
                 instruction: ps`Ensuring that you do not duplicate code that is outside of the selection, apply the following change:
 ${replacementCode}`,
                 model,
-                intent: 'edit',
+                intent: 'smartApply',
             },
             source: 'chat',
         })

--- a/vscode/src/edit/types.ts
+++ b/vscode/src/edit/types.ts
@@ -2,7 +2,7 @@
  * The intent classification for the edit.
  * Manually determined depending on how the edit is triggered.
  */
-export type EditIntent = 'add' | 'edit' | 'fix' | 'doc' | 'test'
+export type EditIntent = 'add' | 'edit' | 'fix' | 'doc' | 'test' | 'smartApply'
 
 /**
  * Create a mapping of all source types to numerical values, so telemetry can be recorded on `metadata`.
@@ -13,6 +13,7 @@ export enum EditIntentTelemetryMetadataMapping {
     fix = 3,
     doc = 4,
     test = 5,
+    smartApply = 6,
 }
 
 /**

--- a/vscode/src/edit/utils/edit-models.ts
+++ b/vscode/src/edit/utils/edit-models.ts
@@ -27,6 +27,7 @@ export function getOverriddenModelForIntent(
         case 'test':
         case 'add':
         case 'edit':
+        case 'smartApply':
             // Support all model usage for add and edit intents.
             return currentModel
     }

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -36,7 +36,12 @@ import { countCode } from '../services/utils/code-count'
 import { FixupDocumentEditObserver } from './FixupDocumentEditObserver'
 import type { FixupFile } from './FixupFile'
 import { FixupFileObserver } from './FixupFileObserver'
-import { FixupTask, type FixupTaskID, type FixupTelemetryMetadata } from './FixupTask'
+import {
+    FixupTask,
+    type FixupTaskID,
+    type FixupTelemetryMetadata,
+    type SmartApplyAdditionalMetadata,
+} from './FixupTask'
 import { TERMINAL_EDIT_STATES } from './codelenses/constants'
 import { FixupDecorator } from './decorations/FixupDecorator'
 import { type Edit, computeDiff, makeDiffEditBuilderCompatible } from './line-diff'
@@ -59,6 +64,7 @@ export interface CreateTaskOptions {
     insertionPoint?: vscode.Position
     telemetryMetadata?: FixupTelemetryMetadata
     taskId?: FixupTaskID
+    smartApplyMetadata?: SmartApplyAdditionalMetadata
 }
 
 // This class acts as the factory for Fixup Tasks and handles communication between the Tree View and editor
@@ -460,7 +466,8 @@ export class FixupController
         rules: Rule[] | null,
         intent: EditIntent,
         source: EventSource,
-        telemetryMetadata?: FixupTelemetryMetadata
+        telemetryMetadata?: FixupTelemetryMetadata,
+        smartApplyMetadata?: SmartApplyAdditionalMetadata
     ): Promise<FixupTask | null> {
         const input = await getInput(
             document,
@@ -491,6 +498,7 @@ export class FixupController
             destinationFile: undefined,
             insertionPoint: undefined,
             telemetryMetadata,
+            smartApplyMetadata,
         })
 
         // Return focus to the editor
@@ -521,6 +529,7 @@ export class FixupController
         insertionPoint,
         telemetryMetadata,
         taskId,
+        smartApplyMetadata,
     }: CreateTaskOptions): FixupTask {
         const authStatus = currentAuthStatus()
         const overriddenModel = getOverriddenModelForIntent(intent, model, authStatus)
@@ -539,7 +548,8 @@ export class FixupController
             destinationFile,
             insertionPoint,
             telemetryMetadata,
-            taskId
+            taskId,
+            smartApplyMetadata
         )
         this.tasks.set(task.id, task)
 

--- a/vscode/src/non-stop/FixupTask.ts
+++ b/vscode/src/non-stop/FixupTask.ts
@@ -84,6 +84,7 @@ export class FixupTask {
         this.instruction = instruction.replace(/^\/(edit|fix)/, ps``).trim()
         this.selectionRange = this.getDefaultSelectionRange(selectionRange)
         this.originalRange = this.selectionRange
+        this.original = document.getText(this.originalRange)
     }
 
     /**

--- a/vscode/src/non-stop/FixupTask.ts
+++ b/vscode/src/non-stop/FixupTask.ts
@@ -24,6 +24,14 @@ export type FixupTelemetryMetadata = {
     [key: string]: unknown
 }
 
+/**
+ * Additional metadata only specific to Smart Apply Tasks.
+ */
+export interface SmartApplyAdditionalMetadata {
+    chatQuery: PromptString
+    replacementCodeBlock: PromptString
+}
+
 export class FixupTask {
     public state_: CodyTaskState = CodyTaskState.Idle
     public diff_: Edit[] | undefined
@@ -79,12 +87,14 @@ export class FixupTask {
         /* The position where the Edit should start. Defaults to the start of the selection range. */
         public insertionPoint: vscode.Position = selectionRange.start,
         public readonly telemetryMetadata: FixupTelemetryMetadata = {},
-        public readonly id: FixupTaskID = Date.now().toString(36).replaceAll(/\d+/g, '')
+        public readonly id: FixupTaskID = Date.now().toString(36).replaceAll(/\d+/g, ''),
+        public readonly smartApplyMetadata?: SmartApplyAdditionalMetadata
     ) {
         this.instruction = instruction.replace(/^\/(edit|fix)/, ps``).trim()
         this.selectionRange = this.getDefaultSelectionRange(selectionRange)
         this.originalRange = this.selectionRange
         this.original = document.getText(this.originalRange)
+        this.smartApplyMetadata = smartApplyMetadata
     }
 
     /**


### PR DESCRIPTION
Prepare for adding the custom model for smart apply. Refactored the code:
- Added a `smart-apply` intent to the edit provider. This makes it simple to differentiate smart apply from other requests and add customizations
- Added a interface for prompt builder and LLM argument provider, so that for fine-tuned model we can have a custom prompt builder instead of having the default one.


## Test plan
- Existing CI to make sure existing functionality does not break
- Played with various features like smart apply, edit, fixing diagnostic error and ensure no feature regression