### PR TITLE
Commit message gen: prioritize 'flash' model over 'flash-lite'

### DIFF
--- a/vscode/src/commands/scm/source-control.ts
+++ b/vscode/src/commands/scm/source-control.ts
@@ -40,7 +40,7 @@ export class CodySourceControl implements vscode.Disposable {
                     .getModels(ModelUsage.Edit)
                     .pipe(skipPendingOperation())
                     .subscribe(models => {
-                        // Removes experimental and preview models
+                        // Remove experimental and preview models
                         const filtered = models.filter(
                             m =>
                                 !m.tags.includes(ModelTag.Experimental) &&
@@ -48,7 +48,7 @@ export class CodySourceControl implements vscode.Disposable {
                         )
                         const flashLite = filtered.find(m => m.id.endsWith('gemini-2.0-flash-lite'))
                         const flash = filtered.find(m => m.id.endsWith('gemini-2.0-flash'))
-                        this.model = flashLite ?? flash ?? filtered.at(0)
+                        this.model = flash ?? flashLite ?? filtered.at(0)
                     })
             )
         )

--- a/vscode/src/commands/scm/source-control.ts
+++ b/vscode/src/commands/scm/source-control.ts
@@ -173,10 +173,11 @@ export class CodySourceControl implements vscode.Disposable {
             }
 
             const { id: model, contextWindow } = this.model
+            const context = await getContextFilesFromGitApi(repository, commitTemplate).catch(() => [])
             const { prompt, ignoredContext } = await this.buildPrompt(
                 contextWindow,
                 getSimplePreamble(model, 1, 'Default', COMMIT_COMMAND_PROMPTS.intro),
-                await getContextFilesFromGitApi(repository, commitTemplate).catch(() => [])
+                context
             ).catch(error => {
                 sourceControlInputbox.value = `${error}`
                 throw new Error()

--- a/vscode/src/commands/scm/source-control.ts
+++ b/vscode/src/commands/scm/source-control.ts
@@ -19,7 +19,7 @@ import {
 import * as vscode from 'vscode'
 import { PromptBuilder } from '../../prompt-builder'
 import type { API, GitExtension, InputBox, Repository } from '../../repository/builtinGitExtension'
-import { getContextFilesFromGitApi as getContext } from '../context/git-api'
+import { getContextFilesFromGitApi } from '../context/git-api'
 import { COMMIT_COMMAND_PROMPTS } from './prompts'
 
 export class CodySourceControl implements vscode.Disposable {
@@ -176,7 +176,7 @@ export class CodySourceControl implements vscode.Disposable {
             const { prompt, ignoredContext } = await this.buildPrompt(
                 contextWindow,
                 getSimplePreamble(model, 1, 'Default', COMMIT_COMMAND_PROMPTS.intro),
-                await getContext(repository, commitTemplate).catch(() => [])
+                await getContextFilesFromGitApi(repository, commitTemplate).catch(() => [])
             ).catch(error => {
                 sourceControlInputbox.value = `${error}`
                 throw new Error()


### PR DESCRIPTION
Closes CODY-5281. This PR depends on https://github.com/sourcegraph/cody/pull/7385.

This commit changes the order in which the `flash` and `flash-lite` models are assigned to `this.model` in `CodySourceControl`.

The `flash` model is now prioritized over the `flash-lite` model. This ensures that the more capable `flash` model is used when available, improving the quality of the generated commit message.

## Test plan

Manually test by comparing the performance and quality for both.