### PR TITLE
fix(cody): use correct access token when authenticating

### DIFF
--- a/agent/src/cli/command-auth/command-login.ts
+++ b/agent/src/cli/command-auth/command-login.ts
@@ -72,11 +72,7 @@ export const loginCommand = new Command('login')
                 process.exit(1)
             }
             if (!account?.userInfo.username) {
-                errorSpinner(
-                    spinner,
-                    new Error(`failed to authenticate with credentials ${JSON.stringify(options)}`),
-                    options
-                )
+                errorSpinner(spinner, new Error('failed to authenticate'), options)
                 process.exit(1)
             }
             spinner.succeed(
@@ -123,7 +119,7 @@ async function loginAction(
             : await captureAccessTokenViaBrowserRedirect(serverEndpoint, spinner)
     const client = SourcegraphGraphQLAPIClient.withStaticConfig({
         configuration: { telemetryLevel: 'agent' },
-        auth: { credentials: { token: options.accessToken }, serverEndpoint: serverEndpoint },
+        auth: { credentials: { token }, serverEndpoint: serverEndpoint },
         clientState: { anonymousUserID: null },
     })
     const userInfo = await client.getCurrentUserInfo()


### PR DESCRIPTION
Fixes CODY-5251

Previously, the command `cody auth login --web` failed because we used an empty access token to authenticate against Sourcegraph. This commit fixes the bug, and updates a logging statement to stop logging the access token.


## Test plan
Run the following command and validate it works as expected
```
❯ pnpm i
❯ cd agent
❯ pnpm agent:build
❯ pnpm agent:skip-root-build auth login --web
```
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
