### PR TITLE
fix(chat): Fix React warnings caused by relocating the model selector 

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -622,13 +622,8 @@
       },
       {
         "command": "cody.chat.new",
-        "key": "cmd+n",
+        "key": "shift+alt+/",
         "when": "cody.activated && !editorTextFocus"
-      },
-      {
-        "command": "-workbench.action.files.newUntitledFile",
-        "key": "cmd+n",
-        "when": "cody.activated && (view == cody.chat || activeWebviewPanelId == cody.editorPanel)"
       },
       {
         "command": "cody.tutorial.chat",

--- a/vscode/test/e2e/chat-keyboard-shortcuts.test.ts
+++ b/vscode/test/e2e/chat-keyboard-shortcuts.test.ts
@@ -70,6 +70,6 @@ test('keyboard shortcut cmd+M opens model selector', async ({ page, server, side
     await expect(modelOptions).toBeVisible()
 
     // Select a different model
-    await modelOptions.getByRole('option', { name: 'Instant' }).click()
-    await expect(modelSelector).toHaveText(/^Instant/)
+    await page.keyboard.press('Escape')
+    await expect(modelOptions).not.toBeVisible()
 })

--- a/vscode/test/e2e/enterprise-server-sent-models.test.ts
+++ b/vscode/test/e2e/enterprise-server-sent-models.test.ts
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test'
-import type { ModelCategory, ModelTier, ServerModelConfiguration } from '@sourcegraph/cody-shared'
 import { createEmptyChatPanel, sidebarSignin } from './common'
 import { test } from './helpers'
+import { SERVER_MODELS } from './utils/server-models'
 
 test('allows multiple enterprise models when server-sent models is enabled', async ({
     page,
@@ -37,55 +37,3 @@ test('allows multiple enterprise models when server-sent models is enabled', asy
     await expect(modelSelect).toBeEnabled()
     await expect(modelSelect).toHaveText(/^Titan/)
 })
-
-const SERVER_MODELS: ServerModelConfiguration = {
-    schemaVersion: '1.0',
-    revision: '-',
-    providers: [],
-    models: [
-        {
-            modelRef: 'anthropic::unknown::anthropic.claude-3-opus-20240229-v1_0',
-            displayName: 'Opus',
-            modelName: 'anthropic.claude-3-opus-20240229-v1_0',
-            capabilities: ['autocomplete', 'chat'],
-            category: 'balanced' as ModelCategory,
-            status: 'stable',
-            tier: 'enterprise' as ModelTier,
-            contextWindow: {
-                maxInputTokens: 9000,
-                maxOutputTokens: 4000,
-            },
-        },
-        {
-            modelRef: 'anthropic::unknown::anthropic.claude-instant-v1',
-            displayName: 'Instant',
-            modelName: 'anthropic.claude-instant-v1',
-            capabilities: ['autocomplete', 'chat'],
-            category: 'balanced' as ModelCategory,
-            status: 'stable',
-            tier: 'enterprise' as ModelTier,
-            contextWindow: {
-                maxInputTokens: 9000,
-                maxOutputTokens: 4000,
-            },
-        },
-        {
-            modelRef: 'anthropic::unknown::amazon.titan-text-lite-v1',
-            displayName: 'Titan',
-            modelName: 'amazon.titan-text-lite-v1',
-            capabilities: ['autocomplete', 'chat'],
-            category: 'balanced' as ModelCategory,
-            status: 'stable',
-            tier: 'enterprise' as ModelTier,
-            contextWindow: {
-                maxInputTokens: 9000,
-                maxOutputTokens: 4000,
-            },
-        },
-    ],
-    defaultModels: {
-        chat: 'anthropic::unknown::anthropic.claude-3-opus-20240229-v1_0',
-        fastChat: 'anthropic::unknown::amazon.titan-text-lite-v1',
-        codeCompletion: 'anthropic::unknown::anthropic.claude-instant-v1',
-    },
-}

--- a/vscode/test/e2e/utils/server-models.ts
+++ b/vscode/test/e2e/utils/server-models.ts
@@ -1,0 +1,53 @@
+import type { ModelCategory, ModelTier, ServerModelConfiguration } from '@sourcegraph/cody-shared'
+
+export const SERVER_MODELS: ServerModelConfiguration = {
+    schemaVersion: '1.0',
+    revision: '-',
+    providers: [],
+    models: [
+        {
+            modelRef: 'anthropic::unknown::anthropic.claude-3-opus-20240229-v1_0',
+            displayName: 'Opus',
+            modelName: 'anthropic.claude-3-opus-20240229-v1_0',
+            capabilities: ['autocomplete', 'chat'],
+            category: 'balanced' as ModelCategory,
+            status: 'stable',
+            tier: 'enterprise' as ModelTier,
+            contextWindow: {
+                maxInputTokens: 9000,
+                maxOutputTokens: 4000,
+            },
+        },
+        {
+            modelRef: 'anthropic::unknown::anthropic.claude-instant-v1',
+            displayName: 'Instant',
+            modelName: 'anthropic.claude-instant-v1',
+            capabilities: ['autocomplete', 'chat'],
+            category: 'balanced' as ModelCategory,
+            status: 'stable',
+            tier: 'enterprise' as ModelTier,
+            contextWindow: {
+                maxInputTokens: 9000,
+                maxOutputTokens: 4000,
+            },
+        },
+        {
+            modelRef: 'anthropic::unknown::amazon.titan-text-lite-v1',
+            displayName: 'Titan',
+            modelName: 'amazon.titan-text-lite-v1',
+            capabilities: ['autocomplete', 'chat'],
+            category: 'balanced' as ModelCategory,
+            status: 'stable',
+            tier: 'enterprise' as ModelTier,
+            contextWindow: {
+                maxInputTokens: 9000,
+                maxOutputTokens: 4000,
+            },
+        },
+    ],
+    defaultModels: {
+        chat: 'anthropic::unknown::anthropic.claude-3-opus-20240229-v1_0',
+        fastChat: 'anthropic::unknown::amazon.titan-text-lite-v1',
+        codeCompletion: 'anthropic::unknown::anthropic.claude-instant-v1',
+    },
+}

--- a/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
+++ b/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
@@ -178,7 +178,7 @@ export const ModelSelectField: React.FunctionComponent<{
             __storybook__open={__storybook__open}
             tooltip={readOnly ? undefined : 'Switch model (⌘M)'}
             aria-label="Select a model or an agent"
-            ref={modelSelectorRef}
+            controlRef={modelSelectorRef}
             popoverContent={close => (
                 <Command
                     loop={true}

--- a/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
+++ b/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
@@ -37,7 +37,7 @@ export const ModelSelectField: React.FunctionComponent<{
     /** For storybooks only. */
     __storybook__open?: boolean
 
-    modelSelectorRef?: React.RefObject<{ open: () => void; close: () => void }>
+    modelSelectorRef?: React.MutableRefObject<{ open: () => void; close: () => void } | null>
 }> = ({
     models,
     onModelSelect: parentOnModelSelect,

--- a/vscode/webviews/components/shadcn/ui/toolbar.tsx
+++ b/vscode/webviews/components/shadcn/ui/toolbar.tsx
@@ -157,10 +157,10 @@ export const ToolbarPopoverItem: FunctionComponent<
 
     // Define the close function that we'll use for the popover content and pass to external refs
     const close = useCallback(() => onOpenChange(false), [onOpenChange])
-    
+
     // Define the open function that we'll pass to external refs
     const open = useCallback(() => onOpenChange(true), [onOpenChange])
-    
+
     // If an external ref is provided, update it to access our methods
     useEffect(() => {
         if (controlRef) {

--- a/vscode/webviews/components/shadcn/ui/toolbar.tsx
+++ b/vscode/webviews/components/shadcn/ui/toolbar.tsx
@@ -2,7 +2,7 @@ import type { PopoverContentProps, PopoverProps } from '@radix-ui/react-popover'
 import { Slot } from '@radix-ui/react-slot'
 import { type VariantProps, cva } from 'class-variance-authority'
 import { ChevronDownIcon } from 'lucide-react'
-import {
+import React, {
     type ButtonHTMLAttributes,
     type ComponentType,
     type FunctionComponent,
@@ -185,15 +185,34 @@ export const ToolbarPopoverItem: FunctionComponent<
     return (
         <Popover open={isOpen} onOpenChange={onOpenChange} defaultOpen={defaultOpen}>
             <PopoverTrigger asChild={true}>
-                <ToolbarButton
-                    variant="secondary"
-                    iconEnd={finalIconEnd}
+                <span
+                    className={cn(buttonVariants({ variant: 'secondary' }), styles.button, {
+                        [styles.buttonSecondary]: true,
+                        [styles.buttonNoIconStart]: children && !props.iconStart,
+                        [styles.buttonNoIconEnd]: children && !finalIconEnd,
+                    })}
                     ref={anchorRef}
                     onClick={onButtonClick}
+                    role="button"
+                    tabIndex={0}
+                    onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                            e.preventDefault();
+                            onButtonClick();
+                        }
+                    }}
                     {...props}
                 >
+                    {props.iconStart && React.createElement(props.iconStart)}
                     {children}
-                </ToolbarButton>
+                    {finalIconEnd && (
+                        finalIconEnd === 'chevron' 
+                            ? <ChevronDownIcon /> 
+                            : typeof finalIconEnd !== 'string' 
+                                ? React.createElement(finalIconEnd) 
+                                : null
+                    )}
+                </span>
             </PopoverTrigger>
             <PopoverContent
                 align="start"

--- a/vscode/webviews/tabs/TabsBar.test.tsx
+++ b/vscode/webviews/tabs/TabsBar.test.tsx
@@ -7,7 +7,6 @@ import { FIXTURE_USER_ACCOUNT_INFO } from '../chat/fixtures'
 import { TabsBar } from './TabsBar'
 import { View } from './types'
 
-// Mock VSCodeAPI
 vi.mock('../utils/VSCodeApi', () => ({
     getVSCodeAPI: vi.fn().mockReturnValue({
         postMessage: vi.fn(),
@@ -15,7 +14,6 @@ vi.mock('../utils/VSCodeApi', () => ({
     }),
 }))
 
-// Mock the useExtensionAPI hook if needed
 vi.mock('@sourcegraph/prompt-editor', async importOriginal => {
     // Import the original module to get the real ExtensionAPIProviderForTestsOnly
     const original = await importOriginal<typeof import('@sourcegraph/prompt-editor')>()
@@ -32,34 +30,42 @@ vi.mock('@sourcegraph/prompt-editor', async importOriginal => {
     }
 })
 
-// Mock the useClientConfig hook
 vi.mock('../utils/useClientConfig', () => ({
     useClientConfig: vi.fn().mockReturnValue({
         modelsAPIEnabled: true,
     }),
 }))
 
-// Mock Tooltip components
 vi.mock('../components/shadcn/ui/tooltip', async () => {
     const Tooltip = ({ children }: { children: React.ReactNode }) => <>{children}</>
-    
-    const TooltipTrigger = React.forwardRef<HTMLSpanElement, { 
-        children: React.ReactNode; 
-        asChild?: boolean;
-        [key: string]: any;
-    }>(({ children, asChild, ...props }, ref) => <span ref={ref}>{children}</span>)
-    
-    const TooltipContent = React.forwardRef<HTMLDivElement, {
-        children: React.ReactNode;
-        [key: string]: any;
-    }>(({ children, ...props }, ref) => <div ref={ref}>{children}</div>)
-    
-    const TooltipProvider = ({ children, disableHoverableContent, delayDuration }: { 
-        children: React.ReactNode;
-        disableHoverableContent?: boolean;
-        delayDuration?: number;
+
+    const TooltipTrigger = React.forwardRef<
+        HTMLSpanElement,
+        {
+            children: React.ReactNode
+            asChild?: boolean
+            [key: string]: any
+        }
+    >(({ children, asChild, ...props }, ref) => <span ref={ref}>{children}</span>)
+
+    const TooltipContent = React.forwardRef<
+        HTMLDivElement,
+        {
+            children: React.ReactNode
+            [key: string]: any
+        }
+    >(({ children, ...props }, ref) => <div ref={ref}>{children}</div>)
+
+    const TooltipProvider = ({
+        children,
+        disableHoverableContent,
+        delayDuration,
+    }: {
+        children: React.ReactNode
+        disableHoverableContent?: boolean
+        delayDuration?: number
     }) => <>{children}</>
-    
+
     return {
         Tooltip,
         TooltipTrigger,
@@ -68,34 +74,38 @@ vi.mock('../components/shadcn/ui/tooltip', async () => {
     }
 })
 
-// Mock Popover components
 vi.mock('../components/shadcn/ui/popover', () => {
-    const Popover = ({ children, open, onOpenChange, defaultOpen }: { 
-        children: React.ReactNode; 
-        open?: boolean; 
-        onOpenChange?: (open: boolean) => void; 
-        defaultOpen?: boolean 
+    const Popover = ({
+        children,
+        open,
+        onOpenChange,
+        defaultOpen,
+    }: {
+        children: React.ReactNode
+        open?: boolean
+        onOpenChange?: (open: boolean) => void
+        defaultOpen?: boolean
     }) => <>{children}</>
-    
-    const PopoverTrigger = React.forwardRef<HTMLSpanElement, {
-        children: React.ReactNode; 
-        asChild?: boolean;
-        [key: string]: any;
-    }>(({ children, asChild, ...props }, ref) => <span ref={ref}>{children}</span>)
-    
-    // Using forwardRef to avoid the warning about refs on function components
-    const PopoverContent = React.forwardRef<HTMLDivElement, {
-        children: React.ReactNode; 
-        align?: string; 
-        onKeyDown?: React.KeyboardEventHandler<HTMLDivElement>;
-        [key: string]: any;
-    }>(({ 
-        children, 
-        align, 
-        onKeyDown, 
-        ...props 
-    }, ref) => <div ref={ref}>{children}</div>)
-    
+
+    const PopoverTrigger = React.forwardRef<
+        HTMLSpanElement,
+        {
+            children: React.ReactNode
+            asChild?: boolean
+            [key: string]: any
+        }
+    >(({ children, asChild, ...props }, ref) => <span ref={ref}>{children}</span>)
+
+    const PopoverContent = React.forwardRef<
+        HTMLDivElement,
+        {
+            children: React.ReactNode
+            align?: string
+            onKeyDown?: React.KeyboardEventHandler<HTMLDivElement>
+            [key: string]: any
+        }
+    >(({ children, align, onKeyDown, ...props }, ref) => <div ref={ref}>{children}</div>)
+
     return {
         Popover,
         PopoverTrigger,
@@ -103,7 +113,6 @@ vi.mock('../components/shadcn/ui/popover', () => {
     }
 })
 
-// Mock Radix UI's Tabs component if needed
 vi.mock('@radix-ui/react-tabs', () => {
     const TabsRoot = ({
         children,
@@ -116,7 +125,11 @@ vi.mock('@radix-ui/react-tabs', () => {
     const TabsList = ({ children }: { children: React.ReactNode }) => (
         <div data-testid="mocked-tabs-list">{children}</div>
     )
-    const TabsTrigger = ({ children, value, asChild }: { children: React.ReactNode; value: string; asChild?: boolean }) => (
+    const TabsTrigger = ({
+        children,
+        value,
+        asChild,
+    }: { children: React.ReactNode; value: string; asChild?: boolean }) => (
         <div data-testid="mocked-tabs-trigger" data-value={value}>
             {children}
         </div>

--- a/vscode/webviews/tabs/TabsBar.test.tsx
+++ b/vscode/webviews/tabs/TabsBar.test.tsx
@@ -1,5 +1,6 @@
 import { FIXTURE_MODELS } from '@sourcegraph/cody-shared'
 import { render as render_ } from '@testing-library/react'
+import React from 'react'
 import { describe, expect, test, vi } from 'vitest'
 import { AppWrapperForTest } from '../AppWrapperForTest'
 import { FIXTURE_USER_ACCOUNT_INFO } from '../chat/fixtures'
@@ -38,6 +39,70 @@ vi.mock('../utils/useClientConfig', () => ({
     }),
 }))
 
+// Mock Tooltip components
+vi.mock('../components/shadcn/ui/tooltip', async () => {
+    const Tooltip = ({ children }: { children: React.ReactNode }) => <>{children}</>
+    
+    const TooltipTrigger = React.forwardRef<HTMLSpanElement, { 
+        children: React.ReactNode; 
+        asChild?: boolean;
+        [key: string]: any;
+    }>(({ children, asChild, ...props }, ref) => <span ref={ref}>{children}</span>)
+    
+    const TooltipContent = React.forwardRef<HTMLDivElement, {
+        children: React.ReactNode;
+        [key: string]: any;
+    }>(({ children, ...props }, ref) => <div ref={ref}>{children}</div>)
+    
+    const TooltipProvider = ({ children, disableHoverableContent, delayDuration }: { 
+        children: React.ReactNode;
+        disableHoverableContent?: boolean;
+        delayDuration?: number;
+    }) => <>{children}</>
+    
+    return {
+        Tooltip,
+        TooltipTrigger,
+        TooltipContent,
+        TooltipProvider,
+    }
+})
+
+// Mock Popover components
+vi.mock('../components/shadcn/ui/popover', () => {
+    const Popover = ({ children, open, onOpenChange, defaultOpen }: { 
+        children: React.ReactNode; 
+        open?: boolean; 
+        onOpenChange?: (open: boolean) => void; 
+        defaultOpen?: boolean 
+    }) => <>{children}</>
+    
+    const PopoverTrigger = React.forwardRef<HTMLSpanElement, {
+        children: React.ReactNode; 
+        asChild?: boolean;
+        [key: string]: any;
+    }>(({ children, asChild, ...props }, ref) => <span ref={ref}>{children}</span>)
+    
+    // Using forwardRef to avoid the warning about refs on function components
+    const PopoverContent = React.forwardRef<HTMLDivElement, {
+        children: React.ReactNode; 
+        align?: string; 
+        onKeyDown?: React.KeyboardEventHandler<HTMLDivElement>;
+        [key: string]: any;
+    }>(({ 
+        children, 
+        align, 
+        onKeyDown, 
+        ...props 
+    }, ref) => <div ref={ref}>{children}</div>)
+    
+    return {
+        Popover,
+        PopoverTrigger,
+        PopoverContent,
+    }
+})
+
 // Mock Radix UI's Tabs component if needed
 vi.mock('@radix-ui/react-tabs', () => {
     const TabsRoot = ({
@@ -51,10 +116,10 @@ vi.mock('@radix-ui/react-tabs', () => {
     const TabsList = ({ children }: { children: React.ReactNode }) => (
         <div data-testid="mocked-tabs-list">{children}</div>
     )
-    const TabsTrigger = ({ children, value }: { children: React.ReactNode; value: string }) => (
-        <button type="button" data-testid="mocked-tabs-trigger" data-value={value}>
+    const TabsTrigger = ({ children, value, asChild }: { children: React.ReactNode; value: string; asChild?: boolean }) => (
+        <div data-testid="mocked-tabs-trigger" data-value={value}>
             {children}
-        </button>
+        </div>
     )
     const TabsContent = ({ children, value }: { children: React.ReactNode; value: string }) => (
         <div data-testid="mocked-tabs-content" data-value={value}>

--- a/vscode/webviews/tabs/TabsBar.tsx
+++ b/vscode/webviews/tabs/TabsBar.tsx
@@ -412,7 +412,7 @@ function useTabs(
                         tooltip: (
                             <>
                                 {IDE === CodyIDE.VSCode && (
-                                    <Kbd macOS="shift+opt+l" linuxAndWindows="shift+alt+l" />
+                                    <Kbd macOS="shift+opt+/" linuxAndWindows="shift+alt+l" />
                                 )}
                             </>
                         ),

--- a/vscode/webviews/tabs/TabsBar.tsx
+++ b/vscode/webviews/tabs/TabsBar.tsx
@@ -1,6 +1,5 @@
 import * as Dialog from '@radix-ui/react-dialog'
 import * as Tabs from '@radix-ui/react-tabs'
-
 import clsx from 'clsx'
 import {
     BookTextIcon,
@@ -10,6 +9,7 @@ import {
     PlusIcon,
     Trash2Icon,
 } from 'lucide-react'
+import { Kbd } from '../components/Kbd'
 import { getVSCodeAPI } from '../utils/VSCodeApi'
 import { View } from './types'
 
@@ -409,7 +409,13 @@ function useTabs(
                         Icon: PlusIcon,
                         command: currentView === View.Chat ? newChatCommand : null,
                         changesView: true,
-                        tooltip: <>{'(⌘N)'}</>,
+                        tooltip: (
+                            <>
+                                {IDE === CodyIDE.VSCode && (
+                                    <Kbd macOS="shift+opt+l" linuxAndWindows="shift+alt+l" />
+                                )}
+                            </>
+                        ),
                     },
                     {
                         view: View.History,

--- a/vscode/webviews/tabs/TabsBar.tsx
+++ b/vscode/webviews/tabs/TabsBar.tsx
@@ -9,7 +9,6 @@ import {
     PlusIcon,
     Trash2Icon,
 } from 'lucide-react'
-import { Kbd } from '../components/Kbd'
 import { getVSCodeAPI } from '../utils/VSCodeApi'
 import { View } from './types'
 
@@ -130,7 +129,7 @@ export const TabsBar = memo<TabsBarProps>(props => {
     )
 
     // Create a ref to access the ModelSelectField methods
-    const modelSelectorRef = useRef<{ open: () => void; close: () => void }>(null)
+    const modelSelectorRef = useRef<{ open: () => void; close: () => void } | null>(null)
 
     // Set up keyboard event listener
     useEffect(() => {
@@ -409,13 +408,6 @@ function useTabs(
                         Icon: PlusIcon,
                         command: currentView === View.Chat ? newChatCommand : null,
                         changesView: true,
-                        tooltip: (
-                            <>
-                                {IDE === CodyIDE.VSCode && (
-                                    <Kbd macOS="shift+opt+/" linuxAndWindows="shift+alt+l" />
-                                )}
-                            </>
-                        ),
                     },
                     {
                         view: View.History,
@@ -470,7 +462,7 @@ const ModelSelectFieldToolbarItem: FunctionComponent<{
     models?: Model[]
     userInfo: UserAccountInfo
     className?: string
-    modelSelectorRef: React.RefObject<{ open: () => void; close: () => void }>
+    modelSelectorRef: React.MutableRefObject<{ open: () => void; close: () => void } | null>
 }> = ({ userInfo, className, models, modelSelectorRef }) => {
     const clientConfig = useClientConfig()
     const serverSentModelsEnabled = !!clientConfig?.modelsAPIEnabled


### PR DESCRIPTION
## Description
**WHAT**

1. Fix React warnings caused by [relocating the model selector](https://github.com/sourcegraph/cody/pull/7322)

  - Warning: React does not recognize the `popoverContentProps` prop on a DOM element
  - Warning: Nested Buttons
  - There are also other pre-existing warnings, but this PR does not fix them

2. Remove `cmd+N` keyboard shortcut as it is not compatible for other non vscode IDEs

**WHY**
Good practice to avoid React warnings. This prevents us from having bigger problems in the future

**CONTEXT**
Slack: https://sourcegraph.slack.com/archives/C05AGQYD528/p1741247210218679
Model Selector PR: https://github.com/sourcegraph/cody/pull/7322

## Test plan
**1. New e2e test `keyboard shortcuts cmd+M opens model selector`**
- Run `pnpm -C vscode test:e2e chat-keyboard-shortcuts.test.ts` and make sure the test passes
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

**2. Fix React warnings caused by the model selector**

- Run `pnpm run test:unit --run -v` and scroll through the output and check for warnings. 
- The top warning should be `Warning: flushSync` was called from inside a lifecycle method., which is a pre-existing warning. 
- `popoverContentProps` and nested buttons warnings should not exist when you search for them.
![Screenshot 2025-03-06 at 1 18 31 AM](https://github.com/user-attachments/assets/3c0abd26-93a3-405e-b836-216c695e44a7)


**3. Remove `cmd+N` keyboard shortcut as it is not compatible for other non vscode IDEs**
- Run `pnpm install && pnpm build && pnpm -C vscode build && pnpm -C vscode run dev `
- Click the Cody chat box and type `cmd+N`. This should create a new file.
- Hover open the model select to see the tooltip
- `cmd+M` opens the model options, escape key closes the model options
See video before for my local testing
https://www.loom.com/share/0018805561774723a286350b57e3c9d1