### PR TITLE
at-mention menu item naming changes

### DIFF
--- a/lib/prompt-editor/src/mentions/mentionMenu/MentionMenuItem.tsx
+++ b/lib/prompt-editor/src/mentions/mentionMenu/MentionMenuItem.tsx
@@ -31,6 +31,7 @@ import {
     LibraryBigIcon,
     LinkIcon,
     ListMinusIcon,
+    SearchIcon,
     SmileIcon,
     SquareDashedMousePointerIcon,
     SquareFunctionIcon,
@@ -178,7 +179,7 @@ export const iconForProvider: Record<
     'https://openctx.org/npm/@openctx/provider-devdocs': LibraryBigIcon,
     'https://openctx.org/npm/@openctx/provider-sourcegraph-search': SourcegraphLogo,
     'internal-linear-issues': LinearLogo, // Can't import LinearIssuesProvider due to transitive dep on vscode.
-    [REMOTE_REPOSITORY_PROVIDER_URI]: FolderGitIcon,
+    [REMOTE_REPOSITORY_PROVIDER_URI]: SearchIcon,
     [REMOTE_FILE_PROVIDER_URI]: FileIcon,
     [REMOTE_DIRECTORY_PROVIDER_URI]: FolderGitIcon,
     [WEB_PROVIDER_URI]: LinkIcon,
@@ -200,4 +201,5 @@ const iconForItem: Record<
     file: FileIcon,
     'square-dashed-mouse-pointer': SquareDashedMousePointerIcon,
     'layout-menubar': LayoutPanelTopIcon,
+    search: SearchIcon,
 }

--- a/vscode/src/chat/initialContext.ts
+++ b/vscode/src/chat/initialContext.ts
@@ -260,10 +260,10 @@ export function getCorpusContextItemsForEditorState(): Observable<
                                 authStatus
                             )
                         ),
-                        title: 'Current Remote Repository',
+                        title: 'Search current repository',
                         description: repo.name,
                         source: items.length > 0 ? ContextItemSource.Unified : ContextItemSource.Initial,
-                        icon: 'git-folder',
+                        icon: 'search',
                     })
                 }
                 // CTA to index repositories should only show for Enterprise customers, see CODY-5017 & CODY-4676
