### PR TITLE
chore: disable renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,15 +1,4 @@
 {
   "$schema": "http://json.schemastore.org/renovate",
-  "extends": ["github>sourcegraph/renovate-config"],
-  "semanticCommits": "disabled",
-  "rebaseWhen": "never",
-  "prBodyNotes": ["Test plan: CI should pass with updated dependencies."],
-  "dependencyDashboardApproval": true,
-  "packageRules": [
-    {
-      "matchDepTypes": ["engines"],
-      "matchPackageNames": ["node"],
-      "rangeStrategy": "bump"
-    }
-  ]
+  "enabled": false
 }


### PR DESCRIPTION
This disables renovate from running

* The PRs are at this point just noise and seem to be ignored
<img width="615" alt="Screenshot 2025-03-06 at 16 37 03" src="https://github.com/user-attachments/assets/7f58e3de-b393-4f38-86fc-0cc026e31998" />

As per the screenshot - `pin depedencies` was opened Jan 1 2024 and it's now over 1 year old.

* Furthermore, disabling renovate saves us a tiny amount of action runner time too


## Test plan
Renovate should not run anymore