### PR TITLE
fix/edits: After a successful edit, the edit instruction field is empty #jetbrains

### DIFF
--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/edit/actions/BaseEditCodeAction.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/edit/actions/BaseEditCodeAction.kt
@@ -32,8 +32,6 @@ open class BaseEditCodeAction(runAction: (Editor) -> Unit) :
 
   override fun update(event: AnActionEvent) {
     super.update(event)
-    println(
-        "BaseEditCodeAction.update event.presentation.isVisible: ${event.presentation.isVisible}, event.presentation.isEnabled: ${event.presentation.isEnabled}")
 
     val project = event.project ?: return
     val (isEnabled, description) =
@@ -57,7 +55,6 @@ open class BaseEditCodeAction(runAction: (Editor) -> Unit) :
       }
     }
 
-    println("isEnabled: $isEnabled, description: $description")
     event.presentation.description = description
     event.presentation.isEnabled = isEnabled
   }

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/edit/actions/BaseEditCodeAction.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/edit/actions/BaseEditCodeAction.kt
@@ -32,6 +32,8 @@ open class BaseEditCodeAction(runAction: (Editor) -> Unit) :
 
   override fun update(event: AnActionEvent) {
     super.update(event)
+    println(
+        "BaseEditCodeAction.update event.presentation.isVisible: ${event.presentation.isVisible}, event.presentation.isEnabled: ${event.presentation.isEnabled}")
 
     val project = event.project ?: return
     val (isEnabled, description) =
@@ -55,6 +57,7 @@ open class BaseEditCodeAction(runAction: (Editor) -> Unit) :
       }
     }
 
+    println("isEnabled: $isEnabled, description: $description")
     event.presentation.description = description
     event.presentation.isEnabled = isEnabled
   }

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/edit/actions/EditCodeAction.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/edit/actions/EditCodeAction.kt
@@ -18,9 +18,10 @@ class EditCodeAction :
 
   override fun update(event: AnActionEvent) {
     super.update(event)
-    event.presentation.isEnabledAndVisible =
-        event.presentation.isEnabledAndVisible &&
-            (event.project?.let { !EditCommandPrompt.isVisible(it) } ?: true)
+    val eventEnabled = event.presentation.isEnabled
+    val popupVisible = event.project?.let { EditCommandPrompt.isVisible(it) } === true
+    // If the popup is visible, we let it handle the keybinding for the action.
+    event.presentation.isEnabled = eventEnabled && !popupVisible
   }
 
   companion object {


### PR DESCRIPTION
We got feedback that it is tedious to delete the last instruction in the input text box. However because the popup auto-dismisses as you scroll around or move your cursor, we need to save your partial input sometimes. This change:

- Saves partial input if the dialog is cancelled (ESC, click outside, etc.)
- After an edit completes, the instruction box is **empty** for the next edit (but you can use up/down for edit history as usual)
- If you "retry" an edit, the instruction box is pre-populated with that edit's instruction

Fixes CODY-5230.

This also simplifies and fixes the logic and control flow around this dialog a bunch:

- The message bus connection was unused and has been removed.
- The popup is removed from the project's user data when it is closed.
- Instead of hammering `performCancelAction` (*okaying* an edit could call this multiple times!) we simply close the popup, and then act on whether the popup was OKed or canceled.
- The "OK" button's label mentioned the input map's shortcut keys, but only listened for one keystroke. Now the label and the keystroke match.
- Doing successive edits could get "stuck" with the edit shortcut disabled because of the `event.presentation.isEnabledAndVisible &&` clause, perhaps since sourcegraph/jetbrains#2382 . Now we let the framework manage visibility and just compute an accurate enabled state.
- We use the popup's default cancel action instead of listening for ESC explicitly.

## Test plan

1. Run JetBrains, for example `cd jetbrains && ./gradlew :customRunIde`
2. Log in to Cody, open a file, highlight some text
3. Start an edit (Alt-K on Windows) and add some instruction, for example, "comment each line"
4. Hit ESC or click outside the dialog, it should disappear
5. Resume the edit (Alt-K) and the instruction "comment each line" should appear
6. Complete the instruction "...in French" and continue the edit (Alt-K)
7. After the edit completes, retry the edit (Alt-R) and change the instruction to "...in Spanish"
8. Hit ESC or click outside the dialog, it should disappear
9. Resume the edit (Alt-K) and the editing "...in Spanish" version should be prefilled
10. Edit it to say "...in Catalan Spanish" and commit the edit (Alt-K), accept the edit.
11. Start a new edit (Alt-K), the instruction box should be empty
12. Verify that up, down scroll through edit history