### PR TITLE
feat(auto-edit): experimental inceptionlabs adapter

### DIFF
--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -46,8 +46,8 @@ export interface AutoEditsTokenLimit {
  * Used to configure the model provider for auto-edit functionality in the VS Code extension.
  */
 export interface AutoEditsModelConfig {
-    /** The provider service to use for auto-edit. Can be 'openai', 'fireworks', 'cody-gateway', or 'sourcegraph' */
-    provider: 'openai' | 'fireworks' | 'cody-gateway' | 'sourcegraph'
+    /** The provider service to use for auto-edit. Can be 'openai', 'fireworks', 'cody-gateway', 'sourcegraph', or 'inceptionlabs' */
+    provider: 'openai' | 'fireworks' | 'cody-gateway' | 'sourcegraph' | 'inceptionlabs'
     /** The specific model identifier to use for auto-edit */
     model: string
     /** The endpoint URL for the provider's API */

--- a/vscode/src/autoedits/adapters/create-adapter.ts
+++ b/vscode/src/autoedits/adapters/create-adapter.ts
@@ -5,6 +5,7 @@ import { autoeditsOutputChannelLogger } from '../output-channel-logger'
 import type { AutoeditsModelAdapter } from './base'
 import { CodyGatewayAdapter } from './cody-gateway'
 import { FireworksAdapter } from './fireworks'
+import { InceptionLabsAdapter } from './inceptionlabs'
 import { OpenAIAdapter } from './openai'
 import { SourcegraphChatAdapter } from './sourcegraph-chat'
 import { SourcegraphCompletionsAdapter } from './sourcegraph-completions'
@@ -19,6 +20,8 @@ export function createAutoeditsModelAdapter({
     chatClient: ChatClient
 }): AutoeditsModelAdapter {
     switch (providerName) {
+        case 'inceptionlabs':
+            return new InceptionLabsAdapter()
         case 'openai':
             return new OpenAIAdapter()
         case 'fireworks':

--- a/vscode/src/autoedits/adapters/inceptionlabs.ts
+++ b/vscode/src/autoedits/adapters/inceptionlabs.ts
@@ -1,0 +1,83 @@
+import { ps } from '@sourcegraph/cody-shared'
+
+import { getNewLineChar } from '../../completions/text-processing/utils'
+import { autoeditsProviderConfig } from '../autoedits-config'
+import { autoeditsOutputChannelLogger } from '../output-channel-logger'
+
+import type { AutoeditModelOptions, AutoeditsModelAdapter, ModelResponse } from './base'
+import { type AutoeditsRequestBody, getModelResponse, getOpenaiCompatibleChatPrompt } from './utils'
+
+export interface InceptionLabsRequestParams {
+    model: string
+    temperature: number
+}
+
+export const inceptionlabsPrompt = {
+    start: ps`The programmer will provide you open files in the editor, recently viewed files, the currently edited file, recent codebase changes, linter errors, and copied content from the codebase. Your task is to rewrite <code_to_rewrite> or add new code to it to match what the programmer will likely do next based on recent edits. Keep your response direct, relevant, and aligned with the existing code patterns. Assume the programmer may have stopped mid-typing or just added a new line. Guidelines for edits: Stay consistent with the detected coding pattern. Output high-quality code. Prioritize continuing the diff history stream, improving code quality, and maintaining focus. Make only necessary changes. Do not skip lines or take shortcuts. The programmer will copy-paste your response directly. <CURSOR_IS_HERE> shows where programmer stopped typing.`,
+
+    end: ps`Based on <diff_history> content, what will I do next? Rewrite the code between <code_to_rewrite> and </code_to_rewrite> based on what I will do next. Remember, you must ONLY respond using the tag: <next-version> with the rewritten code. IMPORTANT: only rewrite the code between <code_to_rewrite> and </code_to_rewrite> tags. Suggest code completions after <CURSOR_IS_HERE> for empty lines. Never output the tag <CURSOR_IS_HERE> in your response.`,
+}
+
+/**
+ * Experimental inceptionlabs auto-edit adapter for internal dogfooding only.
+ */
+export class InceptionLabsAdapter implements AutoeditsModelAdapter {
+    async getModelResponse(option: AutoeditModelOptions): Promise<ModelResponse> {
+        const requestBody = this.getMessageBody(option)
+        try {
+            const apiKey = autoeditsProviderConfig.experimentalAutoeditsConfigOverride?.apiKey
+
+            if (!apiKey) {
+                autoeditsOutputChannelLogger.logError(
+                    'getModelResponse',
+                    'No api key provided in the config override'
+                )
+                throw new Error('No api key provided in the config override')
+            }
+            const response = await getModelResponse({
+                apiKey,
+                url: option.url,
+                body: requestBody,
+                abortSignal: option.abortSignal,
+            })
+
+            if (response.type === 'aborted') {
+                return response
+            }
+
+            const newLineChar = getNewLineChar(option.codeToRewrite)
+            const prediction = response.responseBody.choices[0].message.content
+                .replace(/<next-version>\n?/g, '')
+                .replace(/\n?<\/next-version>/g, '')
+                // For now manually limit prediction to the same number of lines as the code to rewrite
+                .split(newLineChar)
+                .slice(0, option.codeToRewrite.split(newLineChar).length)
+                .join(newLineChar)
+
+            return {
+                ...response,
+                prediction,
+            }
+        } catch (error) {
+            autoeditsOutputChannelLogger.logError('getModelResponse', 'Error calling Fireworks API:', {
+                verbose: error,
+            })
+            throw error
+        }
+    }
+
+    private getMessageBody(options: AutoeditModelOptions): AutoeditsRequestBody {
+        const baseParams: InceptionLabsRequestParams = {
+            model: options.model,
+            temperature: 0,
+        }
+
+        return {
+            ...baseParams,
+            messages: getOpenaiCompatibleChatPrompt({
+                // systemMessage: options.prompt.systemMessage,
+                userMessage: options.prompt.userMessage,
+            }),
+        }
+    }
+}

--- a/vscode/src/autoedits/adapters/utils.ts
+++ b/vscode/src/autoedits/adapters/utils.ts
@@ -1,5 +1,6 @@
 import { type Message, type PromptString, charsToTokens, isAbortError } from '@sourcegraph/cody-shared'
 import type { AbortedModelResponse, ModelResponseShared, SuccessModelResponse } from './base'
+import type { InceptionLabsRequestParams } from './inceptionlabs'
 
 export interface FireworksCompatibleRequestParams {
     stream: boolean
@@ -33,6 +34,7 @@ export interface FireworksCompletionModelRequestParams extends FireworksCompatib
 export type AutoeditsRequestBody =
     | FireworksChatModelRequestParams
     | FireworksCompletionModelRequestParams
+    | InceptionLabsRequestParams
 
 export function getMaxOutputTokensForAutoedits(codeToRewrite: string): number {
     const MAX_NEW_GENERATED_TOKENS = 512

--- a/vscode/src/autoedits/prompt/default-prompt-strategy.ts
+++ b/vscode/src/autoedits/prompt/default-prompt-strategy.ts
@@ -55,10 +55,10 @@ export class DefaultUserPromptStrategy extends AutoeditsUserPromptStrategy {
             getJaccardSimilarityPrompt
         )
 
-        const { fileWithMarkerPrompt, areaPrompt } = getCurrentFilePromptComponents(
+        const { fileWithMarkerPrompt, areaPrompt } = getCurrentFilePromptComponents({
             document,
-            codeToReplaceData
-        )
+            codeToReplaceDataRaw: codeToReplaceData,
+        })
 
         const currentFilePrompt = ps`${constants.CURRENT_FILE_INSTRUCTION}${fileWithMarkerPrompt}`
 

--- a/vscode/src/autoedits/prompt/prompt-utils.test.ts
+++ b/vscode/src/autoedits/prompt/prompt-utils.test.ts
@@ -90,7 +90,10 @@ describe('getCurrentFilePromptComponents', () => {
             },
         })
 
-        const result = getCurrentFilePromptComponents(document, codeToReplaceData)
+        const result = getCurrentFilePromptComponents({
+            document,
+            codeToReplaceDataRaw: codeToReplaceData,
+        })
         expect(result.fileWithMarkerPrompt.toString()).toBe(dedent`
             (\`test.ts\`)
             <file>
@@ -154,7 +157,10 @@ describe('getCurrentFilePromptComponents', () => {
             },
         })
 
-        const result = getCurrentFilePromptComponents(document, codeToReplaceData)
+        const result = getCurrentFilePromptComponents({
+            document,
+            codeToReplaceDataRaw: codeToReplaceData,
+        })
         expect(result.fileWithMarkerPrompt.toString()).toBe(dedent`
             (\`test.ts\`)
             <file>

--- a/vscode/src/autoedits/prompt/prompt-utils.ts
+++ b/vscode/src/autoedits/prompt/prompt-utils.ts
@@ -64,10 +64,15 @@ export function getPromptForTheContextSource(
     return ps`${instructionPrompt}\n${prompt}`
 }
 
-export function getCurrentFilePromptComponents(
-    document: vscode.TextDocument,
+export function getCurrentFilePromptComponents({
+    document,
+    codeToReplaceDataRaw,
+    includeCursor,
+}: {
+    document: vscode.TextDocument
     codeToReplaceDataRaw: CodeToReplaceData
-): {
+    includeCursor?: boolean
+}): {
     fileWithMarkerPrompt: PromptString
     areaPrompt: PromptString
 } {
@@ -92,11 +97,15 @@ export function getCurrentFilePromptComponents(
         )
     )
 
+    const codeToRewrite = includeCursor
+        ? ps`${codeToReplaceData.codeToRewritePrefix}<CURSOR_IS_HERE>${codeToReplaceData.codeToRewriteSuffix}`
+        : codeToReplaceData.codeToRewrite
+
     const areaPrompt = joinPromptsWithNewlineSeparator(
         constants.AREA_FOR_CODE_MARKER_OPEN,
         codeToReplaceData.prefixInArea,
         constants.CODE_TO_REWRITE_TAG_OPEN,
-        codeToReplaceData.codeToRewrite,
+        codeToRewrite,
         constants.CODE_TO_REWRITE_TAG_CLOSE,
         codeToReplaceData.suffixInArea,
         constants.AREA_FOR_CODE_MARKER_CLOSE


### PR DESCRIPTION
- Implements the experimental auto-edit adapter for the diffusion coding model hosted by https://www.inceptionlabs.ai/
- The model is not fine-tuned on our data yet. I didn't spend much time prompt engineering the adapter to get stable results, so the model often does not follow instructions precisely and does not suggest completions as much as I would expect.
- Latency can be viewed in the auto-edit debug panel.
- Closes [CODY-5317: Implement experimental support for the diffusion model from InceptionLabs](https://linear.app/sourcegraph/issue/CODY-5317/implement-experimental-support-for-the-diffusion-model-from)

## Test plan

- CI
- Manually test by using local override settings for auto-edit. You can find the InceptionLabs token in 1Password.

```json
  "cody.experimental.autoedit.config.override": {
    "url": "https://inference.lambdalabs.com/v1/chat/completions",
    "provider": "inceptionlabs",
    "isChatModel": true,
    "model": "mercury-coder-small",
    "apiKey": "XXX",
    "tokenLimit": {
      "prefixTokens": 500,
      "suffixTokens": 500,
      "maxPrefixLinesInArea": 20,
      "maxSuffixLinesInArea": 8,
      "codeToRewritePrefixLines": 3,
      "codeToRewriteSuffixLines": 4,
      "contextSpecificTokenLimit": {
        "recent-edits": 2500,
        "jaccard-similarity": 0,
        "recent-copy": 150,
        "diagnostics": 150,
        "recent-view-port": 500,
      }
    }
  },
