### PR TITLE
Fix gear action in Find with Sourcegraph dialog

### DIFF
--- a/jetbrains/src/main/java/com/sourcegraph/config/GoToPluginSettingsButtonFactory.java
+++ b/jetbrains/src/main/java/com/sourcegraph/config/GoToPluginSettingsButtonFactory.java
@@ -27,9 +27,7 @@ public class GoToPluginSettingsButtonFactory {
           @Override
           public void actionPerformed(@NotNull AnActionEvent e) {
             new OpenCodySettingsEditorAction()
-                .actionPerformed(
-                    AnActionEvent.createFromDataContext(
-                        "", e.getPresentation(), SimpleDataContext.getProjectContext(project)));
+                .actionPerformed(e.withDataContext(SimpleDataContext.getProjectContext(project)));
           }
         };
 

--- a/jetbrains/src/main/java/com/sourcegraph/config/GoToPluginSettingsButtonFactory.java
+++ b/jetbrains/src/main/java/com/sourcegraph/config/GoToPluginSettingsButtonFactory.java
@@ -1,8 +1,11 @@
 package com.sourcegraph.config;
 
 import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.Presentation;
 import com.intellij.openapi.actionSystem.impl.ActionButton;
+import com.intellij.openapi.actionSystem.impl.SimpleDataContext;
+import com.intellij.openapi.project.Project;
 import com.intellij.util.IconUtil;
 import com.intellij.util.ui.JBDimension;
 import com.intellij.util.ui.JBUI;
@@ -14,11 +17,21 @@ import org.jetbrains.annotations.NotNull;
 public class GoToPluginSettingsButtonFactory {
 
   @NotNull
-  public static ActionButton createGoToPluginSettingsButton() {
+  public static ActionButton createGoToPluginSettingsButton(Project project) {
     JBDimension actionButtonSize = JBUI.size(22, 22);
 
-    AnAction action = new OpenCodySettingsEditorAction();
     Presentation presentation = new Presentation("Open Plugin Settings");
+
+    AnAction action =
+        new AnAction() {
+          @Override
+          public void actionPerformed(@NotNull AnActionEvent e) {
+            new OpenCodySettingsEditorAction()
+                .actionPerformed(
+                    AnActionEvent.createFromDataContext(
+                        "", e.getPresentation(), SimpleDataContext.getProjectContext(project)));
+          }
+        };
 
     ActionButton button =
         new ActionButton(

--- a/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
+++ b/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
@@ -93,7 +93,7 @@ public class FindPopupPanel extends BorderLayoutPanel implements Disposable {
     }
     browserContainerForOptionalBorder.add(browserAndLoadingPanel, BorderLayout.CENTER);
 
-    HeaderPanel headerPanel = new HeaderPanel();
+    HeaderPanel headerPanel = new HeaderPanel(project);
 
     BorderLayoutPanel topPanel = new BorderLayoutPanel();
     topPanel.add(headerPanel, BorderLayout.NORTH);

--- a/jetbrains/src/main/java/com/sourcegraph/find/HeaderPanel.java
+++ b/jetbrains/src/main/java/com/sourcegraph/find/HeaderPanel.java
@@ -1,5 +1,6 @@
 package com.sourcegraph.find;
 
+import com.intellij.openapi.project.Project;
 import com.intellij.util.ui.JBEmptyBorder;
 import com.intellij.util.ui.components.BorderLayoutPanel;
 import com.sourcegraph.Icons;
@@ -8,7 +9,7 @@ import java.awt.*;
 import javax.swing.*;
 
 public class HeaderPanel extends BorderLayoutPanel {
-  public HeaderPanel() {
+  public HeaderPanel(Project project) {
     super();
     setBorder(new JBEmptyBorder(5, 5, 2, 5));
 
@@ -17,7 +18,7 @@ public class HeaderPanel extends BorderLayoutPanel {
     title.add(new JLabel("Find with Sourcegraph", Icons.SourcegraphLogo, SwingConstants.LEFT));
 
     JPanel buttons = new JPanel(new FlowLayout(FlowLayout.RIGHT, 0, 0));
-    buttons.add(GoToPluginSettingsButtonFactory.createGoToPluginSettingsButton());
+    buttons.add(GoToPluginSettingsButtonFactory.createGoToPluginSettingsButton(project));
 
     add(title, BorderLayout.WEST);
     add(buttons, BorderLayout.EAST);


### PR DESCRIPTION


<!-- start git-machete generated -->

There was an issue with the action... 


# Based on PR #7368

## Chain of upstream PRs as of 2025-03-07

* PR #7368:
  `main` ← `mkondratek/chore/cleanup-icons`

  * **PR #7369 (THIS ONE)**:
    `mkondratek/chore/cleanup-icons` ← `mkondratek/fix/gear-action`

<!-- end git-machete generated -->

## Test plan
1. right click in the editor
2. Sourcegraph / Find with Sourcegraph...
3. click the gear icon 

Before:
nothing

After this PR:
setttings file opens

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->