### PR TITLE
fix(ci): improve windows unit-test job and cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,6 @@ jobs:
           restore-keys: ${{ runner.os }}-pnpm-store-
 
       - run: pnpm install
-        if: steps.restore-pnpm-cache.outputs.cache-hit != 'true'
 
       - name: Save cache pnpm store
         if: steps.restore-pnpm-cache.outputs.cache-hit != 'true'
@@ -103,7 +102,6 @@ jobs:
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: ${{ runner.os }}-pnpm-store-
       - run: pnpm install
-        if: steps.restore-pnpm-cache.outputs.cache-hit != 'true'
 
       - name: Save cache pnpm store
         if: steps.restore-pnpm-cache.outputs.cache-hit != 'true'
@@ -163,7 +161,6 @@ jobs:
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: ${{ runner.os }}-pnpm-store-
       - run: pnpm install
-        if: steps.restore-pnpm-cache.outputs.cache-hit != 'true'
 
       - name: Save cache pnpm store
         if: steps.restore-pnpm-cache.outputs.cache-hit != 'true'
@@ -220,7 +217,6 @@ jobs:
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: ${{ runner.os }}-pnpm-store-
       - run: pnpm install
-        if: steps.restore-pnpm-cache.outputs.cache-hit != 'true'
 
       - name: Save cache pnpm store
         if: steps.restore-pnpm-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,13 +56,22 @@ jobs:
       - run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
         shell: bash
         id: pnpm-cache
-      - name: Cache pnpm store
-        uses: actions/cache@v4
+      - name: Restore cache pnpm store
+        uses: actions/cache/restore@v4
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
           key: ${{ runner.os }}-${{ matrix.node }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: ${{ runner.os }}-${{ matrix.node }}-pnpm-store-
+
       - run: pnpm install
+        if: steps.cache-primes.outputs.cache-hit != 'true'
+
+      - name: Save cache pnpm store
+        if: steps.cache-primes.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-${{ matrix.node }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
       - run: pnpm build
       - run: pnpm run test:unit --run
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
         shell: bash
         id: pnpm-cache
       - name: Restore cache pnpm store
+        id: restore-pnpm-cache
         uses: actions/cache/restore@v4
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
@@ -64,10 +65,10 @@ jobs:
           restore-keys: ${{ runner.os }}-pnpm-store-
 
       - run: pnpm install
-        if: steps.cache-primes.outputs.cache-hit != 'true'
+        if: steps.restore-pnpm-cache.outputs.cache-hit != 'true'
 
       - name: Save cache pnpm store
-        if: steps.cache-primes.outputs.cache-hit != 'true'
+        if: steps.restore-pnpm-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-${{ matrix.node }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: ${{ runner.os }}-pnpm-store-
 
       - run: pnpm install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,13 +95,22 @@ jobs:
       - run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
         shell: bash
         id: pnpm-cache
-      - name: Cache pnpm store
+      - name: Restore cache pnpm store
+        id: restore-pnpm-cache
         uses: actions/cache@v4
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: ${{ runner.os }}-pnpm-store-
       - run: pnpm install
+        if: steps.restore-pnpm-cache.outputs.cache-hit != 'true'
+
+      - name: Save cache pnpm store
+        if: steps.restore-pnpm-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
       - run: xvfb-run -a pnpm -C vscode run test:integration
         if: matrix.runner == 'ubuntu'
       - run: pnpm -C vscode run test:integration
@@ -146,13 +155,22 @@ jobs:
       - run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
         shell: bash
         id: pnpm-cache
-      - name: Cache pnpm store
+      - name: Restore cache pnpm store
+        id: restore-pnpm-cache
         uses: actions/cache@v4
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: ${{ runner.os }}-pnpm-store-
       - run: pnpm install
+        if: steps.restore-pnpm-cache.outputs.cache-hit != 'true'
+
+      - name: Save cache pnpm store
+        if: steps.restore-pnpm-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
       - run: GITHUB_REF=$BRANCH_NAME xvfb-run -a pnpm -C vscode run test:e2e --shard=${{ matrix.shard }}
         if: matrix.runner == 'ubuntu'
         env:
@@ -194,13 +212,22 @@ jobs:
       - run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
         shell: bash
         id: pnpm-cache
-      - name: Cache pnpm store
+      - name: Restore cache pnpm store
+        id: restore-pnpm-cache
         uses: actions/cache@v4
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: ${{ runner.os }}-pnpm-store-
       - run: pnpm install
+        if: steps.restore-pnpm-cache.outputs.cache-hit != 'true'
+
+      - name: Save cache pnpm store
+        if: steps.restore-pnpm-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
       # Run Biome and capture the output. If biome crashes, it still reports a
       # successful CI run (exit code 0) but that will ripple down to errors in
       # the Biome VS Code extension. This ensures that we don't accidentally

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
           key: ${{ runner.os }}-${{ matrix.node }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: ${{ runner.os }}-${{ matrix.node }}-pnpm-store-
+          restore-keys: ${{ runner.os }}-pnpm-store-
 
       - run: pnpm install
         if: steps.cache-primes.outputs.cache-hit != 'true'
@@ -71,7 +71,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-${{ matrix.node }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
       - run: pnpm build
       - run: pnpm run test:unit --run
         env:


### PR DESCRIPTION
This fixes the windows unit test job to not timeout and complete about ~3 mins faster

* Use restore and save cache actions - so that we cache sooner
* change cache key to **not** include the node version, this allows the cache to be reused by other windows runners

## Test plan
CI