### PR TITLE
chore/telemetry: Stop logging discarded autoedit events

### DIFF
--- a/vscode/src/autoedits/analytics-logger/analytics-logger.test.ts
+++ b/vscode/src/autoedits/analytics-logger/analytics-logger.test.ts
@@ -302,7 +302,7 @@ describe('AutoeditAnalyticsLogger', () => {
         expect(suggestedEvent3.privateMetadata.id).not.toBe(suggestedEvent2.privateMetadata.id)
     })
 
-    it('logs `discarded` if the suggestion was not suggested for any reason', () => {
+    it.skip('logs `discarded` if the suggestion was not suggested for any reason', () => {
         const requestId = autoeditLogger.createRequest(getRequestStartMetadata())
         autoeditLogger.markAsContextLoaded({ requestId, payload: { contextSummary: undefined } })
         autoeditLogger.markAsDiscarded({

--- a/vscode/src/autoedits/analytics-logger/analytics-logger.ts
+++ b/vscode/src/autoedits/analytics-logger/analytics-logger.ts
@@ -446,16 +446,19 @@ export class AutoeditAnalyticsLogger {
         >
     }): void {
         autoeditsOutputChannelLogger.logDebug('writeAutoeditEvent', action, ...logDebugArgs)
-        telemetryRecorder.recordEvent('cody.autoedit', action, {
-            ...telemetryParams,
-            billingMetadata:
-                action === 'accepted' || action === 'suggested'
-                    ? {
-                          product: 'cody',
-                          category: action === 'accepted' ? 'core' : 'billable',
-                      }
-                    : undefined,
-        })
+        // do not log discared until the bug is fixed with it overfiring.
+        if (action !== 'discarded') {
+            telemetryRecorder.recordEvent('cody.autoedit', action, {
+                ...telemetryParams,
+                billingMetadata:
+                    action === 'accepted' || action === 'suggested'
+                        ? {
+                              product: 'cody',
+                              category: action === 'accepted' ? 'core' : 'billable',
+                          }
+                        : undefined,
+            })
+        }
     }
     /**
      * Rate-limited error logging, capturing exceptions with Sentry and grouping repeated logs.


### PR DESCRIPTION
Modify the analytics logger to avoid logging discarded autoedit events until the issue with them overfiring is fixed.

## Test plan
CI and locally tested