### PR TITLE
add agentic chat back to model dropdown

### DIFF
--- a/lib/shared/src/chat/chat.ts
+++ b/lib/shared/src/chat/chat.ts
@@ -1,6 +1,7 @@
 import { isError } from 'lodash'
 import { authStatus } from '../auth/authStatus'
 import { firstValueFrom } from '../misc/observable'
+import { modelsService } from '../models/modelsService'
 import type { Message } from '../sourcegraph-api'
 import type { SourcegraphCompletionsClient } from '../sourcegraph-api/completions/client'
 import type {
@@ -26,6 +27,12 @@ export class ChatClient {
         abortSignal?: AbortSignal,
         interactionId?: string
     ): Promise<AsyncGenerator<CompletionGeneratorValue>> {
+        // Replace internal models used for wrapper models with the actual model ID.
+        if (params.model?.includes('deep-cody')) {
+            const sonnetModel = modelsService.getAllModelsWithSubstring('sonnet')[0]
+            params.model = sonnetModel.id
+        }
+
         const [versions, authStatus_] = await Promise.all([
             currentSiteVersion(),
             await firstValueFrom(authStatus),

--- a/lib/shared/src/models/client.ts
+++ b/lib/shared/src/models/client.ts
@@ -3,7 +3,7 @@ import type { ModelTag } from './tags'
 
 // @deprecated Now called the agentic chat
 export const DeepCodyAgentID = 'deep-cody'
-
+export const DeepCodyModelRef = 'sourcegraph::2023-06-01::deep-cody'
 export const ToolCodyModelRef = 'sourcegraph::2024-12-31::tool-cody'
 export const ToolCodyModelName = 'tool-cody'
 
@@ -14,6 +14,21 @@ export const TOOL_CODY_MODEL: ServerModel = {
     capabilities: ['chat'],
     category: 'accuracy',
     status: 'internal' as ModelTag.Internal,
+    tier: 'pro' as ModelTag.Pro,
+    contextWindow: {
+        maxInputTokens: 45000,
+        maxOutputTokens: 4000,
+    },
+}
+
+export const DEEP_CODY_MODEL: ServerModel = {
+    // This modelRef does not exist in the backend and is used to identify the model in the client.
+    modelRef: DeepCodyModelRef,
+    displayName: 'Agentic chat',
+    modelName: DeepCodyAgentID,
+    capabilities: ['chat'],
+    category: 'accuracy',
+    status: 'experimental' as ModelTag.Experimental,
     tier: 'pro' as ModelTag.Pro,
     contextWindow: {
         maxInputTokens: 45000,

--- a/lib/shared/src/models/sync.test.ts
+++ b/lib/shared/src/models/sync.test.ts
@@ -534,8 +534,7 @@ describe('syncModels', () => {
         vi.spyOn(modelsService, 'modelsChanges', 'get').mockReturnValue(Observable.of(result))
 
         // Check if Deep Cody model is in the primary models list.
-        // NOTE: Deep Cody has been removed from the model list and should not be present in the primary models list.
-        expect(result.primaryModels.some(model => model.id.includes('deep-cody'))).toBe(false)
+        expect(result.primaryModels.some(model => model.id.includes('deep-cody'))).toBe(true)
 
         // preference should not be affected and remains unchanged as this is handled in a later step.
         expect(result.preferences.selected.chat).toBe(undefined)

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -49,6 +49,7 @@ import {
     isDotCom,
     isError,
     isRateLimitError,
+    isS2,
     logError,
     modelsService,
     pendingOperation,
@@ -545,9 +546,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         const experimentalPromptEditorEnabled = await firstValueFrom(
             featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.CodyExperimentalPromptEditor)
         )
-        const experimentalAgenticChatEnabled = await firstValueFrom(
-            featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.DeepCody)
-        )
+        const experimentalAgenticChatEnabled = isS2(auth.serverEndpoint)
         const sidebarViewOnly = this.extensionClient.capabilities?.webviewNativeConfig?.view === 'single'
         const isEditorViewType = this.webviewPanelOrView?.viewType === 'cody.editorPanel'
         const webviewType = isEditorViewType && !sidebarViewOnly ? 'editor' : 'sidebar'
@@ -672,7 +671,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
 
                 this.chatBuilder.setSelectedModel(model)
 
-                const chatAgent = getAgentName(manuallySelectedIntent)
+                const chatAgent = getAgentName(manuallySelectedIntent, model)
 
                 this.chatBuilder.addHumanMessage({
                     text: inputText,

--- a/vscode/src/chat/chat-view/handlers/registry.ts
+++ b/vscode/src/chat/chat-view/handlers/registry.ts
@@ -1,6 +1,10 @@
 import Anthropic from '@anthropic-ai/sdk'
 import type { ChatMessage } from '@sourcegraph/cody-shared'
-import { DeepCodyAgentID, ToolCodyModelRef } from '@sourcegraph/cody-shared/src/models/client'
+import {
+    DeepCodyAgentID,
+    DeepCodyModelRef,
+    ToolCodyModelRef,
+} from '@sourcegraph/cody-shared/src/models/client'
 import { getConfiguration } from '../../../configuration'
 import { AgenticHandler } from './AgenticHandler'
 import { ChatHandler } from './ChatHandler'
@@ -58,6 +62,9 @@ export function getAgent(model: string, agentName: string, tools: AgentTools): A
     return new ChatHandler(contextRetriever, editor, chatClient)
 }
 
-export function getAgentName(intent: ChatMessage['intent']): string | undefined {
+export function getAgentName(intent: ChatMessage['intent'], model?: string): string | undefined {
+    if (model === DeepCodyModelRef) {
+        return DeepCodyAgentID
+    }
     return (intent !== 'chat' && intent) || undefined
 }

--- a/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/ModeSelectorButton.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/ModeSelectorButton.tsx
@@ -70,7 +70,7 @@ function getIntentOptions({
             badge: agenticChatEnabled ? 'Experimental' : 'Pro',
             icon: Sparkle,
             intent: 'agentic',
-            hidden: !isDotComUser && !agenticChatEnabled,
+            hidden: !agenticChatEnabled,
             disabled: !agenticChatEnabled,
         },
         {
@@ -99,7 +99,7 @@ export const ModeSelectorField: React.FunctionComponent<{
     intent: ChatMessage['intent']
     className?: string
     manuallySelectIntent: (intent?: ChatMessage['intent']) => void
-}> = ({ isDotComUser, isCodyProUser, className, intent, omniBoxEnabled, manuallySelectIntent }) => {
+}> = ({ isDotComUser, className, intent, omniBoxEnabled, manuallySelectIntent }) => {
     const {
         clientCapabilities: { edit },
         config: { experimentalAgenticChatEnabled },
@@ -111,9 +111,9 @@ export const ModeSelectorField: React.FunctionComponent<{
                 isEditEnabled: edit !== 'none',
                 isDotComUser,
                 omniBoxEnabled,
-                agenticChatEnabled: isCodyProUser || experimentalAgenticChatEnabled,
+                agenticChatEnabled: experimentalAgenticChatEnabled,
             }).filter(option => !option.hidden),
-        [edit, isDotComUser, isCodyProUser, omniBoxEnabled, experimentalAgenticChatEnabled]
+        [edit, isDotComUser, omniBoxEnabled, experimentalAgenticChatEnabled]
     )
 
     // Memoize the handler to avoid recreating on each render


### PR DESCRIPTION
https://github.com/sourcegraph/cody/pull/7332 to add agentic chat back to model selector.

Also only shows Agentic mode from mode selector for S2 users for internal dogfood

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Revert https://github.com/sourcegraph/cody/pull/7332 