### PR TITLE
feat(auto-edit): reduce context size

### DIFF
--- a/vscode/src/autoedits/autoedits-config.ts
+++ b/vscode/src/autoedits/autoedits-config.ts
@@ -24,17 +24,17 @@ export interface AutoeditsProviderConfig extends BaseAutoeditsProviderConfig {
 }
 
 const defaultTokenLimit = {
-    prefixTokens: 2500,
-    suffixTokens: 2500,
+    prefixTokens: 500,
+    suffixTokens: 500,
     maxPrefixLinesInArea: 11,
     maxSuffixLinesInArea: 4,
     codeToRewritePrefixLines: 1,
     codeToRewriteSuffixLines: 2,
     contextSpecificTokenLimit: {
-        [RetrieverIdentifier.RecentEditsRetriever]: 1500,
+        [RetrieverIdentifier.RecentEditsRetriever]: 2500,
         [RetrieverIdentifier.JaccardSimilarityRetriever]: 0,
         [RetrieverIdentifier.RecentCopyRetriever]: 500,
-        [RetrieverIdentifier.DiagnosticsRetriever]: 500,
+        [RetrieverIdentifier.DiagnosticsRetriever]: 250,
         [RetrieverIdentifier.RecentViewPortRetriever]: 2500,
     },
 } as const satisfies AutoEditsTokenLimit


### PR DESCRIPTION
- Reduces the context limits:
    - Document prefix and suffix from 5000 to 1000. 
    - Recent edits from 1500 to 2500
    - Diagnostics retriever from 500 to 250
- No quality evaluations are available for this change yet. We will work on it with @hitesh-1997 in the next couple of weeks. This change's goal is to reduce latency and is based on the idea that the document prefix and suffix are less important than recent edits. Since the model is relatively small, it likely does not benefit from a long context window. For example, in autocomplete, our total context limit is 2k tokens. The diagnostics retriever limit is reduced based on manual testing, seeing that most of the errors are not actionable for the model, and usually, having a couple of them is enough.
- Closes [CODY-5303: Decrease the context size of the requests](https://linear.app/sourcegraph/issue/CODY-5303/decrease-the-context-size-of-the-requests)

## Test plan

CI + manually tested locally with the autoedit debug panel
