### PR TITLE
Add support for global Cody config

### DIFF
--- a/jetbrains/src/main/kotlin/com/sourcegraph/config/GlobalCodySettings.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/config/GlobalCodySettings.kt
@@ -1,0 +1,24 @@
+package com.sourcegraph.config
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.BaseState
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.SimplePersistentStateComponent
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+
+@Service(Service.Level.APP)
+@State(name = "GlobalCodySettings", storages = [Storage("cody.xml")])
+class GlobalCodySettings : SimplePersistentStateComponent<CodySettingsState>(CodySettingsState()) {
+  companion object {
+    @JvmStatic
+    fun getConfigJson(): String {
+      val instance = ApplicationManager.getApplication().getService(GlobalCodySettings::class.java)
+      return instance.state.jsonConfig ?: ""
+    }
+  }
+}
+
+class CodySettingsState : BaseState() {
+  var jsonConfig by string()
+}


### PR DESCRIPTION
This is special usage feature, which provide JetBrains toolbox with option to manipulate cody settings.
It was requested by one of our existing customers.

In addition to reading settings from project-level `cody_settings.json` this PR add support for `%APPDATA%/JetBrains/<product><version>/options/cody.xml` file, which contains single string entry which include whole additional json config.

For json config like:

```
{
  "cody.override.serverEndpoint": "https://sourcegraph.test:443",
}
```

Content of  `cody.xml` should be:

```
<application>
  <component name="GlobalCodySettings">
    <option name="jsonConfig" value="{&#10;  &quot;cody.override.serverEndpoint&quot;:  &quot;https://sourcegraph.test:443&quot;,&#10;}" />
  </component>
</application>
```

Standard xml escaping rules applies.

## Test plan

1. Create `%APPDATA%/JetBrains/<product><version>/options/cody.xml` in your IJ installation 
2. Add the content from previous description, just change  `serverEndpoint` to some your private instance (or just keep invalid one if you don't have any)
3. Restart IJ
4. Cody should log to your overridden endpoint (if it is valid you have credentials saved) or otherwise prefill instance URL and ask you to sign in.

![image](https://github.com/user-attachments/assets/6ad24122-7833-4a36-a8c2-0c9d1451a859)



