### PR TITLE
Fix Remote Directories Provider Valid Site Version Logic

### DIFF
--- a/vscode/src/context/openctx.ts
+++ b/vscode/src/context/openctx.ts
@@ -13,7 +13,6 @@ import {
     clientCapabilities,
     combineLatest,
     createDisposables,
-    debounceTime,
     distinctUntilChanged,
     featureFlagProvider,
     graphqlClient,
@@ -62,27 +61,11 @@ export function observeOpenCtxController(
             })),
             distinctUntilChanged()
         ),
-        authStatus.pipe(
-            distinctUntilChanged(),
-            debounceTime(0),
-            switchMap(auth =>
-                auth.authenticated
-                    ? promiseFactoryToObservable(signal =>
-                          graphqlClient.isValidSiteVersion(
-                              {
-                                  minimumVersion: '5.7.0',
-                              },
-                              signal
-                          )
-                      )
-                    : Observable.of(false)
-            )
-        ),
         promiseFactoryToObservable(
             async () => createOpenCtxController ?? (await import('@openctx/vscode-lib')).createController
         )
     ).pipe(
-        map(([{ experimentalNoodle }, isValidSiteVersion, createController]) => {
+        map(([{ experimentalNoodle }, createController]) => {
             try {
                 // Enable fetching of openctx configuration from Sourcegraph instance
                 const mergeConfiguration = experimentalNoodle
@@ -107,8 +90,7 @@ export function observeOpenCtxController(
                               ClientConfigSingleton.getInstance().changes.pipe(
                                   skipPendingOperation(),
                                   distinctUntilChanged()
-                              ),
-                              isValidSiteVersion
+                              )
                           ),
                     mergeConfiguration,
                 })
@@ -126,21 +108,36 @@ export function observeOpenCtxController(
 let openctxOutputChannel: vscode.OutputChannel | undefined
 
 export function getOpenCtxProviders(
-    authStatusChanges: Observable<Pick<AuthStatus, 'endpoint'>>,
-    clientConfigChanges: Observable<CodyClientConfig | undefined>,
-    isValidSiteVersion: boolean
+    authStatusChanges: Observable<Pick<AuthStatus, 'endpoint' | 'authenticated'>>,
+    clientConfigChanges: Observable<CodyClientConfig | undefined>
 ): Observable<ImportedProviderConfiguration[]> {
     return combineLatest(
         resolvedConfig.pipe(pluck('configuration'), distinctUntilChanged()),
         clientConfigChanges,
         authStatusChanges,
-        featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.GitMentionProvider)
+        featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.GitMentionProvider),
+        authStatusChanges.pipe(
+            map(auth => auth.authenticated),
+            switchMap(authenticated =>
+                authenticated
+                    ? promiseFactoryToObservable(signal =>
+                          graphqlClient.isValidSiteVersion(
+                              {
+                                  minimumVersion: '5.7.0',
+                              },
+                              signal
+                          )
+                      )
+                    : Observable.of(false)
+            )
+        )
     ).map(
-        ([config, clientConfig, authStatus, gitMentionProvider]: [
+        ([config, clientConfig, authStatus, gitMentionProvider, isValidSiteVersion]: [
             ClientConfiguration,
             CodyClientConfig | undefined,
             Pick<AuthStatus, 'endpoint'>,
             boolean | undefined,
+            boolean,
         ]) => {
             const providers: ImportedProviderConfiguration[] = [
                 {


### PR DESCRIPTION
Issue: The Remote Directories provider is hidden on the latest versions of Cody. https://sourcegraph.slack.com/archives/C04MSD3DP5L/p1740424611276459

The issue was that the `isValidSiteVersion` was always false. Most probably due to the stale closure issue. 

I have reworked the logic and updated the tests and it appears now. 

## Test plan

- Open Cody
- Do @
- Remote Directories provider should be visible for non-Dotcom users. 