### PR TITLE
Fix token-receiver url generation logic

### DIFF
--- a/vscode/src/services/AuthProviderSimplified.ts
+++ b/vscode/src/services/AuthProviderSimplified.ts
@@ -26,34 +26,15 @@ function openExternalAuthUrl(provider: AuthMethod, tokenReceiverUrl?: string): T
     // 1. Specific login page (GitHub, etc.) redirects to the new token page
     // 2. New token page redirects back to the extension with the new token
     const referralCode = getCodyAuthReferralCode(vscode.env.uriScheme)
-    const tokenReceiver = tokenReceiverUrl
-        ? `&tokenReceiverUrl=${encodeURIComponent(tokenReceiverUrl)}`
-        : ''
-
-    const newTokenUrl = `/user/settings/tokens/new/callback?requestFrom=${referralCode}${tokenReceiver}`
-    const site = new URL(newTokenUrl, DOTCOM_URL)
-    const genericLoginUrl = `${site}sign-in?returnTo=${newTokenUrl}`
-    const gitHubLoginUrl = `${site}.auth/openidconnect/login?prompt_auth=github&pc=sams&redirect=${newTokenUrl}`
-    const gitLabLoginUrl = `${site}.auth/openidconnect/login?prompt_auth=gitlab&pc=sams&redirect=${newTokenUrl}`
-    const googleLoginUrl = `${site}.auth/openidconnect/login?prompt_auth=google&pc=sams&redirect=${newTokenUrl}`
-
-    let uriSpec: string
-    switch (provider) {
-        case 'github':
-            uriSpec = gitHubLoginUrl
-            break
-        case 'gitlab':
-            uriSpec = gitLabLoginUrl
-            break
-        case 'google':
-            uriSpec = googleLoginUrl
-            break
-        default:
-            // This login form has links to other login methods, it is the best
-            // catch-all
-            uriSpec = genericLoginUrl
-            break
-    }
+    const tokenReceiver = tokenReceiverUrl ? `&tokenReceiverUrl=${tokenReceiverUrl}` : ''
+    const redirect = encodeURIComponent(
+        `/user/settings/tokens/new/callback?requestFrom=${referralCode}${tokenReceiver}`
+    )
+    const site = DOTCOM_URL.toString()
+    const uriSpec =
+        provider === 'github' || provider === 'gitlab' || provider === 'google'
+            ? `${site}.auth/openidconnect/login?prompt_auth=${provider}&pc=sams&redirect=${redirect}`
+            : `${site}sign-in?returnTo=${redirect}`
 
     // VScode Uri handling escapes ?, = in the redirect parameter. dotcom's
     // redirectTo handling does not unescape these. As a result we route


### PR DESCRIPTION
## Changes

VSC uses two types of login redirect, either by `vscode://sourcegraph.cody-ai` uri if browser and os supports that, or through local http server if it does not.

Url we use to trigger redirect looks like that:

https://sourcegraph.com/users/pkukielka-zvxqk/settings/tokens/new/callback?requestFrom=CODY&tokenReceiverUrl=http%3A%2F%2F127.0.0.1%3A58543%aaaabbbbccccddddeeeeffffgggghhhhhh.auth/openidconnect/login?prompt_auth=github&pc=sams&redirect=/user/settings/tokens/new/callback?requestFrom=CODY&tokenReceiverUrl=http%3A%2F%2F127.0.0.1%3A58543%aaaabbbbccccddddeeeeffffgggghhhhhh

But should be:

https://sourcegraph.com/.auth/openidconnect/login?prompt_auth=github&pc=sams&redirect=%2Fuser%2Fsettings%2Ftokens%2Fnew%2Fcallback%3FrequestFrom%3DCODY%26tokenReceiverUrl%3Dhttp%3A%2F%2F127.0.0.1%3A63992%aaaabbbbccccddddeeeeffffgggghhhhhh

It was broken long time ago but we never noticed: https://github.com/sourcegraph/cody/pull/4664

## Test plan

1. Sing out from current account
2. Close VSC
3. Reopen VSC and sing in using GitHutb
4. When `Authorize Cody - VS Code Extension?` window will show make sure it opens in newest Chrome (if that is not the case you can simply copy-paste it to Chrome window)
5. Click `Authorize`
6. Make sure you are properly signed in