### PR TITLE
feat(telemetry): Add OS platform and architecture information for telemetry

### DIFF
--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -101,6 +101,10 @@ interface RawClientConfiguration {
     debugVerbose: boolean
     telemetryLevel: 'all' | 'off' | 'agent'
 
+    // OS information for telemetry
+    osPlatform?: string
+    osArch?: string
+    
     serverEndpoint?: string
     customHeaders?: Record<string, string>
     chatPreInstruction?: PromptString

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -317,8 +317,7 @@ export {
     MockServerTelemetryRecorderProvider,
     NoOpTelemetryRecorderProvider,
     TelemetryRecorderProvider,
-    noOpTelemetryRecorder,
-    type ExtensionDetails,
+    noOpTelemetryRecorder
 } from './telemetry-v2/TelemetryRecorderProvider'
 export type { TelemetryRecorder } from './telemetry-v2/TelemetryRecorderProvider'
 export * from './telemetry-v2/singleton'

--- a/lib/shared/src/telemetry-v2/singleton.ts
+++ b/lib/shared/src/telemetry-v2/singleton.ts
@@ -44,6 +44,9 @@ export function updateGlobalTelemetryInstances(
                 `recordEvent${updatedProvider.noOp ? ' (no-op)' : ''}: ${event.feature}/${event.action}`,
                 {
                     verbose: {
+                        source: event.source,
+                        client: event.source?.client,
+                        clientVersion: event.source?.clientVersion,
                         parameters: event.parameters,
                         timestamp: event.timestamp,
                     },

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -14,6 +14,7 @@ import {
 import type { ChatModelProviderConfig } from '@sourcegraph/cody-shared/src/models/sync'
 import { CONFIG_KEY, type ConfigKeys } from './configuration-keys'
 import { localStorage } from './services/LocalStorageProvider'
+import { getOSArch } from './os'
 
 interface ConfigGetter {
     get<T>(section: (typeof CONFIG_KEY)[ConfigKeys], defaultValue?: T): T
@@ -25,6 +26,9 @@ interface ConfigGetter {
 export function getConfiguration(
     config: ConfigGetter = vscode.workspace.getConfiguration()
 ): ClientConfiguration {
+    // Get OS information
+    const { platform: osPlatform, arch: osArch } = getOSArch()
+
     function getHiddenSetting<T>(configKey: string, defaultValue?: T): T {
         return config.get<T>(`cody.${configKey}` as any, defaultValue)
     }
@@ -205,6 +209,9 @@ export function getConfiguration(
          */
         overrideAuthToken: getHiddenSetting<string | undefined>('override.authToken'),
         overrideServerEndpoint: getHiddenSetting<string | undefined>('override.serverEndpoint'),
+        // add platform and arch
+        osPlatform,
+        osArch,
     }
 }
 


### PR DESCRIPTION
Include OS platform and architecture details in v2t-telemetry to enhance data collection and reporting.

## test plan
CI + locally