### PR TITLE
Commit message gen: handle a case when there is no staged commit

### DIFF
--- a/vscode/src/commands/context/git-api.test.ts
+++ b/vscode/src/commands/context/git-api.test.ts
@@ -60,16 +60,15 @@ describe('getContextFilesFromGitDiff', () => {
         diff.mockImplementation((staged) => {
             if (staged === true) {
                 return Promise.resolve('') // No staged changes
-            } else {
-                // Return unstaged changes when diff(false) is called
-                return Promise.resolve(
-                    'diff --git a/file2.ts b/file2.ts\n' +
-                    '--- a/file2.ts\n' +
-                    '+++ b/file2.ts\n' +
-                    '@@ -1,1 +1,2 @@\n' +
-                    '+console.log("Unstaged change");\n'
-                )
             }
+            // Return unstaged changes when diff(false) is called
+            return Promise.resolve(
+                'diff --git a/file2.ts b/file2.ts\n' +
+                '--- a/file2.ts\n' +
+                '+++ b/file2.ts\n' +
+                '@@ -1,1 +1,2 @@\n' +
+                '+console.log("Unstaged change");\n'
+            )
         })
 
         mockDoesFileExist.mockResolvedValue(true)

--- a/vscode/src/commands/context/git-api.test.ts
+++ b/vscode/src/commands/context/git-api.test.ts
@@ -16,7 +16,7 @@ describe('getContextFilesFromGitDiff', () => {
         diffIndexWithHEAD: vi.fn(),
         diffWithHEAD: vi.fn(),
         diff: vi.fn(),
-        rootUri: URI.parse('file:///repo/root')
+        rootUri: URI.parse('file:///repo/root'),
     } as unknown as Repository
 
     const diffIndexWithHEAD = mockGitRepo.diffIndexWithHEAD as Mock
@@ -55,19 +55,19 @@ describe('getContextFilesFromGitDiff', () => {
     it('should return diffs for unstaged changes when no staged changes', async () => {
         diffIndexWithHEAD.mockResolvedValue([])
         diffWithHEAD.mockResolvedValue([{ uri: URI.parse('file:///path/to/file2.ts') }])
-        
+
         // Mock both diff(true) for staged changes and diff(false) for unstaged changes
-        diff.mockImplementation((staged) => {
+        diff.mockImplementation(staged => {
             if (staged === true) {
                 return Promise.resolve('') // No staged changes
             }
             // Return unstaged changes when diff(false) is called
             return Promise.resolve(
                 'diff --git a/file2.ts b/file2.ts\n' +
-                '--- a/file2.ts\n' +
-                '+++ b/file2.ts\n' +
-                '@@ -1,1 +1,2 @@\n' +
-                '+console.log("Unstaged change");\n'
+                    '--- a/file2.ts\n' +
+                    '+++ b/file2.ts\n' +
+                    '@@ -1,1 +1,2 @@\n' +
+                    '+console.log("Unstaged change");\n'
             )
         })
 

--- a/vscode/src/commands/context/git-api.ts
+++ b/vscode/src/commands/context/git-api.ts
@@ -81,10 +81,11 @@ export async function getContextFilesFromGitDiff(gitRepo: Repository): Promise<C
             const normalizePath = (path: string) => path.replace(/\\/g, '/')
 
             // Verify the file exists before adding it as context.
-            // we do this by checking the reverse path because of how nested workspaces might add unknown prefixes
-            const normalizedDiffPath = normalizePath(diffPath)
+            // We do this by checking the reverse path because of how nested workspaces might add unknown prefixes.
+            const normalizedDiffPath = normalizePath(diffPath) // Example: "vscode/test.txt" - the path from the workspace root
             const matchingFile = diffFiles.find(file => {
-                const filePath = normalizePath(displayPath(file.uri))
+                // Example filePath: "/Users/yk/Desktop/cody/vscode/test.txt"
+                const filePath = normalizePath(file.uri.path)
                 return filePath.endsWith(normalizedDiffPath)
             })
             if (!matchingFile || !(await doesFileExist(matchingFile.uri))) {

--- a/vscode/src/commands/context/git-api.ts
+++ b/vscode/src/commands/context/git-api.ts
@@ -5,7 +5,7 @@ import {
     displayPath,
 } from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
-import { logDebug, logError } from '../../output-channel-logger'
+import { logError } from '../../output-channel-logger'
 import type { Repository } from '../../repository/builtinGitExtension'
 import { doesFileExist } from '../utils/workspace-files'
 
@@ -167,10 +167,8 @@ export async function getContextFilesFromGitDiff(gitRepo: Repository): Promise<C
         } else {
             diffOutput = await getAllUnstagedFileChanges(gitRepo)
         }
-        logDebug('diffOutput', 'diffOutput', JSON.stringify(diffOutput))
         const diffOutputSplit = diffOutput.trim().split(/diff --git a\/.+? b\//)
         const diffOutputByFiles = diffOutputSplit.filter(Boolean)
-        logDebug('diffOutputByFiles', 'diffOutputByFiles', JSON.stringify(diffOutputByFiles))
         // Compare the diff files to the diff output to ensure they match,
         // if the numbers are different, we can't trust the diff output were split correctly.
         if (!diffFiles.length || !diffOutput || diffOutputByFiles.length !== diffFiles.length) {

--- a/vscode/src/commands/context/git-api.ts
+++ b/vscode/src/commands/context/git-api.ts
@@ -150,7 +150,12 @@ export async function getContextFilesFromGitDiff(gitRepo: Repository): Promise<C
         // Get the diff output for staged changes if there is any,
         // otherwise, get the diff output for unstaged changes.
         const hasStagedChanges = Boolean(stagedFiles?.length)
-        const command = `git diff${hasStagedChanges ? ' --cached' : ''}`
+        let command = undefined
+        if (hasStagedChanges) {
+            command = 'git diff --cached'
+        } else {
+            command = 'git diff'
+        }
 
         // A list of file uris to use for comparison with the diff output.
         const diffFiles = hasStagedChanges ? stagedFiles : unstagedFiles

--- a/vscode/src/commands/context/git-api.ts
+++ b/vscode/src/commands/context/git-api.ts
@@ -61,18 +61,18 @@ export async function getAllUnstagedFileChanges(gitRepo: Repository): Promise<st
         const rootPath = gitRepo.rootUri.fsPath
 
         // Get diff for tracked unstaged files
-        const trackedDiff = await gitRepo.diff(false) // false means unstaged changes
+        const trackedUnstagedDiff = await gitRepo.diff(false) // false means unstaged changes
 
-        // Get all untracked files
-        const untrackedFiles = await getUntrackedUnstagedFiles(gitRepo)
+        // Get all untracked unstaged files
+        const untrackedUnstagedFiles = await getUntrackedUnstagedFiles(gitRepo)
 
-        if (untrackedFiles.length === 0) {
-            return trackedDiff // If no untracked files, just return tracked changes
+        if (untrackedUnstagedFiles.length === 0) {
+            return trackedUnstagedDiff // If no untracked files, just return tracked changes
         }
 
         // Get diff for untracked files by comparing them with /dev/null
         const untrackedDiffs = await Promise.all(
-            untrackedFiles.map(async file => {
+            untrackedUnstagedFiles.map(async file => {
                 try {
                     // Get relative path from repo root
                     const relativePath = vscode.workspace.asRelativePath(file.uri, false)

--- a/vscode/src/commands/context/git-api.ts
+++ b/vscode/src/commands/context/git-api.ts
@@ -163,7 +163,8 @@ export async function getContextFilesFromGitDiff(gitRepo: Repository): Promise<C
             diffOutput = await getAllUnstagedFileChanges(gitRepo)
         }
         logDebug('diffOutput', 'diffOutput', JSON.stringify(diffOutput))
-        const diffOutputByFiles = diffOutput.split(/diff --git a\/.+? b\//).filter(Boolean)
+        const diffOutputSplit = diffOutput.trim().split(/diff --git a\/.+? b\//)
+        const diffOutputByFiles = diffOutputSplit.filter(Boolean)
         logDebug('diffOutputByFiles', 'diffOutputByFiles', JSON.stringify(diffOutputByFiles))
         // Compare the diff files to the diff output to ensure they match,
         // if the numbers are different, we can't trust the diff output were split correctly.

--- a/vscode/src/commands/context/git-api.ts
+++ b/vscode/src/commands/context/git-api.ts
@@ -74,8 +74,13 @@ export async function getAllUnstagedFileChanges(gitRepo: Repository): Promise<st
         const untrackedDiffs = await Promise.all(
             untrackedUnstagedFiles.map(async file => {
                 try {
-                    // Get relative path from repo root
-                    const relativePath = vscode.workspace.asRelativePath(file.uri, false)
+                    // Get paths relative to the git repository root
+                    const absoluteFilePath = file.uri.fsPath
+                    const repoRootUri = gitRepo.rootUri
+                    const absoluteRepoPath = repoRootUri.fsPath
+
+                    const path = require('path')
+                    const relativePath = path.relative(absoluteRepoPath, absoluteFilePath)
 
                     // Use git diff command with /dev/null to show full file content as added
                     const { stdout } = await execAsync(

--- a/vscode/src/commands/context/git-api.ts
+++ b/vscode/src/commands/context/git-api.ts
@@ -79,7 +79,7 @@ export async function getAllUnstagedFileChanges(gitRepo: Repository): Promise<st
                     const repoRootUri = gitRepo.rootUri
                     const absoluteRepoPath = repoRootUri.fsPath
 
-                    const path = require('path')
+                    const path = require('node:path')
                     const relativePath = path.relative(absoluteRepoPath, absoluteFilePath)
 
                     // Use git diff command with /dev/null to show full file content as added

--- a/vscode/src/commands/context/git-api.ts
+++ b/vscode/src/commands/context/git-api.ts
@@ -98,7 +98,7 @@ export async function getAllUnstagedFileChanges(gitRepo: Repository): Promise<st
         )
 
         // Filter out empty diffs and combine all diffs
-        const allDiffs = [trackedDiff, ...untrackedDiffs.filter(diff => diff.trim().length > 0)]
+        const allDiffs = [trackedUnstagedDiff, ...untrackedDiffs.filter(diff => diff.trim().length > 0)]
         return allDiffs.join('\n')
     } catch (error) {
         logError('getAllUnstagedFileChanges', 'failed', { verbose: error })

--- a/vscode/src/commands/scm/source-control.ts
+++ b/vscode/src/commands/scm/source-control.ts
@@ -40,7 +40,7 @@ export class CodySourceControl implements vscode.Disposable {
                     .getModels(ModelUsage.Edit)
                     .pipe(skipPendingOperation())
                     .subscribe(models => {
-                        // Removes experimental and preview models
+                        // Remove experimental and preview models
                         const filtered = models.filter(
                             m =>
                                 !m.tags.includes(ModelTag.Experimental) &&
@@ -48,7 +48,7 @@ export class CodySourceControl implements vscode.Disposable {
                         )
                         const flashLite = filtered.find(m => m.id.endsWith('gemini-2.0-flash-lite'))
                         const flash = filtered.find(m => m.id.endsWith('gemini-2.0-flash'))
-                        this.model = flashLite ?? flash ?? filtered.at(0)
+                        this.model = flash ?? flashLite ?? filtered.at(0)
                     })
             )
         )

--- a/vscode/src/commands/scm/source-control.ts
+++ b/vscode/src/commands/scm/source-control.ts
@@ -173,10 +173,11 @@ export class CodySourceControl implements vscode.Disposable {
             }
 
             const { id: model, contextWindow } = this.model
+            const context = await getContextFilesFromGitApi(repository, commitTemplate).catch(() => [])
             const { prompt, ignoredContext } = await this.buildPrompt(
                 contextWindow,
                 getSimplePreamble(model, 1, 'Default', COMMIT_COMMAND_PROMPTS.intro),
-                await getContextFilesFromGitApi(repository, commitTemplate).catch(() => [])
+                context
             ).catch(error => {
                 sourceControlInputbox.value = `${error}`
                 throw new Error()

--- a/vscode/src/commands/scm/source-control.ts
+++ b/vscode/src/commands/scm/source-control.ts
@@ -225,7 +225,7 @@ export class CodySourceControl implements vscode.Disposable {
         preamble: Message[],
         context: ContextItem[]
     ): Promise<{ prompt: Message[]; ignoredContext: ContextItem[] }> {
-        if (!context.length) {
+        if (context.length === 0) {
             throw new Error('Failed to get git output.')
         }
 

--- a/vscode/src/commands/scm/source-control.ts
+++ b/vscode/src/commands/scm/source-control.ts
@@ -19,7 +19,7 @@ import {
 import * as vscode from 'vscode'
 import { PromptBuilder } from '../../prompt-builder'
 import type { API, GitExtension, InputBox, Repository } from '../../repository/builtinGitExtension'
-import { getContextFilesFromGitApi as getContext } from '../context/git-api'
+import { getContextFilesFromGitApi } from '../context/git-api'
 import { COMMIT_COMMAND_PROMPTS } from './prompts'
 
 export class CodySourceControl implements vscode.Disposable {
@@ -176,7 +176,7 @@ export class CodySourceControl implements vscode.Disposable {
             const { prompt, ignoredContext } = await this.buildPrompt(
                 contextWindow,
                 getSimplePreamble(model, 1, 'Default', COMMIT_COMMAND_PROMPTS.intro),
-                await getContext(repository, commitTemplate).catch(() => [])
+                await getContextFilesFromGitApi(repository, commitTemplate).catch(() => [])
             ).catch(error => {
                 sourceControlInputbox.value = `${error}`
                 throw new Error()


### PR DESCRIPTION
Closes CODY-5275.

When there is a change but it's not staged, we can now generate a commit message based on it.

This PR depends on https://github.com/sourcegraph/cody/pull/7387.

## Test plan

CI/CI and manually test it.