### PR TITLE
feat(smart-apply): Prefetch the site version and enable for jetbrains

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -58,6 +58,8 @@ export enum FeatureFlag {
 
     CodySmartApplyExperimentEnabledFeatureFlag = 'cody-smart-apply-experiment-enabled-flag',
     CodySmartApplyExperimentVariant1 = 'cody-smart-apply-experiment-variant-1',
+    CodySmartApplyExperimentVariant2 = 'cody-smart-apply-experiment-variant-2',
+    CodySmartApplyExperimentVariant3 = 'cody-smart-apply-experiment-variant-3',
     CodySmartApplyPrefetching = 'cody-smart-apply-prefetching',
 
     CodyAutoEditExperimentEnabledFeatureFlag = 'cody-autoedit-experiment-enabled-flag',

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -444,3 +444,5 @@ export {
     type RuleService,
     isRulesEnabled,
 } from './rules/service'
+
+export type { SiteAndCodyAPIVersions } from './sourcegraph-api/siteVersion'

--- a/lib/shared/src/sourcegraph-api/siteVersion.ts
+++ b/lib/shared/src/sourcegraph-api/siteVersion.ts
@@ -20,7 +20,7 @@ type V2TelemetryCodyApiVersion = 5
 // Any number greater than 4 is considered a valid Cody API version
 type CodyApiVersion = LegacyCodyApiVersion | number
 
-interface SiteAndCodyAPIVersions {
+export interface SiteAndCodyAPIVersions {
     siteVersion: string
     codyAPIVersion: CodyApiVersion
 }

--- a/vscode/src/edit/prompt/constants.ts
+++ b/vscode/src/edit/prompt/constants.ts
@@ -19,6 +19,10 @@ export const SMART_APPLY_CUSTOM_PROMPT_TOPICS = {
     CODE_TO_UPDATE_LOCATION_MARKER_IN_FULL_FILE_CODE: ps`<<< CODE_TO_UPDATE_LOCATION_IN_THE_FULL_FILE_CODE >>>`,
 }
 
+// Check the sourcegraph backend to check the exact model behind the feature flag.
+// Link to the model: https://github.com/sourcegraph/sourcegraph/blob/main/cmd/cody-gateway/internal/httpapi/completions/fireworks.go#L358
 export const SMART_APPLY_MODEL_IDENTIFIERS = {
     FireworksQwenCodeDefault: 'fireworks::v1::smart-apply-qwen-default',
+    FireworksQwenCodeVariant2: 'fireworks::v1::smart-apply-qwen-variant-2',
+    FireworksQwenCodeVariant3: 'fireworks::v1::smart-apply-qwen-variant-3',
 }

--- a/vscode/src/edit/prompt/smart-apply/selection.ts
+++ b/vscode/src/edit/prompt/smart-apply/selection.ts
@@ -79,7 +79,7 @@ interface SmartApplySelection {
 
 function getSmartApplySelectionProvider(model: EditModel): SmartApplySelectionProvider {
     if (Object.values(SMART_APPLY_MODEL_IDENTIFIERS).includes(model)) {
-        return new CustomModelSelectionProvider()
+        return new CustomModelSelectionProvider({ shouldAlwaysUseEntireFile: true })
     }
     return new DefaultSelectionProvider()
 }

--- a/vscode/src/edit/prompt/smart-apply/selection/custom-model.ts
+++ b/vscode/src/edit/prompt/smart-apply/selection/custom-model.ts
@@ -44,6 +44,12 @@ const DEFAULT_SELECTION_PROMPT = {
 }
 
 export class CustomModelSelectionProvider implements SmartApplySelectionProvider {
+    private readonly shouldAlwaysUseEntireFile: boolean
+
+    constructor(config: { shouldAlwaysUseEntireFile: boolean }) {
+        this.shouldAlwaysUseEntireFile = config.shouldAlwaysUseEntireFile
+    }
+
     public async getSelectedText({
         instruction,
         replacement,
@@ -52,6 +58,10 @@ export class CustomModelSelectionProvider implements SmartApplySelectionProvider
         chatClient,
         contextWindow,
     }: SelectionPromptProviderArgs): Promise<string> {
+        if (this.shouldAlwaysUseEntireFile) {
+            return 'ENTIRE_FILE'
+        }
+
         const documentRange = new vscode.Range(0, 0, document.lineCount - 1, 0)
         const documentText = PromptString.fromDocumentText(document, documentRange)
         const tokenCount = await TokenCounterUtils.countPromptString(documentText)

--- a/vscode/src/edit/smart-apply-manager.ts
+++ b/vscode/src/edit/smart-apply-manager.ts
@@ -130,6 +130,7 @@ export class SmartApplyManager implements vscode.Disposable {
         const taskAndSelection = await this.getSmartApplyTask({
             configuration,
             model,
+            smartApplyStartTime: performance.now(),
             shouldUpdateCache: true,
         })
 
@@ -145,10 +146,12 @@ export class SmartApplyManager implements vscode.Disposable {
     private async getSmartApplyTask({
         configuration,
         model,
+        smartApplyStartTime,
         shouldUpdateCache,
     }: {
         configuration: SmartApplyArguments['configuration']
         model: string
+        smartApplyStartTime: number
         shouldUpdateCache: boolean
     }): SmartApplyCacheEntry {
         let inFlight = this.cache.get(configuration.id)
@@ -158,7 +161,7 @@ export class SmartApplyManager implements vscode.Disposable {
             // reusing it more than once.
             this.cache.delete(configuration.id)
         } else {
-            inFlight = this.fetchSmartApplyTask(configuration, model)
+            inFlight = this.fetchSmartApplyTask(configuration, model, smartApplyStartTime)
 
             if (shouldUpdateCache) {
                 this.cache.set(configuration.id, inFlight)
@@ -175,14 +178,14 @@ export class SmartApplyManager implements vscode.Disposable {
 
     private async fetchSmartApplyTask(
         configuration: SmartApplyArguments['configuration'],
-        model: string
+        model: string,
+        smartApplyStartTime: number
     ): SmartApplyCacheEntry {
         const { id, instruction, document, replacement } = configuration
         const versions = this.siteVersion ?? (await currentSiteVersion())
         if (isError(versions)) {
             throw new Error('Unable to determine site version', versions)
         }
-
         const replacementCode = PromptString.unsafe_fromLLMResponse(replacement)
 
         const selectionStartTime = performance.now()
@@ -236,6 +239,8 @@ ${replacementCode}`,
 
         this.smartApplyContextLogger.recordSmartApplyBaseContext({
             taskId: task.id,
+            startedAt: smartApplyStartTime,
+            isPrefetched: this.isPrefetchingEnabled,
             model,
             userQuery: configuration.instruction.toString(),
             replacementCodeBlock: replacementCode.toString(),
@@ -257,6 +262,8 @@ ${replacementCode}`,
 
         return context.with(extractContextFromTraceparent(traceparent), async () => {
             await wrapInActiveSpan('edit.smart-apply', async span => {
+                const smartApplyStartTime = performance.now()
+
                 span.setAttribute('sampled', true)
                 span.setAttribute('continued', true)
 
@@ -292,6 +299,7 @@ ${replacementCode}`,
                 const taskAndSelection = await this.getSmartApplyTask({
                     configuration,
                     model,
+                    smartApplyStartTime,
                     shouldUpdateCache: false,
                 })
                 editor.setDecorations(SMART_APPLY_FILE_DECORATION, [])


### PR DESCRIPTION
## Context
- Each call to `currentSiteVersion` takes about ~500ms. This was happening for both the selection and apply phase and for other edit providers. The PR adds async observing the smart apply values and using that for both selection and apply. This saves ~1 sec total.

## Test plan
- Add a debugger breakpoint at the site version call, and check we are fetching this async.