### PR TITLE
feat(auto-edit): cancel redundant requests

### DIFF
--- a/vscode/src/autoedits/adapters/base.ts
+++ b/vscode/src/autoedits/adapters/base.ts
@@ -1,12 +1,10 @@
 import type { CodeCompletionsParams, PromptString } from '@sourcegraph/cody-shared'
 import type { AutoeditsRequestBody } from './utils'
 
-export interface ModelResponse {
-    prediction: string
+export type ModelResponseShared = {
+    type: 'success' | 'aborted'
     /** URL used to make the request to the model API */
     requestUrl: string
-    /** Response headers received from the model API */
-    responseHeaders: Record<string, string>
     /** Optional request headers sent to the model API */
     requestHeaders?: Record<string, string>
     /**
@@ -14,12 +12,28 @@ export interface ModelResponse {
      * TODO: update to proper types from different adapters.
      */
     requestBody?: AutoeditsRequestBody | CodeCompletionsParams
+}
+
+export interface SuccessModelResponse extends ModelResponseShared {
+    type: 'success'
+    prediction: string
+    /**
+     * Response headers received from the model API
+     */
+    responseHeaders: Record<string, string>
     /**
      * Optional full response body received from the model API
      * This is propagated to the analytics logger for debugging purposes
+     * TODO: replace `any` with the proper type.
      */
-    responseBody?: any
+    responseBody: Record<string, any>
 }
+
+export interface AbortedModelResponse extends ModelResponseShared {
+    type: 'aborted'
+}
+
+export type ModelResponse = SuccessModelResponse | AbortedModelResponse
 
 export interface AutoeditsModelAdapter {
     getModelResponse(args: AutoeditModelOptions): Promise<ModelResponse>
@@ -48,4 +62,5 @@ export interface AutoeditModelOptions {
     codeToRewrite: string
     userId: string | null
     isChatModel: boolean
+    abortSignal: AbortSignal
 }

--- a/vscode/src/autoedits/adapters/cody-gateway.test.ts
+++ b/vscode/src/autoedits/adapters/cody-gateway.test.ts
@@ -24,6 +24,7 @@ describe('CodyGatewayAdapter', () => {
         codeToRewrite: 'const x = 1',
         userId: 'test-user',
         isChatModel: true,
+        abortSignal: new AbortController().signal,
     }
 
     const mockFetch = vi.fn()
@@ -65,6 +66,7 @@ describe('CodyGatewayAdapter', () => {
                 'X-Sourcegraph-Feature': 'code_completions',
             },
             body: expect.stringContaining('"model":"anthropic/claude-2"'),
+            signal: expect.any(AbortSignal),
         })
 
         // Verify request body structure

--- a/vscode/src/autoedits/adapters/fireworks.test.ts
+++ b/vscode/src/autoedits/adapters/fireworks.test.ts
@@ -4,7 +4,7 @@ import { ps } from '@sourcegraph/cody-shared'
 
 import * as autoeditsConfig from '../autoedits-config'
 
-import type { AutoeditModelOptions } from './base'
+import type { AutoeditModelOptions, SuccessModelResponse } from './base'
 import { FireworksAdapter } from './fireworks'
 
 describe('FireworksAdapter', () => {
@@ -20,6 +20,7 @@ describe('FireworksAdapter', () => {
         codeToRewrite: 'const x = 1',
         userId: 'test-user',
         isChatModel: true,
+        abortSignal: new AbortController().signal,
     }
 
     const apiKey = 'test-api-key'
@@ -58,6 +59,7 @@ describe('FireworksAdapter', () => {
                 Authorization: `Bearer ${apiKey}`,
             },
             body: expect.stringContaining('"model":"accounts/fireworks/models/llama-v2-7b"'),
+            signal: expect.any(AbortSignal),
         })
 
         const requestBody = JSON.parse(mockFetch.mock.calls[0][1].body)
@@ -126,7 +128,7 @@ describe('FireworksAdapter', () => {
         })
 
         const response = await adapter.getModelResponse(options)
-        expect(response.prediction).toBe(expectedResponse)
+        expect((response as SuccessModelResponse).prediction).toBe(expectedResponse)
     })
 
     it('returns correct response for completions model', async () => {
@@ -140,6 +142,6 @@ describe('FireworksAdapter', () => {
         })
 
         const response = await adapter.getModelResponse(nonChatOptions)
-        expect(response.prediction).toBe(expectedResponse)
+        expect((response as SuccessModelResponse).prediction).toBe(expectedResponse)
     })
 })

