### PR TITLE
fix(autoedit): Fix conflict between suggestions and completion menu

### DIFF
--- a/vscode/src/autoedits/autoedits-provider.test.ts
+++ b/vscode/src/autoedits/autoedits-provider.test.ts
@@ -25,6 +25,7 @@ import {
 import { ContextMixer } from '../completions/context/context-mixer'
 
 import { mockLocalStorage } from '../services/LocalStorageProvider'
+import { autoeditTriggerKind } from './analytics-logger'
 import {
     AUTOEDIT_CONTEXT_FETCHING_DEBOUNCE_INTERVAL,
     AUTOEDIT_TOTAL_DEBOUNCE_INTERVAL,
@@ -470,6 +471,18 @@ describe('AutoeditsProvider', () => {
 
         await acceptSuggestionCommand()
         expect(editBuilder.size).toBe(1)
+    })
+
+    it('does not trigger a suggestion if the user has selectedCompletionInfo', async () => {
+        const prediction = 'const x = 1\n'
+        const { result } = await autoeditResultFor('const x = █\n', {
+            prediction,
+            inlineCompletionContext: {
+                triggerKind: autoeditTriggerKind.automatic,
+                selectedCompletionInfo: { range: new vscode.Range(0, 0, 0, 5), text: 'beans' },
+            },
+        })
+        expect(result).toBeNull()
     })
 
     describe('Debounce logic', () => {

--- a/vscode/src/autoedits/autoedits-provider.test.ts
+++ b/vscode/src/autoedits/autoedits-provider.test.ts
@@ -475,14 +475,17 @@ describe('AutoeditsProvider', () => {
 
     it('does not trigger a suggestion if the user has selectedCompletionInfo', async () => {
         const prediction = 'const x = 1\n'
+        const completionItem = { range: new vscode.Range(0, 0, 0, 5), text: 'beans' }
         const { result } = await autoeditResultFor('const x = █\n', {
             prediction,
             inlineCompletionContext: {
                 triggerKind: autoeditTriggerKind.automatic,
-                selectedCompletionInfo: { range: new vscode.Range(0, 0, 0, 5), text: 'beans' },
+                selectedCompletionInfo: completionItem,
             },
         })
-        expect(result).toBeNull()
+        expect(result?.items).toStrictEqual([
+            { insertText: completionItem.text, range: completionItem.range },
+        ])
     })
 
     describe('Debounce logic', () => {

--- a/vscode/src/autoedits/autoedits-provider.ts
+++ b/vscode/src/autoedits/autoedits-provider.ts
@@ -154,6 +154,15 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
     ): Promise<AutoeditsResult | null> {
         let stopLoading: (() => void) | undefined
 
+        if (inlineCompletionContext.selectedCompletionInfo !== undefined) {
+            // User has a currently selected item in the autocomplete widget.
+            // Right now we avoid suggesting auto-edits when this is the case, otherwise
+            // we may override the users' selection and make an undesirable change.
+            // TODO: We should consider the optimal solution here, it may be better to show an
+            // inline completion (not an edit) that includes the currently selected item.
+            return null
+        }
+
         try {
             const startedAt = getTimeNowInMillis()
             const controller = new AbortController()

--- a/vscode/src/autoedits/autoedits-provider.ts
+++ b/vscode/src/autoedits/autoedits-provider.ts
@@ -48,10 +48,10 @@ const RESET_SUGGESTION_ON_CURSOR_CHANGE_AFTER_INTERVAL_MS = 60 * 1000
 const ON_SELECTION_CHANGE_DEFAULT_DEBOUNCE_INTERVAL_MS = 15
 
 export interface AutoeditsResult extends vscode.InlineCompletionList {
-    requestId: AutoeditRequestID
+    requestId: AutoeditRequestID | null
     prediction: string
     /** temporary data structure, will need to update before integrating with the agent API */
-    decorationInfo: DecorationInfo
+    decorationInfo: DecorationInfo | null
 }
 
 /**
@@ -155,12 +155,19 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
         let stopLoading: (() => void) | undefined
 
         if (inlineCompletionContext.selectedCompletionInfo !== undefined) {
+            const { range, text } = inlineCompletionContext.selectedCompletionInfo
             // User has a currently selected item in the autocomplete widget.
-            // Right now we avoid suggesting auto-edits when this is the case, otherwise
-            // we may override the users' selection and make an undesirable change.
+            // Instead of attempting to suggest an auto-edit, just show the selected item
+            // as the completion. This is to avoid an undesirable edit conflicting with the acceptance
+            // of the item shown in the widget.
             // TODO: We should consider the optimal solution here, it may be better to show an
             // inline completion (not an edit) that includes the currently selected item.
-            return null
+            return {
+                requestId: null,
+                items: [{ insertText: text, range }],
+                prediction: text,
+                decorationInfo: null,
+            }
         }
 
         try {


### PR DESCRIPTION


https://github.com/user-attachments/assets/5d105794-516b-44dd-b81f-b0c991c835a1



## Description

Fixes an issue where we attempt to suggest an auto-edit that could conflict with the completion menu in a bad way. E.g. it may delete or add code that doesn't reflect the selected item in the menu. If the user was to accept this item with Tab, the edit would be accepted including the unwanted code.

## Test plan

- Unit tests
- Manual testing with completion items