### PR TITLE
api: Fix version detection for non-main-branch images

### DIFF
--- a/lib/shared/src/sourcegraph-api/siteVersion.test.ts
+++ b/lib/shared/src/sourcegraph-api/siteVersion.test.ts
@@ -33,14 +33,12 @@ describe('inferCodyApiVersion', () => {
         // dotcom
         expect(inferCodyApiVersion('314951_2025-03-07_6.1-abeeb1a5e10d', true)).toBe(8)
 
-        // TODO: Erik believes these should return 8, but they don't do that anymore
-        // after https://github.com/sourcegraph/cody/pull/7365.
         expect(inferCodyApiVersion('6.1.0', false)).toBe(5)
-        expect(inferCodyApiVersion('6.2.0', false)).toBe(5)
+        expect(inferCodyApiVersion('6.2.0', false)).toBe(8)
         // branch deployment
-        expect(inferCodyApiVersion('6.1.x_313350_2025-02-25_6.1-63a41475e780', false)).toBe(8)
+        expect(inferCodyApiVersion('6.1.x_313350_2025-03-11_6.1-63a41475e780', false)).toBe(8)
         // main deployment
-        expect(inferCodyApiVersion('315302_2025-03-10_6.1-9994f058e2af', false)).toBe(8)
+        expect(inferCodyApiVersion('315302_2025-03-11_6.1-9994f058e2af', false)).toBe(8)
     })
 
     test('returns latestCodyClientConfig for local dev', () => {

--- a/lib/shared/src/sourcegraph-api/siteVersion.test.ts
+++ b/lib/shared/src/sourcegraph-api/siteVersion.test.ts
@@ -16,6 +16,10 @@ describe('inferCodyApiVersion', () => {
         expect(inferCodyApiVersion('5.5.0', false)).toBe(1)
         expect(inferCodyApiVersion('5.6.0', false)).toBe(1)
         expect(inferCodyApiVersion('5.7.0', false)).toBe(1)
+        // branch deployment (2024-09-11 is the cutoff date for 2->8)
+        expect(inferCodyApiVersion('5.11.x_313350_2024-09-10_5.11-63a41475e780', false)).toBe(1)
+        // main deployment (2024-09-11 is the cutoff date for 2->8)
+        expect(inferCodyApiVersion('315302_2024-09-10_5.11-9994f058e2af', false)).toBe(1)
     })
 
     test('returns DefaultMinimumAPIVersion for newer versions when latest not set', () => {
@@ -25,8 +29,18 @@ describe('inferCodyApiVersion', () => {
         expect(inferCodyApiVersion('5.10.1', false)).toBe(DefaultMinimumAPIVersion)
     })
 
-    test('returns latestCodyClientConfig for dotcom', () => {
+    test('Latest API version', () => {
+        // dotcom
         expect(inferCodyApiVersion('314951_2025-03-07_6.1-abeeb1a5e10d', true)).toBe(8)
+
+        // TODO: Erik believes these should return 8, but they don't do that anymore
+        // after https://github.com/sourcegraph/cody/pull/7365.
+        expect(inferCodyApiVersion('6.1.0', false)).toBe(5)
+        expect(inferCodyApiVersion('6.2.0', false)).toBe(5)
+        // branch deployment
+        expect(inferCodyApiVersion('6.1.x_313350_2025-02-25_6.1-63a41475e780', false)).toBe(8)
+        // main deployment
+        expect(inferCodyApiVersion('315302_2025-03-10_6.1-9994f058e2af', false)).toBe(8)
     })
 
     test('returns latestCodyClientConfig for local dev', () => {

--- a/lib/shared/src/sourcegraph-api/siteVersion.ts
+++ b/lib/shared/src/sourcegraph-api/siteVersion.ts
@@ -192,7 +192,6 @@ export function inferCodyApiVersion(version: string, isDotCom: boolean): CodyApi
         return 1
     }
 
-    console.log(version, parsedVersion, 'inferCodyApiVersion')
 
     // Use minimum version for all other cases instead of 0
     return DefaultMinimumAPIVersion

--- a/lib/shared/src/sourcegraph-api/siteVersion.ts
+++ b/lib/shared/src/sourcegraph-api/siteVersion.ts
@@ -173,6 +173,9 @@ export function inferCodyApiVersion(version: string, isDotCom: boolean): CodyApi
 
     // 5.4.0+ supports api-version=1
     // 5.8.0+ supports api-version=2
+    if (parsedVersion && semver.gte(parsedVersion, '6.2.0')) {
+        return 8
+    }
     if (parsedVersion && semver.ltr(parsedVersion, '5.8.0')) {
         return 1
     }
@@ -186,12 +189,14 @@ export function inferCodyApiVersion(version: string, isDotCom: boolean): CodyApi
     // deployments that release less frequently.
     if (parsedVersion === null) {
         const date = parseDateFromPreReleaseVersion(version)
-        if (date && date >= new Date('2024-09-11')) {
+        if (date && date >= new Date('2025-03-11')) {
             return 8
+        }
+        if (date && date >= new Date('2024-09-11')) {
+            return 5
         }
         return 1
     }
-
 
     // Use minimum version for all other cases instead of 0
     return DefaultMinimumAPIVersion


### PR DESCRIPTION
I noticed that some instances were still using api-version 1, and went to dig in why that is. Turns out some edge-case in our versioning scheme wasn't honored (branch name prefix), so I fixed that.

Test plan: Added tests that fail before the code change.
