### PR TITLE
Fix autocomplete and code lenses issues on file renamed/moved operations

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/CodyAgentServer.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/CodyAgentServer.kt
@@ -158,6 +158,8 @@ interface CodyAgentServer {
   fun textDocument_didFocus(params: TextDocument_DidFocusParams)
   @JsonNotification("textDocument/didSave")
   fun textDocument_didSave(params: TextDocument_DidSaveParams)
+  @JsonNotification("textDocument/didRename")
+  fun textDocument_didRename(params: TextDocument_DidRenameParams)
   @JsonNotification("textDocument/didClose")
   fun textDocument_didClose(params: ProtocolTextDocument)
   @JsonNotification("workspace/didDeleteFiles")

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/TextDocument_DidRenameParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/TextDocument_DidRenameParams.kt
@@ -1,0 +1,8 @@
+@file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
+package com.sourcegraph.cody.agent.protocol_generated;
+
+data class TextDocument_DidRenameParams(
+  val oldUri: String,
+  val newUri: String,
+)
+

--- a/agent/src/AgentWorkspaceDocuments.test.ts
+++ b/agent/src/AgentWorkspaceDocuments.test.ts
@@ -45,6 +45,21 @@ describe('AgentWorkspaceDocuments', () => {
         expect(document2.protocolDocument.visibleRange).toBeUndefined()
     })
 
+    it('renameDocument', () => {
+        const document = documents.loadAndUpdateDocument(
+            ProtocolTextDocumentWithUri.from(uri, { content: 'hello' })
+        )
+        expect(document.getText()).toBe('hello')
+        expect(documents.getDocument(uri)?.getText()).toBe('hello')
+
+        const newUri = vscode.Uri.parse('file:///bar.txt')
+        documents.renameDocument(uri, newUri)
+
+        expect(documents.getDocument(uri)).toBeUndefined()
+        const renamedDoc = documents.getDocument(newUri)
+        expect(renamedDoc?.getText()).toBe('hello')
+    })
+
     it('incremental sync', () => {
         const document = documents.loadAndUpdateDocument(
             ProtocolTextDocumentWithUri.from(uri, { content: ['abc', 'def', 'ghi'].join('\n') })

--- a/agent/src/AgentWorkspaceDocuments.ts
+++ b/agent/src/AgentWorkspaceDocuments.ts
@@ -182,6 +182,26 @@ export class AgentWorkspaceDocuments implements vscode_shim.WorkspaceDocuments {
         this.agentDocuments.delete(uri.toString())
     }
 
+    public renameDocument(oldUri: vscode.Uri, newUri: vscode.Uri): void {
+        const documentAndEditor = this.agentDocuments.get(oldUri.toString())
+        if (documentAndEditor) {
+            this.agentDocuments.delete(oldUri.toString())
+            const { document, editor } = documentAndEditor
+
+            const newDocument = new AgentTextDocument(
+                ProtocolTextDocumentWithUri.fromDocument({
+                    uri: newUri.toString(),
+                    content: document.protocolDocument.underlying.content,
+                    selection: document.protocolDocument.underlying.selection,
+                    contentChanges: document.protocolDocument.underlying.contentChanges,
+                    visibleRange: document.protocolDocument.underlying.visibleRange,
+                    testing: document.protocolDocument.underlying.testing,
+                })
+            )
+            this.agentDocuments.set(newUri.toString(), { document: newDocument, editor })
+        }
+    }
+
     private vscodeTab(uri: vscode.Uri): vscode.Tab {
         return {
             input: {

--- a/agent/src/AgentWorkspaceDocuments.ts
+++ b/agent/src/AgentWorkspaceDocuments.ts
@@ -199,6 +199,13 @@ export class AgentWorkspaceDocuments implements vscode_shim.WorkspaceDocuments {
                 })
             )
             this.agentDocuments.set(newUri.toString(), { document: newDocument, editor })
+
+            // Update activeTextEditor if the renamed document was the active one
+            if (this.activeDocumentFilePath?.toString() === oldUri.toString()) {
+                // Create a new editor with the updated document
+                const updatedEditor = new AgentTextEditor(newDocument, { edit: this.params?.edit })
+                this.setActiveTextEditor(updatedEditor)
+            }
         }
     }
 

--- a/agent/src/AgentWorkspaceDocuments.ts
+++ b/agent/src/AgentWorkspaceDocuments.ts
@@ -186,7 +186,7 @@ export class AgentWorkspaceDocuments implements vscode_shim.WorkspaceDocuments {
         const documentAndEditor = this.agentDocuments.get(oldUri.toString())
         if (documentAndEditor) {
             this.agentDocuments.delete(oldUri.toString())
-            const { document, editor } = documentAndEditor
+            const { document } = documentAndEditor
 
             const newDocument = new AgentTextDocument(
                 ProtocolTextDocumentWithUri.fromDocument({
@@ -198,14 +198,8 @@ export class AgentWorkspaceDocuments implements vscode_shim.WorkspaceDocuments {
                     testing: document.protocolDocument.underlying.testing,
                 })
             )
-            this.agentDocuments.set(newUri.toString(), { document: newDocument, editor })
-
-            // Update activeTextEditor if the renamed document was the active one
-            if (this.activeDocumentFilePath?.toString() === oldUri.toString()) {
-                // Create a new editor with the updated document
-                const updatedEditor = new AgentTextEditor(newDocument, { edit: this.params?.edit })
-                this.setActiveTextEditor(updatedEditor)
-            }
+            const updatedEditor = new AgentTextEditor(newDocument, this.params)
+            this.agentDocuments.set(newUri.toString(), { document: newDocument, editor: updatedEditor })
         }
     }
 

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -583,6 +583,12 @@ export class Agent extends MessageHandler implements ExtensionClient {
             vscode_shim.onDidSaveTextDocument.fire(document)
         })
 
+        this.registerNotification('textDocument/didRename', params => {
+            const oldUri = vscode.Uri.parse(params.oldUri)
+            const newUri = vscode.Uri.parse(params.newUri)
+            vscode_shim.onDidRenameFiles.fire({ files: [{ oldUri, newUri }] })
+        })
+
         this.registerNotification('extensionConfiguration/didChange', config => {
             this.handleConfigChanges(config)
         })

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -586,6 +586,7 @@ export class Agent extends MessageHandler implements ExtensionClient {
         this.registerNotification('textDocument/didRename', params => {
             const oldUri = vscode.Uri.parse(params.oldUri)
             const newUri = vscode.Uri.parse(params.newUri)
+            this.workspace.renameDocument(oldUri, newUri)
             vscode_shim.onDidRenameFiles.fire({ files: [{ oldUri, newUri }] })
         })
 

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/listeners/CodyElementRefactoringListenerProvider.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/listeners/CodyElementRefactoringListenerProvider.kt
@@ -1,0 +1,27 @@
+package com.sourcegraph.cody.listeners
+
+import com.intellij.psi.PsiElement
+import com.intellij.refactoring.listeners.RefactoringElementListener
+import com.intellij.refactoring.listeners.RefactoringElementListenerProvider
+import com.sourcegraph.cody.agent.CodyAgentService.Companion.withServer
+
+class CodyElementListenerProvider : RefactoringElementListenerProvider {
+  override fun getListener(element: PsiElement) =
+      object : RefactoringElementListener {
+        override fun elementMoved(p0: PsiElement) {
+          val virtualFileBefore = element.containingFile.virtualFile
+          val virtualFileAfter = p0.containingFile.virtualFile
+          withServer(element.project) { server ->
+            println("elementMoved from $virtualFileBefore to $virtualFileAfter")
+          }
+        }
+
+        override fun elementRenamed(p0: PsiElement) {
+          val virtualFileBefore = element.containingFile.virtualFile
+          val virtualFileAfter = p0.containingFile.virtualFile
+          withServer(element.project) { server ->
+            println("elementRenamed from $virtualFileBefore to $virtualFileAfter")
+          }
+        }
+      }
+}

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/listeners/CodyElementRefactoringListenerProvider.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/listeners/CodyElementRefactoringListenerProvider.kt
@@ -4,24 +4,24 @@ import com.intellij.psi.PsiElement
 import com.intellij.refactoring.listeners.RefactoringElementListener
 import com.intellij.refactoring.listeners.RefactoringElementListenerProvider
 import com.sourcegraph.cody.agent.CodyAgentService.Companion.withServer
+import com.sourcegraph.cody.agent.protocol_extensions.ProtocolTextDocumentExt.uriFor
+import com.sourcegraph.cody.agent.protocol_generated.TextDocument_DidRenameParams
 
 class CodyElementListenerProvider : RefactoringElementListenerProvider {
-  override fun getListener(element: PsiElement) =
-      object : RefactoringElementListener {
-        override fun elementMoved(p0: PsiElement) {
-          val virtualFileBefore = element.containingFile.virtualFile
-          val virtualFileAfter = p0.containingFile.virtualFile
-          withServer(element.project) { server ->
-            println("elementMoved from $virtualFileBefore to $virtualFileAfter")
-          }
-        }
+  override fun getListener(element: PsiElement): RefactoringElementListener {
+    val uriBefore = uriFor(element.containingFile.virtualFile)
+    return object : RefactoringElementListener {
+      override fun elementMoved(p0: PsiElement) = notifyAgent(p0)
 
-        override fun elementRenamed(p0: PsiElement) {
-          val virtualFileBefore = element.containingFile.virtualFile
-          val virtualFileAfter = p0.containingFile.virtualFile
-          withServer(element.project) { server ->
-            println("elementRenamed from $virtualFileBefore to $virtualFileAfter")
-          }
+      override fun elementRenamed(p0: PsiElement) = notifyAgent(p0)
+
+      private fun notifyAgent(p0: PsiElement) {
+        val uriAfter = uriFor(p0.containingFile.virtualFile)
+        assert(uriBefore != uriAfter)
+        withServer(element.project) { server ->
+          server.textDocument_didRename(TextDocument_DidRenameParams(uriBefore, uriAfter))
         }
       }
+    }
+  }
 }

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/listeners/CodyElementRefactoringListenerProvider.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/listeners/CodyElementRefactoringListenerProvider.kt
@@ -3,23 +3,26 @@ package com.sourcegraph.cody.listeners
 import com.intellij.psi.PsiElement
 import com.intellij.refactoring.listeners.RefactoringElementListener
 import com.intellij.refactoring.listeners.RefactoringElementListenerProvider
-import com.sourcegraph.cody.agent.CodyAgentService.Companion.withServer
-import com.sourcegraph.cody.agent.protocol_extensions.ProtocolTextDocumentExt.uriFor
+import com.sourcegraph.cody.agent.CodyAgentService.Companion.withAgent
+import com.sourcegraph.cody.agent.protocol_extensions.ProtocolTextDocumentExt.vscNormalizedUriFor
 import com.sourcegraph.cody.agent.protocol_generated.TextDocument_DidRenameParams
 
 class CodyElementListenerProvider : RefactoringElementListenerProvider {
   override fun getListener(element: PsiElement): RefactoringElementListener {
-    val uriBefore = uriFor(element.containingFile.virtualFile)
+    val uriBefore = vscNormalizedUriFor(element.containingFile.virtualFile)
     return object : RefactoringElementListener {
-      override fun elementMoved(p0: PsiElement) = notifyAgent(p0)
+      override fun elementMoved(newPsiElement: PsiElement) = notifyAgent(newPsiElement)
 
-      override fun elementRenamed(p0: PsiElement) = notifyAgent(p0)
+      override fun elementRenamed(newPsiElement: PsiElement) = notifyAgent(newPsiElement)
 
-      private fun notifyAgent(p0: PsiElement) {
-        val uriAfter = uriFor(p0.containingFile.virtualFile)
+      private fun notifyAgent(newPsiElement: PsiElement) {
+        val uriAfter = vscNormalizedUriFor(newPsiElement.containingFile.virtualFile)
+        if (uriBefore == null || uriAfter == null) {
+          return
+        }
         assert(uriBefore != uriAfter)
-        withServer(element.project) { server ->
-          server.textDocument_didRename(TextDocument_DidRenameParams(uriBefore, uriAfter))
+        withAgent(element.project) { agent ->
+          agent.server.textDocument_didRename(TextDocument_DidRenameParams(uriBefore, uriAfter))
         }
       }
     }

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/listeners/CodyElementRefactoringListenerProvider.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/listeners/CodyElementRefactoringListenerProvider.kt
@@ -17,10 +17,9 @@ class CodyElementListenerProvider : RefactoringElementListenerProvider {
 
       private fun notifyAgent(newPsiElement: PsiElement) {
         val uriAfter = vscNormalizedUriFor(newPsiElement.containingFile.virtualFile)
-        if (uriBefore == null || uriAfter == null) {
+        if (uriBefore == null || uriAfter == null || uriBefore == uriAfter) {
           return
         }
-        assert(uriBefore != uriAfter)
         withAgent(element.project) { agent ->
           agent.server.textDocument_didRename(TextDocument_DidRenameParams(uriBefore, uriAfter))
         }

--- a/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -126,6 +126,8 @@
                 implementation="com.sourcegraph.cody.edit.lenses.providers.EditRetryCodeVisionProvider"/>
 
         <config.codeVisionGroupSettingProvider implementation="com.sourcegraph.cody.edit.lenses.EditCodeVisionGroupSettingProvider"/>
+
+        <refactoring.elementListenerProvider implementation="com.sourcegraph.cody.listeners.CodyElementListenerProvider"/>
     </extensions>
 
     <applicationListeners>

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -342,6 +342,8 @@ export type ClientNotifications = {
     'textDocument/didFocus': [{ uri: string }]
     // The user saved the file to disk.
     'textDocument/didSave': [{ uri: string }]
+    // The user renamed a document.
+    'textDocument/didRename': [{ oldUri: string; newUri: string }]
     // The user closed the editor tab for the given document.
     // Only the 'uri' property is required, other properties are ignored.
     'textDocument/didClose': [ProtocolTextDocument]


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/jetbrains/issues/2360.
Fixes https://linear.app/sourcegraph/issue/QA-695/jb-specific-autocomplete-feature-stops-working-after-renaming-file.

This PR adds missing handling for `onDidRenameFiles` events. 

## Test plan 

Note: It refers to JB Client.


### Test Case 1: Autocomplete after file rename/move
**Steps:**
1. Open a file and trigger an autocomplete; verify it appears 
2. Move the file / rename the file
3. Trigger the autocompletion in at the same place (or anywhere in the file)
4. Verify that the suggestion appears

### Test Case 2: File Rename Operation

**Setup:**
```
project/
├── src/
│   └── foo.txt
```

**Steps:**
1. Open `foo.txt` in editor
2. Trigger Cody's "Edit Code" action
3. Verify code lenses appear with Accept/Reject buttons
4. Use Shift+F6 (or right click / Rename...) to rename `foo.txt` to `bar.txt`
5. Verify:
   - Code lenses remain visible after rename
   - Accept button successfully dismisses the lenses
   - New file path is correctly reflected

### Test Case 3: File Move Operation

**Setup:**
```
project/
├── src/
│   └── foo.txt
└── dest/
```

**Steps:**
1. Open `src/foo.txt` in editor
2. Trigger Cody's "Edit Code" action  
3. Verify code lenses appear with Accept/Reject buttons
4. Drag and drop `foo.txt` from `src/` to `dest/` folder
5. Verify:
   - Code lenses remain visible after move
   - Accept button successfully dismisses the lenses
   - File path updated to reflect new location

### Expected Behavior
- Code lenses should remain functional after file operations
- Accept/Reject buttons should work properly
- File path references should be updated in Cody's internal state


<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
