### PR TITLE
Remove CodyPromptsV2 (and fix prompts migration layout)

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -98,12 +98,6 @@ export enum FeatureFlag {
     CodyUnifiedPrompts = 'cody-unified-prompts',
     CodyDeepSeekChat = 'cody-deepseek-chat',
 
-    /**
-     * For internal use only. New Prompts UI and logic is behind this feature flag
-     * will be removed as soon as commands will be deprecated.
-     */
-    CodyPromptsV2 = 'prompt-creation-v2',
-
     // Enables Anthropic's prompt caching feature on messages for Cody Clients
     CodyPromptCachingOnMessages = 'cody-experimental-prompt-caching-on-messages',
 

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -35,7 +35,6 @@ interface ChatboxProps {
     showIDESnippetActions?: boolean
     setView: (view: View) => void
     smartApplyEnabled?: boolean
-    isPromptsV2Enabled?: boolean
     isWorkspacesUpgradeCtaEnabled?: boolean
 }
 
@@ -51,7 +50,6 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
     showIDESnippetActions = true,
     setView,
     smartApplyEnabled,
-    isPromptsV2Enabled,
     isWorkspacesUpgradeCtaEnabled,
 }) => {
     const transcriptRef = useRef(transcript)
@@ -231,11 +229,7 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
             />
             {transcript.length === 0 && showWelcomeMessage && (
                 <>
-                    <WelcomeMessage
-                        IDE={userInfo.IDE}
-                        setView={setView}
-                        isPromptsV2Enabled={isPromptsV2Enabled}
-                    />
+                    <WelcomeMessage IDE={userInfo.IDE} setView={setView}/>
                     {isWorkspacesUpgradeCtaEnabled && userInfo.IDE !== CodyIDE.Web && (
                         <div className="tw-absolute tw-bottom-0 tw-left-1/2 tw-transform tw--translate-x-1/2 tw-w-[95%] tw-z-1 tw-mb-4 tw-max-h-1/2">
                             <WelcomeNotice />

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -229,7 +229,7 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
             />
             {transcript.length === 0 && showWelcomeMessage && (
                 <>
-                    <WelcomeMessage IDE={userInfo.IDE} setView={setView}/>
+                    <WelcomeMessage IDE={userInfo.IDE} setView={setView} />
                     {isWorkspacesUpgradeCtaEnabled && userInfo.IDE !== CodyIDE.Web && (
                         <div className="tw-absolute tw-bottom-0 tw-left-1/2 tw-transform tw--translate-x-1/2 tw-w-[95%] tw-z-1 tw-mb-4 tw-max-h-1/2">
                             <WelcomeNotice />

--- a/vscode/webviews/CodyPanel.tsx
+++ b/vscode/webviews/CodyPanel.tsx
@@ -79,7 +79,6 @@ export const CodyPanel: FunctionComponent<CodyPanelProps> = ({
     const externalAPI = useExternalAPI()
     const api = useExtensionAPI()
     const { value: chatModels } = useObservable(useMemo(() => api.chatModels(), [api.chatModels]))
-    const isPromptsV2Enabled = useFeatureFlag(FeatureFlag.CodyPromptsV2)
     // workspace upgrade eligibility should be that the flag is set, is on dotcom and only has one account. This prevents enterprise customers that are logged into multiple endpoints from seeing the CTA
     const isWorkspacesUpgradeCtaEnabled =
         useFeatureFlag(FeatureFlag.SourcegraphTeamsUpgradeCTA) &&
@@ -142,7 +141,6 @@ export const CodyPanel: FunctionComponent<CodyPanelProps> = ({
                             showWelcomeMessage={showWelcomeMessage}
                             scrollableParent={tabContainerRef.current}
                             smartApplyEnabled={smartApplyEnabled}
-                            isPromptsV2Enabled={isPromptsV2Enabled}
                             setView={setView}
                             isWorkspacesUpgradeCtaEnabled={isWorkspacesUpgradeCtaEnabled}
                         />
@@ -156,11 +154,7 @@ export const CodyPanel: FunctionComponent<CodyPanelProps> = ({
                         />
                     )}
                     {view === View.Prompts && (
-                        <PromptsTab
-                            IDE={clientCapabilities.agentIDE}
-                            setView={setView}
-                            isPromptsV2Enabled={isPromptsV2Enabled}
-                        />
+                        <PromptsTab IDE={clientCapabilities.agentIDE} setView={setView}/>
                     )}
                     {view === View.Settings && <SettingsTab />}
                 </TabContainer>

--- a/vscode/webviews/CodyPanel.tsx
+++ b/vscode/webviews/CodyPanel.tsx
@@ -154,7 +154,7 @@ export const CodyPanel: FunctionComponent<CodyPanelProps> = ({
                         />
                     )}
                     {view === View.Prompts && (
-                        <PromptsTab IDE={clientCapabilities.agentIDE} setView={setView}/>
+                        <PromptsTab IDE={clientCapabilities.agentIDE} setView={setView} />
                     )}
                     {view === View.Settings && <SettingsTab />}
                 </TabContainer>

--- a/vscode/webviews/chat/components/WelcomeMessage.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.tsx
@@ -14,10 +14,7 @@ interface WelcomeMessageProps {
     isWorkspacesUpgradeCtaEnabled?: boolean
 }
 
-export const WelcomeMessage: FunctionComponent<WelcomeMessageProps> = ({
-    setView,
-    IDE,
-}) => {
+export const WelcomeMessage: FunctionComponent<WelcomeMessageProps> = ({ setView, IDE }) => {
     // Remove the old welcome message dismissal key that is no longer used.
     localStorage.removeItem(localStorageKey)
 

--- a/vscode/webviews/chat/components/WelcomeMessage.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.tsx
@@ -11,14 +11,12 @@ const localStorageKey = 'chat.welcome-message-dismissed'
 interface WelcomeMessageProps {
     setView: (view: View) => void
     IDE: CodyIDE
-    isPromptsV2Enabled?: boolean
     isWorkspacesUpgradeCtaEnabled?: boolean
 }
 
 export const WelcomeMessage: FunctionComponent<WelcomeMessageProps> = ({
     setView,
     IDE,
-    isPromptsV2Enabled,
 }) => {
     // Remove the old welcome message dismissal key that is no longer used.
     localStorage.removeItem(localStorageKey)
@@ -28,7 +26,7 @@ export const WelcomeMessage: FunctionComponent<WelcomeMessageProps> = ({
     return (
         <div className="tw-flex-1 tw-flex tw-flex-col tw-items-start tw-w-full tw-px-8 tw-gap-6 tw-transition-all tw-relative">
             <div className="tw-flex tw-flex-col tw-gap-4 tw-w-full">
-                {isPromptsV2Enabled && IDE !== CodyIDE.Web && (
+                {IDE !== CodyIDE.Web && (
                     <PromptMigrationWidget dismissible={true} className="tw-w-full" />
                 )}
                 <PromptList

--- a/vscode/webviews/prompts/PromptsTab.module.css
+++ b/vscode/webviews/prompts/PromptsTab.module.css
@@ -9,5 +9,5 @@
 }
 
 .prompt-migration-widget {
-    margin: 1rem 1rem -0.75rem 1rem;
+    margin: 0.75rem 0.75rem 0 0.75rem;
 }

--- a/vscode/webviews/prompts/PromptsTab.tsx
+++ b/vscode/webviews/prompts/PromptsTab.tsx
@@ -15,15 +15,14 @@ import styles from './PromptsTab.module.css'
 export const PromptsTab: React.FC<{
     IDE: CodyIDE
     setView: (view: View) => void
-    isPromptsV2Enabled?: boolean
-}> = ({ IDE, setView, isPromptsV2Enabled }) => {
+}> = ({ IDE, setView }) => {
     const runAction = useActionSelect()
 
     const [promptsFilter, setPromptsFilter] = useState<PromptsFilterArgs>({})
 
     return (
         <div className="tw-overflow-auto tw-h-full tw-flex tw-flex-col">
-            {isPromptsV2Enabled && IDE !== CodyIDE.Web && (
+            {IDE !== CodyIDE.Web && (
                 <PromptMigrationWidget dismissible={false} className={styles.promptMigrationWidget} />
             )}
             <PromptsFilter promptFilters={promptsFilter} setPromptFilters={setPromptsFilter} />


### PR DESCRIPTION
Part of https://linear.app/sourcegraph/issue/SRCH-1734/issue-with-migrating-local-custom-commands-for-rakuten

Prior to this PR we still had an old new prompt feature flag for prompt migration. It's been almost 5 months since the new prompt replaced cody commands, I'm removing this flag in order to simplify migration for all customers who still may have some commands in their user configs. Also I noticed some small layout shift there, fixed it too.

Note: that migration run keys haven't been changed so users who ran this migration before won't see this widget anymore (even if they have added somehow new personal commands in their configs) 

| Welcome screen | Prompts Tab |
| --------  | -------- |
| <img width="1124" alt="Screenshot 2025-03-05 at 13 31 38" src="https://github.com/user-attachments/assets/2060681d-b081-4aef-b37e-ba005e776246" /> | <img width="1124" alt="Screenshot 2025-03-05 at 13 31 43" src="https://github.com/user-attachments/assets/034c0f88-5c36-4933-937a-de2912f3dce9" /> | 

## Test plan
- Check that you can see personal prompts migration tool (on the new vs code instance if you haven't ran this before)


