### PR TITLE
Updating CodyAuthService from authStatus/didUpdate

### DIFF
--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -175,16 +175,6 @@ class AuthProvider implements vscode.Disposable {
                 try {
                     this.lastEndpoint = authStatus.endpoint
                     vscode.commands.executeCommand('authStatus.update', authStatus)
-                    vscode.commands.executeCommand(
-                        'setContext',
-                        'cody.activated',
-                        authStatus.authenticated
-                    )
-                    vscode.commands.executeCommand(
-                        'setContext',
-                        'cody.serverEndpoint',
-                        authStatus.endpoint
-                    )
                 } catch (error) {
                     logError('AuthProvider', 'Unexpected error while setting context', error)
                 }

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -175,6 +175,16 @@ class AuthProvider implements vscode.Disposable {
                 try {
                     this.lastEndpoint = authStatus.endpoint
                     vscode.commands.executeCommand('authStatus.update', authStatus)
+                    vscode.commands.executeCommand(
+                        'setContext',
+                        'cody.activated',
+                        authStatus.authenticated
+                    )
+                    vscode.commands.executeCommand(
+                        'setContext',
+                        'cody.serverEndpoint',
+                        authStatus.endpoint
+                    )
                 } catch (error) {
                     logError('AuthProvider', 'Unexpected error while setting context', error)
                 }


### PR DESCRIPTION
Instead of using `window_didChangeContext` notification to receive auth status we now use dedicated endpoint `authStatus/didUpdate` which contains a full set of auth data. 
## Test plan
**Test Case 1:**
1. Make sure you are logged into Cody
2. Run JB app
3. Check that Cody logs in normally

**Test Case 2:**
1. Log out of Cody
2. Restart JB
3. Go through the login process
4. Check to see if Cody has gone into logged-in state

**Test Case 3:**
1. Make sure you are logged into Cody
2. Run JB app
3. Use 'Switch Account' action in Codi's user menu to change account
4. After changing the account, Cody should remain logged in
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