--- a/vscode/src/autoedits/adapters/sourcegraph-chat.test.ts
+++ b/vscode/src/autoedits/adapters/sourcegraph-chat.test.ts
@@ -1,7 +1,7 @@
 import { ps } from '@sourcegraph/cody-shared'
 import type { ChatClient } from '@sourcegraph/cody-shared'
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { AutoeditModelOptions } from './base'
+import type { AutoeditModelOptions, SuccessModelResponse } from './base'
 import { SourcegraphChatAdapter } from './sourcegraph-chat'
 import { getMaxOutputTokensForAutoedits } from './utils'
 
@@ -19,6 +19,7 @@ describe('SourcegraphChatAdapter', () => {
         codeToRewrite: 'const x = 1',
         userId: 'test-user',
         isChatModel: true,
+        abortSignal: new AbortController().signal,
     }
 
     beforeEach(() => {
@@ -84,7 +85,7 @@ describe('SourcegraphChatAdapter', () => {
         mockChatClient.chat = mockChat
 
         const response = await adapter.getModelResponse(options)
-        expect(response.prediction).toBe('part1part2')
+        expect((response as SuccessModelResponse).prediction).toBe('part1part2')
     })
 
     it('handles errors correctly', async () => {

--- a/vscode/src/autoedits/adapters/sourcegraph-chat.ts
+++ b/vscode/src/autoedits/adapters/sourcegraph-chat.ts
@@ -24,7 +24,7 @@ export class SourcegraphChatAdapter implements AutoeditsModelAdapter {
                         content: option.codeToRewrite,
                     },
                 },
-                new AbortController().signal
+                option.abortSignal
             )
 
             let accumulated = ''
@@ -39,9 +39,12 @@ export class SourcegraphChatAdapter implements AutoeditsModelAdapter {
 
             // For direct API calls without HTTP headers, we return an empty object
             return {
+                type: 'success',
                 prediction: accumulated,
                 responseHeaders: {},
+                responseBody: {},
                 requestUrl: option.url,
+                requestHeaders: {},
             }
         } catch (error) {
             autoeditsOutputChannelLogger.logError(

--- a/vscode/src/autoedits/adapters/sourcegraph-completions.test.ts
+++ b/vscode/src/autoedits/adapters/sourcegraph-completions.test.ts
@@ -1,7 +1,7 @@
 import type { CodeCompletionsClient } from '@sourcegraph/cody-shared'
 import { ps } from '@sourcegraph/cody-shared'
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { AutoeditModelOptions } from './base'
+import type { AutoeditModelOptions, SuccessModelResponse } from './base'
 import { SourcegraphCompletionsAdapter } from './sourcegraph-completions'
 import { getMaxOutputTokensForAutoedits } from './utils'
 
@@ -18,6 +18,7 @@ describe('SourcegraphCompletionsAdapter', () => {
         codeToRewrite: 'const x = 1',
         userId: 'test-user',
         isChatModel: false,
+        abortSignal: new AbortController().signal,
     }
 
     beforeEach(() => {
@@ -79,7 +80,7 @@ describe('SourcegraphCompletionsAdapter', () => {
         adapter.client = { complete: mockComplete }
 
         const response = await adapter.getModelResponse(options)
-        expect(response.prediction).toBe('part1part2')
+        expect((response as SuccessModelResponse).prediction).toBe('part1part2')
     })
 
     it('handles errors correctly', async () => {

--- a/vscode/src/autoedits/adapters/utils.ts
+++ b/vscode/src/autoedits/adapters/utils.ts
@@ -1,4 +1,5 @@
-import { type Message, type PromptString, charsToTokens } from '@sourcegraph/cody-shared'
+import { type Message, type PromptString, charsToTokens, isAbortError } from '@sourcegraph/cody-shared'
+import type { AbortedModelResponse, ModelResponseShared, SuccessModelResponse } from './base'
 
 export interface FireworksCompatibleRequestParams {
     stream: boolean
@@ -63,38 +64,58 @@ export function getSourcegraphCompatibleChatPrompt(param: {
     return prompt
 }
 
-export async function getModelResponse(
-    url: string,
-    body: string,
-    apiKey: string,
-    customHeaders: Record<string, string> = {}
-): Promise<{
-    data: any
-    requestHeaders: Record<string, string>
-    responseHeaders: Record<string, string>
+export async function getModelResponse({
+    apiKey,
+    url,
+    body,
+    abortSignal,
+    customHeaders = {},
+}: {
+    apiKey: string
     url: string
-}> {
+    body: ModelResponseShared['requestBody']
+    abortSignal: AbortSignal
+    customHeaders?: Record<string, string>
+}): Promise<Omit<SuccessModelResponse, 'prediction'> | AbortedModelResponse> {
     const requestHeaders = {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${apiKey}`,
         ...customHeaders,
     }
-    const response = await fetch(url, {
-        method: 'POST',
-        headers: requestHeaders,
-        body: body,
-    })
-    if (response.status !== 200) {
-        const errorText = await response.text()
-        throw new Error(`HTTP error! status: ${response.status}, message: ${errorText}`)
+
+    const partialResult = {
+        requestHeaders,
+        requestUrl: url,
+        requestBody: body,
     }
 
-    // Extract headers into a plain object
-    const responseHeaders: Record<string, string> = {}
-    response.headers.forEach((value, key) => {
-        responseHeaders[key] = value
-    })
+    try {
+        const response = await fetch(url, {
+            method: 'POST',
+            headers: requestHeaders,
+            body: JSON.stringify(body),
+            signal: abortSignal,
+        })
 
-    const data = await response.json()
-    return { data, requestHeaders, responseHeaders, url }
+        if (response.status !== 200) {
+            const errorText = await response.text()
+            throw new Error(`HTTP error! status: ${response.status}, message: ${errorText}`)
+        }
+
+        // Extract headers into a plain object
+        const responseHeaders: Record<string, string> = {}
+        response.headers.forEach((value, key) => {
+            responseHeaders[key] = value
+        })
+
+        const responseBody = await response.json()
+        return { ...partialResult, type: 'success', responseBody, responseHeaders }
+    } catch (error) {
+        if (isAbortError(error)) {
+            return { ...partialResult, type: 'aborted' }
+        }
+
+        // Propagate error the auto-edit provider
+        throw error
+    }
 }

--- a/vscode/src/autoedits/analytics-logger/analytics-logger.test.ts
+++ b/vscode/src/autoedits/analytics-logger/analytics-logger.test.ts
@@ -65,6 +65,7 @@ describe('AutoeditAnalyticsLogger', () => {
         codeToRewrite: 'This is test code to rewrite',
         userId: 'test-user-id',
         isChatModel: false,
+        abortSignal: new AbortController().signal,
     }
 
     function getRequestStartMetadata(): Parameters<AutoeditAnalyticsLogger['createRequest']>[0] {
@@ -110,6 +111,7 @@ describe('AutoeditAnalyticsLogger', () => {
             requestId,
             prompt: modelOptions.prompt,
             modelResponse: {
+                type: 'success',
                 prediction,
                 requestHeaders: {},
                 requestUrl: modelOptions.url,

--- a/vscode/src/autoedits/analytics-logger/analytics-logger.ts
+++ b/vscode/src/autoedits/analytics-logger/analytics-logger.ts
@@ -19,7 +19,7 @@ import { charactersLogger } from '../../services/CharactersLogger'
 import { upstreamHealthProvider } from '../../services/UpstreamHealthProvider'
 import { captureException, shouldErrorBeReported } from '../../services/sentry/sentry'
 import { splitSafeMetadata } from '../../services/telemetry-v2'
-import type { AutoeditsPrompt, ModelResponse } from '../adapters/base'
+import type { AutoeditsPrompt, SuccessModelResponse } from '../adapters/base'
 import { autoeditsOutputChannelLogger } from '../output-channel-logger'
 import type { CodeToReplaceData } from '../prompt/prompt-utils'
 import type { DecorationInfo } from '../renderer/decorators/base'
@@ -160,7 +160,7 @@ export class AutoeditAnalyticsLogger {
         payload,
         modelResponse,
     }: {
-        modelResponse: ModelResponse
+        modelResponse: SuccessModelResponse
         requestId: AutoeditRequestID
         prompt: AutoeditsPrompt
         payload: Required<Pick<LoadedState['payload'], 'source' | 'isFuzzyMatch' | 'prediction'>>

--- a/vscode/src/completions/default-client.ts
+++ b/vscode/src/completions/default-client.ts
@@ -71,8 +71,6 @@ class DefaultCodeCompletionsClient implements CodeCompletionsClient {
                     ...getClientIdentificationHeaders(),
                 })
 
-                // Force HTTP connection reuse to reduce latency.
-                // c.f. https://github.com/microsoft/vscode/issues/173861
                 setJSONAcceptContentTypeHeaders(headers)
                 addCodyClientIdentificationHeaders(headers)
 

--- a/vscode/webviews/autoedit-debug/autoedit-data-sdk.ts
+++ b/vscode/webviews/autoedit-debug/autoedit-data-sdk.ts
@@ -1,4 +1,4 @@
-import { SuccessModelResponse } from '../../src/autoedits/adapters/base'
+import type { SuccessModelResponse } from '../../src/autoedits/adapters/base'
 import type { AutoeditRequestDebugState } from '../../src/autoedits/debug-panel/debug-store'
 import { DISCARD_REASONS, getDetailedTimingInfo } from './autoedit-ui-utils'
 

--- a/vscode/webviews/autoedit-debug/autoedit-data-sdk.ts
+++ b/vscode/webviews/autoedit-debug/autoedit-data-sdk.ts
@@ -1,3 +1,4 @@
+import { SuccessModelResponse } from '../../src/autoedits/adapters/base'
 import type { AutoeditRequestDebugState } from '../../src/autoedits/debug-panel/debug-store'
 import { DISCARD_REASONS, getDetailedTimingInfo } from './autoedit-ui-utils'
 
@@ -251,11 +252,24 @@ export const getNetworkLatencyInfo = (
     return { upstreamLatency, gatewayLatency }
 }
 
+export const getSuccessModelResponse = (
+    entry: AutoeditRequestDebugState
+): SuccessModelResponse | null => {
+    if ('modelResponse' in entry.state && entry.state.modelResponse.type === 'success') {
+        return entry.state.modelResponse
+    }
+    return null
+}
+
 /**
  * Get the full response body from the model if available
  */
 export const getFullResponseBody = (entry: AutoeditRequestDebugState): any | null => {
-    if ('modelResponse' in entry.state && entry.state.modelResponse?.responseBody) {
+    if (
+        'modelResponse' in entry.state &&
+        entry.state.modelResponse.type === 'success' &&
+        entry.state.modelResponse?.responseBody
+    ) {
         return entry.state.modelResponse.responseBody
     }
     return null

--- a/vscode/webviews/autoedit-debug/sections/NetworkRequestSection.tsx
+++ b/vscode/webviews/autoedit-debug/sections/NetworkRequestSection.tsx
@@ -1,6 +1,7 @@
 import type { FC } from 'react'
 
 import type { AutoeditRequestDebugState } from '../../../src/autoedits/debug-panel/debug-store'
+import { getSuccessModelResponse } from '../autoedit-data-sdk'
 import { JsonViewer } from '../components/JsonViewer'
 
 export const NetworkRequestSection: FC<{
@@ -58,7 +59,7 @@ export const NetworkResponseSection: FC<{
     }
 
     // Extract modelResponse if available
-    const modelResponse = 'modelResponse' in entry.state ? entry.state.modelResponse : null
+    const modelResponse = getSuccessModelResponse(entry)
 
     return (
         <div className="tw-grid tw-grid-cols-2 tw-gap-4">


### PR DESCRIPTION
- Propagates the abort signal to the fetch call used for auto-edit requests, ensuring that we cancel them based on the logic in the auto-edit provider. This should reduce the load on our inference deployment.
- Instead of throwing an error on cancellation, we return an object indicating to the auto-edit provider that the request was cancelled. This allows us to maintain the same data flow for the integration with the analytics logger and the debug panel.
- Closes [CODY-5306: Cancel redundant network requests](https://linear.app/sourcegraph/issue/CODY-5306/cancel-redundant-network-requests)

## Test plan

CI + manually tested with the auto-edit debug panel + updated unit tests 
