### PR TITLE
chore(auto-edit): disable rewrite_speculation

### DIFF
--- a/vscode/src/autoedits/adapters/cody-gateway.test.ts
+++ b/vscode/src/autoedits/adapters/cody-gateway.test.ts
@@ -79,7 +79,6 @@ describe('CodyGatewayAdapter', () => {
                     type: 'content',
                     content: options.codeToRewrite,
                 },
-                rewrite_speculation: true,
                 user: options.userId,
                 messages: expect.any(Array),
             })
@@ -108,7 +107,6 @@ describe('CodyGatewayAdapter', () => {
                     type: 'content',
                     content: options.codeToRewrite,
                 },
-                rewrite_speculation: true,
                 user: options.userId,
                 prompt: nonChatOptions.prompt.userMessage.toString(),
             })

--- a/vscode/src/autoedits/adapters/cody-gateway.ts
+++ b/vscode/src/autoedits/adapters/cody-gateway.ts
@@ -5,9 +5,7 @@ import { autoeditsOutputChannelLogger } from '../output-channel-logger'
 import type { AutoeditModelOptions, AutoeditsModelAdapter, ModelResponse } from './base'
 import {
     type AutoeditsRequestBody,
-    type FireworksChatModelRequestParams,
     type FireworksCompatibleRequestParams,
-    type FireworksCompletionModelRequestParams,
     getMaxOutputTokensForAutoedits,
     getModelResponse,
     getOpenaiCompatibleChatPrompt,
@@ -80,7 +78,6 @@ export class CodyGatewayAdapter implements AutoeditsModelAdapter {
                 type: 'content',
                 content: options.codeToRewrite,
             },
-            rewrite_speculation: true,
             user: options.userId || undefined,
         }
 
@@ -91,12 +88,12 @@ export class CodyGatewayAdapter implements AutoeditsModelAdapter {
                     systemMessage: options.prompt.systemMessage,
                     userMessage: options.prompt.userMessage,
                 }),
-            } as FireworksChatModelRequestParams
+            }
         }
 
         return {
             ...baseBody,
             prompt: options.prompt.userMessage,
-        } as FireworksCompletionModelRequestParams
+        }
     }
 }


### PR DESCRIPTION
- Disables rewrite speculation based on offline latency evals.
- Exposes request/response body to the auto-edit debug panel from the Fireworks adapter.

## Test plan

CI
