### PR TITLE
Edit: Omit prefixes for reasoning models

### DIFF
--- a/lib/shared/src/models/model.ts
+++ b/lib/shared/src/models/model.ts
@@ -148,10 +148,6 @@ export function createModelFromServerModel({
         output: maxOutputTokens,
     }
     const usage = capabilities.flatMap(capabilityToUsage)
-    // NOTE: Model with reasoning enabled should only be used for chat.
-    if (capabilities.includes('reasoning') && usage.includes(ModelUsage.Edit)) {
-        usage.splice(usage.indexOf(ModelUsage.Edit), 1)
-    }
     // Use Extended Context Window
     if (maxInputTokens === EXTENDED_CHAT_INPUT_TOKEN_BUDGET + EXTENDED_USER_CONTEXT_TOKEN_BUDGET) {
         _contextWindow.input = EXTENDED_CHAT_INPUT_TOKEN_BUDGET

--- a/vscode/src/edit/prompt/index.ts
+++ b/vscode/src/edit/prompt/index.ts
@@ -5,6 +5,7 @@ import {
     type ChatMessage,
     type EditModel,
     type EditProvider,
+    ModelTag,
     PromptString,
     TokenCounterUtils,
     currentResolvedConfig,
@@ -37,18 +38,23 @@ const getInteractionArgsFromIntent = (
     const { provider } = getModelInfo(model)
     // Default to the generic Claude prompt if the provider is unknown
     const interaction = INTERACTION_PROVIDERS[provider] || claude
+
+    // Check if the model has the reasoning tag
+    const modelInfo = modelsService.getModelByID(model)
+    const isReasoningModel = modelInfo?.tags.includes(ModelTag.Reasoning)
+
     switch (intent) {
         case 'add':
-            return interaction.getAdd(options)
+            return interaction.getAdd({ ...options, isReasoningModel })
         case 'fix':
-            return interaction.getFix(options)
+            return interaction.getFix({ ...options, isReasoningModel })
         case 'doc':
-            return interaction.getDoc(options)
+            return interaction.getDoc({ ...options, isReasoningModel })
         case 'edit':
         case 'smartApply':
-            return interaction.getEdit(options)
+            return interaction.getEdit({ ...options, isReasoningModel })
         case 'test':
-            return interaction.getTest(options)
+            return interaction.getTest({ ...options, isReasoningModel })
     }
 }
 

--- a/vscode/src/edit/prompt/index.ts
+++ b/vscode/src/edit/prompt/index.ts
@@ -37,7 +37,7 @@ const getInteractionArgsFromIntent = (
     const modelInfo = modelsService.getModelByID(model)
     const isReasoningModel = modelInfo?.tags.includes(ModelTag.Reasoning)
     // Default to the generic Claude prompt if the provider is unknown
-    const interaction = modelInfo?.provider ? INTERACTION_PROVIDERS[modelInfo.provider] : claude
+    const interaction = INTERACTION_PROVIDERS[modelInfo?.provider || ''] || claude
 
     switch (intent) {
         case 'add':

--- a/vscode/src/edit/prompt/index.ts
+++ b/vscode/src/edit/prompt/index.ts
@@ -9,7 +9,6 @@ import {
     PromptString,
     TokenCounterUtils,
     currentResolvedConfig,
-    getModelInfo,
     getSimplePreamble,
     modelsService,
     ps,
@@ -35,13 +34,10 @@ const getInteractionArgsFromIntent = (
     model: EditModel,
     options: GetLLMInteractionOptions
 ): LLMInteraction => {
-    const { provider } = getModelInfo(model)
-    // Default to the generic Claude prompt if the provider is unknown
-    const interaction = INTERACTION_PROVIDERS[provider] || claude
-
-    // Check if the model has the reasoning tag
     const modelInfo = modelsService.getModelByID(model)
     const isReasoningModel = modelInfo?.tags.includes(ModelTag.Reasoning)
+    // Default to the generic Claude prompt if the provider is unknown
+    const interaction = modelInfo?.provider ? INTERACTION_PROVIDERS[modelInfo.provider] : claude
 
     switch (intent) {
         case 'add':

--- a/vscode/src/edit/prompt/index.ts
+++ b/vscode/src/edit/prompt/index.ts
@@ -23,10 +23,10 @@ import { openai } from './models/openai'
 import type { EditLLMInteraction, GetLLMInteractionOptions, LLMInteraction } from './type'
 
 const INTERACTION_PROVIDERS: Record<EditProvider, EditLLMInteraction> = {
-    Anthropic: claude,
-    OpenAI: openai,
+    anthropic: claude,
+    openai: openai,
     // NOTE: Sharing the same model for GPT models for now.
-    Google: openai,
+    google: openai,
 } as const
 
 const getInteractionArgsFromIntent = (
@@ -36,6 +36,7 @@ const getInteractionArgsFromIntent = (
 ): LLMInteraction => {
     const modelInfo = modelsService.getModelByID(model)
     const isReasoningModel = modelInfo?.tags.includes(ModelTag.Reasoning)
+    console.log(modelInfo)
     // Default to the generic Claude prompt if the provider is unknown
     const interaction = INTERACTION_PROVIDERS[modelInfo?.provider || ''] || claude
 

--- a/vscode/src/edit/prompt/models/generic.ts
+++ b/vscode/src/edit/prompt/models/generic.ts
@@ -171,3 +171,18 @@ export const buildGenericPrompt = (
             }
     }
 }
+
+interface GenericPrefix {
+    assistantText: PromptString
+    assistantPrefix: PromptString
+}
+
+export const getGenericPrefixes = (
+    proposedPrefix: GenericPrefix,
+    isReasoningModel?: boolean
+): GenericPrefix | undefined => {
+    if (isReasoningModel) {
+        return undefined
+    }
+    return proposedPrefix
+}

--- a/vscode/src/edit/prompt/models/openai.ts
+++ b/vscode/src/edit/prompt/models/openai.ts
@@ -1,32 +1,38 @@
 import { ps } from '@sourcegraph/cody-shared'
 import { PROMPT_TOPICS } from '../constants'
 import type { EditLLMInteraction } from '../type'
-import { buildGenericPrompt } from './generic'
+import { buildGenericPrompt, getGenericPrefixes } from './generic'
 
 const RESPONSE_PREFIX = ps`<${PROMPT_TOPICS.OUTPUT}>\n`
 const SHARED_PARAMETERS = {
     responseTopic: PROMPT_TOPICS.OUTPUT,
     stopSequences: [`</${PROMPT_TOPICS.OUTPUT}>`],
+}
+
+const MODEL_PREFIX = {
     assistantText: RESPONSE_PREFIX,
     assistantPrefix: RESPONSE_PREFIX,
-}
+} as const
 
 export const openai: EditLLMInteraction = {
     getEdit(options) {
         return {
             ...SHARED_PARAMETERS,
+            ...getGenericPrefixes(MODEL_PREFIX, options.isReasoningModel),
             prompt: buildGenericPrompt('edit', options),
         }
     },
     getDoc(options) {
         return {
             ...SHARED_PARAMETERS,
+            ...getGenericPrefixes(MODEL_PREFIX, options.isReasoningModel),
             prompt: buildGenericPrompt('doc', options),
         }
     },
     getFix(options) {
         return {
             ...SHARED_PARAMETERS,
+            ...getGenericPrefixes(MODEL_PREFIX, options.isReasoningModel),
             prompt: buildGenericPrompt('fix', options),
         }
     },
@@ -37,13 +43,17 @@ export const openai: EditLLMInteraction = {
         }
         return {
             ...SHARED_PARAMETERS,
-            assistantText: ps`${assistantPreamble}${RESPONSE_PREFIX}`,
+            ...getGenericPrefixes(
+                { ...MODEL_PREFIX, assistantText: ps`${assistantPreamble}${RESPONSE_PREFIX}` },
+                options.isReasoningModel
+            ),
             prompt: buildGenericPrompt('add', options),
         }
     },
     getTest(options) {
         return {
             ...SHARED_PARAMETERS,
+            ...getGenericPrefixes(MODEL_PREFIX, options.isReasoningModel),
             prompt: buildGenericPrompt('test', options),
         }
     },

--- a/vscode/src/edit/prompt/type.ts
+++ b/vscode/src/edit/prompt/type.ts
@@ -48,6 +48,7 @@ export interface GetLLMInteractionOptions {
     uri: vscode.Uri
     document: vscode.TextDocument
     rules?: Rule[] | null
+    isReasoningModel?: boolean
 }
 
 type LLMInteractionBuilder = (options: GetLLMInteractionOptions) => LLMInteraction


### PR DESCRIPTION
## Description

Using 3.7 Sonnet as a reasoning model breaks for inline edit because we prefix the response with text that isn't <thinking>

We should support reasoning models for inline edit, even if they are not recommended right now due to additional latency.

## Test plan

1. Make an inline edit with 3.7 Sonnet, check it works as expected