@@ -271,7 +271,7 @@ export function getCorpusContextItemsForEditorState(): Observable<
                     if (!clientCapabilities().isCodyWeb) {
                         items.push({
                             type: 'open-link',
-                            title: 'Current Remote Repository',
+                            title: 'Search current repository',
                             badge: 'Not yet available',
                             content: null,
                             uri: URI.parse(

--- a/vscode/src/chat/initialContext.ts
+++ b/vscode/src/chat/initialContext.ts
@@ -260,7 +260,7 @@ export function getCorpusContextItemsForEditorState(): Observable<
                                 authStatus
                             )
                         ),
-                        title: 'Search current repository',
+                        title: 'Current repository search',
                         description: repo.name,
                         source: items.length > 0 ? ContextItemSource.Unified : ContextItemSource.Initial,
                         icon: 'search',
@@ -271,14 +271,14 @@ export function getCorpusContextItemsForEditorState(): Observable<
                     if (!clientCapabilities().isCodyWeb) {
                         items.push({
                             type: 'open-link',
-                            title: 'Search current repository',
+                            title: 'Current repository search',
                             badge: 'Not yet available',
                             content: null,
                             uri: URI.parse(
                                 'https://sourcegraph.com/docs/cody/prompts-guide#indexing-your-repositories-for-context'
                             ),
                             name: '',
-                            icon: 'folder',
+                            icon: 'search',
                         })
                     }
                 }

--- a/vscode/src/context/openctx.ts
+++ b/vscode/src/context/openctx.ts
@@ -219,7 +219,7 @@ function getCodyWebOpenCtxProviders(): Observable<ImportedProviderConfiguration[
             {
                 settings: true,
                 providerUri: RemoteRepositorySearch.providerUri,
-                provider: createRemoteRepositoryProvider('Repositories'),
+                provider: createRemoteRepositoryProvider('Repository search'),
             },
             {
                 settings: true,

--- a/vscode/src/context/openctx/remoteRepositorySearch.ts
+++ b/vscode/src/context/openctx/remoteRepositorySearch.ts
@@ -16,7 +16,7 @@ export function createRemoteRepositoryProvider(customTitle?: string): OpenCtxPro
         providerUri: REMOTE_REPOSITORY_PROVIDER_URI,
 
         meta() {
-            return { name: customTitle ?? 'Remote Repositories', mentions: {} }
+            return { name: customTitle ?? 'Repository search', mentions: {} }
         },
 
         async mentions({ query }) {

--- a/vscode/test/e2e/common.ts
+++ b/vscode/test/e2e/common.ts
@@ -171,10 +171,11 @@ export function chatInputMentions(chatInput: Locator): Locator {
 export async function openMentionsForProvider(
     frame: FrameLocator,
     chatInput: Locator,
-    provider: string
+    provider: string,
+    exact?: boolean
 ): Promise<void> {
     await chatInput.pressSequentially('@', { delay: 350 })
-    await frame.getByRole('option', { name: provider }).click()
+    await frame.getByRole('option', { name: provider, exact }).click()
 }
 
 export function mentionMenu(chatFrame: FrameLocator): Locator {

--- a/vscode/test/e2e/mention-repository.test.ts
+++ b/vscode/test/e2e/mention-repository.test.ts
@@ -43,7 +43,7 @@ testWithGitRemote('@-mention repository', async ({ page, sidebar, server }) => {
 
     // Wait for the current user repo to be loaded before opening the mention menu.
     await expect(chatInputMentions(lastChatInput)).toHaveText([userRepo])
-    await openMentionsForProvider(chatFrame, lastChatInput, 'Repository search')
+    await openMentionsForProvider(chatFrame, lastChatInput, 'Repository search', true)
     await expect(mentionMenuItems(chatFrame)).toHaveText(['a/b', 'c/d'])
     await selectMentionMenuItem(chatFrame, 'c/d')
     await expect(chatInputMentions(lastChatInput)).toHaveText([userRepo, 'codehost.example/c/d'])

--- a/vscode/test/e2e/mention-repository.test.ts
+++ b/vscode/test/e2e/mention-repository.test.ts
@@ -43,7 +43,7 @@ testWithGitRemote('@-mention repository', async ({ page, sidebar, server }) => {
 
     // Wait for the current user repo to be loaded before opening the mention menu.
     await expect(chatInputMentions(lastChatInput)).toHaveText([userRepo])
-    await openMentionsForProvider(chatFrame, lastChatInput, 'Remote Repositories')
+    await openMentionsForProvider(chatFrame, lastChatInput, 'Repository search')
     await expect(mentionMenuItems(chatFrame)).toHaveText(['a/b', 'c/d'])
     await selectMentionMenuItem(chatFrame, 'c/d')
     await expect(chatInputMentions(lastChatInput)).toHaveText([userRepo, 'codehost.example/c/d'])

--- a/web/lib/components/CodyPromptTemplate.tsx
+++ b/web/lib/components/CodyPromptTemplate.tsx
@@ -230,7 +230,7 @@ const DYNAMIC_MENTIONS: ContextItem[] = [
         title: 'Current Repository',
         uri: Uri.parse('cody://repository'),
         description: 'Picks the current repository',
-        icon: 'git-folder',
+        icon: 'search',
     } as ContextItemCurrentRepository,
     {
         type: 'current-directory',

--- a/web/lib/components/CodyWebChat.tsx
+++ b/web/lib/components/CodyWebChat.tsx
@@ -310,7 +310,7 @@ const CodyWebPanel: FC<CodyWebPanelProps> = props => {
                         },
                         description: fileURL,
                     },
-                    icon: 'git-folder',
+                    icon: 'search',
                 } as ContextItemOpenCtx)
             } else {
                 // Common file mention with possible file range positions


### PR DESCRIPTION
Make it clear when you tag in repository context, it means "search this repository" and update the icons to indicate that.

Before:

<img width="590" alt="image" src="https://github.com/user-attachments/assets/b2bc687e-d70e-4bf0-a718-b1d9098168a4" />

After:

<img width="414" alt="image" src="https://github.com/user-attachments/assets/12e3703e-f2b0-4cc8-a53c-e21cd736a288" />


## Test plan

Appearance only