### PR TITLE
fix(chat): New Chat Key Binding UI Changes

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -623,7 +623,7 @@
       {
         "command": "cody.chat.new",
         "key": "shift+alt+/",
-        "when": "cody.activated && !editorTextFocus"
+        "when": "cody.activated"
       },
       {
         "command": "cody.tutorial.chat",

--- a/vscode/webviews/tabs/TabsBar.tsx
+++ b/vscode/webviews/tabs/TabsBar.tsx
@@ -362,8 +362,8 @@ const TabButton = forwardRef<HTMLButtonElement, TabButtonProps>((props, ref) => 
                         'tw-flex tw-gap-2 tw-items-center !tw-font-normal !tw-text-inherit tw-leading-none tw-p-2 tw-opacity-80 hover:tw-opacity-100 tw-border-transparent tw-transition tw-translate-y-[1px] tw-text-sm',
                         {
                             '!tw-opacity-100 !tw-border-[var(--vscode-tab-activeBorderTop)] tw-border-b-[1px]':
-                                isActive,
-                            '!tw-opacity-100': prominent,
+                                isActive && Icon !== PlusIcon,
+                            '!tw-opacity-100': prominent || (isActive && Icon === PlusIcon),
                         }
                     )}
                     data-testid={dataTestId}

--- a/vscode/webviews/tabs/TabsBar.tsx
+++ b/vscode/webviews/tabs/TabsBar.tsx
@@ -408,6 +408,7 @@ function useTabs(
                         Icon: PlusIcon,
                         command: currentView === View.Chat ? newChatCommand : null,
                         changesView: true,
+                        tooltip: <>{'(⇧⌥/)'}</>,
                     },
                     {
                         view: View.History,


### PR DESCRIPTION
## Description
- Remove `!editorTextFocus` check From the New Chat Key Binding so that keybindings for chat can work when an editor is in focus
- Display the shortcut message for new chats
- Update the UI to not highlight the new chat button (the blue bar)

Thread: https://sourcegraph.slack.com/archives/C04MSD3DP5L/p1741384718035099

**Note: DNM this PR until we get a confirmation about this change in the slack thread**

## Test plan
local test + CI
- Start the debugger
- Can start a new chat with the key binding when the editor is not focused
- Make sure the key binding shortcut UI is there
- Make sure the new chat button highlight is removed

**BEFORE**
<img width="430" alt="Screenshot 2025-03-07 at 4 20 30 PM" src="https://github.com/user-attachments/assets/accb5ca4-da39-46fa-b940-f6aa44ed76cf" />


**AFTER**
<img width="439" alt="Screenshot 2025-03-07 at 4 15 44 PM" src="https://github.com/user-attachments/assets/765c6f64-feac-4c95-96c7-a8bda553f226" />
<img width="183" alt="Screenshot 2025-03-07 at 4 15 30 PM" src="https://github.com/user-attachments/assets/80f9564c-6d7e-474b-9588-c2ab147adf4b" />

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
