### PR TITLE
chore(telemetry): update `billingMetadata` for autoedit and completion events

### DIFF
--- a/vscode/src/autoedits/analytics-logger/analytics-logger.test.ts
+++ b/vscode/src/autoedits/analytics-logger/analytics-logger.test.ts
@@ -173,12 +173,9 @@ describe('AutoeditAnalyticsLogger', () => {
         expect(recordSpy).toHaveBeenCalledTimes(3)
         expect(recordSpy).toHaveBeenNthCalledWith(1, 'cody.autoedit', 'suggested', expect.any(Object))
         expect(recordSpy).toHaveBeenNthCalledWith(2, 'cody.autoedit', 'accepted', expect.any(Object))
-        expect(recordSpy).toHaveBeenNthCalledWith(
-            3,
-            'cody.autoedit',
-            'invalidTransitionToAccepted',
-            undefined
-        )
+        expect(recordSpy).toHaveBeenNthCalledWith(3, 'cody.autoedit', 'invalidTransitionToAccepted', {
+            billingMetadata: undefined,
+        })
 
         const suggestedEventPayload = recordSpy.mock.calls[0].at(2)
         expect(suggestedEventPayload).toMatchInlineSnapshot(`
@@ -319,10 +316,7 @@ describe('AutoeditAnalyticsLogger', () => {
         const discardedEventPayload = recordSpy.mock.calls[0].at(2)
         expect(discardedEventPayload).toMatchInlineSnapshot(`
           {
-            "billingMetadata": {
-              "category": "billable",
-              "product": "cody",
-            },
+            "billingMetadata": undefined,
             "interactionID": undefined,
             "metadata": {
               "discardReason": 2,
@@ -352,18 +346,12 @@ describe('AutoeditAnalyticsLogger', () => {
         autoeditLogger.markAsRejected(requestId)
 
         expect(recordSpy).toHaveBeenCalledTimes(2)
-        expect(recordSpy).toHaveBeenNthCalledWith(
-            1,
-            'cody.autoedit',
-            'invalidTransitionToSuggested',
-            undefined
-        )
-        expect(recordSpy).toHaveBeenNthCalledWith(
-            2,
-            'cody.autoedit',
-            'invalidTransitionToRejected',
-            undefined
-        )
+        expect(recordSpy).toHaveBeenNthCalledWith(1, 'cody.autoedit', 'invalidTransitionToSuggested', {
+            billingMetadata: undefined,
+        })
+        expect(recordSpy).toHaveBeenNthCalledWith(2, 'cody.autoedit', 'invalidTransitionToRejected', {
+            billingMetadata: undefined,
+        })
     })
 
     it('throttles repeated error logs, capturing the first occurrence immediately', () => {

--- a/vscode/src/autoedits/analytics-logger/analytics-logger.ts
+++ b/vscode/src/autoedits/analytics-logger/analytics-logger.ts
@@ -62,7 +62,6 @@ type AutoeditEventAction =
 
 const AUTOEDIT_EVENT_BILLING_CATEGORY: Partial<Record<AutoeditEventAction, BillingCategory>> = {
     accepted: 'core',
-    discarded: 'billable',
     suggested: 'billable',
 }
 
@@ -447,9 +446,17 @@ export class AutoeditAnalyticsLogger {
         >
     }): void {
         autoeditsOutputChannelLogger.logDebug('writeAutoeditEvent', action, ...logDebugArgs)
-        telemetryRecorder.recordEvent('cody.autoedit', action, telemetryParams)
+        telemetryRecorder.recordEvent('cody.autoedit', action, {
+            ...telemetryParams,
+            billingMetadata:
+                action === 'accepted' || action === 'suggested'
+                    ? {
+                          product: 'cody',
+                          category: action === 'accepted' ? 'core' : 'billable',
+                      }
+                    : undefined,
+        })
     }
-
     /**
      * Rate-limited error logging, capturing exceptions with Sentry and grouping repeated logs.
      */

--- a/vscode/src/autoedits/autoedits-provider.test.ts
+++ b/vscode/src/autoedits/autoedits-provider.test.ts
@@ -346,6 +346,7 @@ describe('AutoeditsProvider', () => {
         const errorPayload = recordSpy.mock.calls[0].at(2)
         expect(errorPayload).toMatchInlineSnapshot(`
           {
+            "billingMetadata": undefined,
             "metadata": {
               "count": 1,
             },

--- a/vscode/src/completions/analytics-logger.ts
+++ b/vscode/src/completions/analytics-logger.ts
@@ -505,19 +505,23 @@ function writeCompletionEvent<SubFeature extends string, Action extends string, 
     } else {
         // Add billing metadata to completion event params.
         params =
-            action === 'error'
-                ? params
-                : {
+            action === 'suggested'
+                ? {
                       ...params,
                       billingMetadata: {
                           product: 'cody',
-                          // Only acceptance events qualify as "core" usage.
-                          category:
-                              action === 'partiallyAccepted' || action === 'accepted'
-                                  ? 'core'
-                                  : 'billable',
+                          category: 'billable',
                       },
                   }
+                : action === 'partiallyAccepted' || action === 'accepted'
+                  ? {
+                        ...params,
+                        billingMetadata: {
+                            product: 'cody',
+                            category: 'core',
+                        },
+                    }
+                  : params
 
         telemetryRecorder.recordEvent('cody.completion', action, params)
     }


### PR DESCRIPTION
Update `billingMetadata` for autoedit and completion events that should not be billable, to ensure accurate categorization.
updates:
- `cody.autoedit:discarded`
- `cody.completion:noResponse`
- `cody.completion:synthesizedFromParallelRequest`

to not be billable events.

## Test plan

CI  + tested locally
The events listed above do not have `billingMetadata`, and confirming the other completion events like suggested, accepted are unaffected.

<img width="622" alt="image" src="https://github.com/user-attachments/assets/29aaed08-ca30-4a62-bd48-fb421f319f2e" />
<img width="583" alt="image" src="https://github.com/user-attachments/assets/76744675-381e-4a71-9372-0ded9edcf6e7" />
<img width="584" alt="image" src="https://github.com/user-attachments/assets/537595c1-abb5-40cb-abdd-b5a536c49724" />
<img width="554" alt="image" src="https://github.com/user-attachments/assets/63d6c699-b42b-45b2-b98d-31a4dd925498" />
<img width="705" alt="image" src="https://github.com/user-attachments/assets/58ceeff7-4e33-479f-8534-a32046e396c3" />

