### PR TITLE
chore(auto-edit): add inference time to the debug panel

### DIFF
--- a/vscode/webviews/autoedit-debug/AutoeditDebugPanel.tsx
+++ b/vscode/webviews/autoedit-debug/AutoeditDebugPanel.tsx
@@ -1,69 +1,185 @@
-import { type FC, useState } from 'react'
+import { type FC, useCallback, useEffect, useMemo, useState } from 'react'
 
 import type { AutoeditRequestDebugState } from '../../src/autoedits/debug-panel/debug-store'
 
+import { extractPhaseInfo } from './autoedit-ui-utils'
 import { AutoeditDetailView } from './components/AutoeditDetailView'
 import { AutoeditListItem } from './components/AutoeditListItem'
 import { EmptyState } from './components/EmptyState'
 
+// All possible phases for filtering
+const ALL_PHASES = [
+    'All Phases',
+    'Start',
+    'Context Loaded',
+    'Inference',
+    'Network',
+    'Post Processed',
+    'Suggested',
+    'Read',
+    'Accepted',
+    'Rejected',
+    'Discarded',
+]
+
 export const AutoeditDebugPanel: FC<{ entries: AutoeditRequestDebugState[] }> = ({ entries }) => {
-    const [selectedEntryId, setSelectedEntryId] = useState<string | null>(
-        entries.length > 0 ? entries[0].state.requestId : null
+    const [phaseFilter, setPhaseFilter] = useState<string>('All Phases')
+
+    // Filter entries based on the selected phase
+    const filteredEntries = useMemo(() => {
+        if (phaseFilter === 'All Phases') {
+            return entries
+        }
+
+        return entries.filter(entry => {
+            const phases = extractPhaseInfo(entry)
+            return phases.some(phase => phase.name === phaseFilter)
+        })
+    }, [entries, phaseFilter])
+
+    // Ensure we always have a valid selectedEntryId that exists in filteredEntries
+    const [selectedEntryId, setSelectedEntryId] = useState<string | null>(null)
+
+    // Update selectedEntryId when entries change or when the filter changes
+    useEffect(() => {
+        if (filteredEntries.length === 0) {
+            setSelectedEntryId(null)
+            return
+        }
+
+        // If the current selection is still valid, keep it
+        if (
+            selectedEntryId &&
+            filteredEntries.some(entry => entry.state.requestId === selectedEntryId)
+        ) {
+            return
+        }
+
+        // Otherwise, select the first entry
+        setSelectedEntryId(filteredEntries[0].state.requestId)
+    }, [filteredEntries, selectedEntryId])
+
+    const selectedEntry = useMemo(
+        () => filteredEntries.find(entry => entry.state.requestId === selectedEntryId) || null,
+        [filteredEntries, selectedEntryId]
     )
 
-    const selectedEntry = entries.find(entry => entry.state.requestId === selectedEntryId) || null
-
     // Handle entry selection
-    const handleEntrySelect = (entryId: string) => {
+    const handleEntrySelect = useCallback((entryId: string) => {
         setSelectedEntryId(entryId)
-    }
+    }, [])
+
+    // Handle phase filter change
+    const handlePhaseFilterChange = useCallback((event: React.ChangeEvent<HTMLSelectElement>) => {
+        setPhaseFilter(event.target.value)
+    }, [])
+
+    // Get current index for navigation
+    const currentIndex = useMemo(() => {
+        if (!selectedEntryId) return -1
+        return filteredEntries.findIndex(entry => entry.state.requestId === selectedEntryId)
+    }, [selectedEntryId, filteredEntries])
 
     // Navigate to previous request
-    const handlePrevious = () => {
-        if (!selectedEntryId || entries.length <= 1) return
-
-        const currentIndex = entries.findIndex(entry => entry.state.requestId === selectedEntryId)
+    const handlePrevious = useCallback(() => {
         if (currentIndex > 0) {
-            setSelectedEntryId(entries[currentIndex - 1].state.requestId)
+            setSelectedEntryId(filteredEntries[currentIndex - 1].state.requestId)
         }
-    }
+    }, [currentIndex, filteredEntries])
 
     // Navigate to next request
-    const handleNext = () => {
-        if (!selectedEntryId || entries.length <= 1) return
-
-        const currentIndex = entries.findIndex(entry => entry.state.requestId === selectedEntryId)
-        if (currentIndex < entries.length - 1) {
-            setSelectedEntryId(entries[currentIndex + 1].state.requestId)
+    const handleNext = useCallback(() => {
+        if (currentIndex >= 0 && currentIndex < filteredEntries.length - 1) {
+            setSelectedEntryId(filteredEntries[currentIndex + 1].state.requestId)
         }
-    }
+    }, [currentIndex, filteredEntries])
 
     // Close the detail view
-    const handleClose = () => {
+    const handleClose = useCallback(() => {
         setSelectedEntryId(null)
-    }
+    }, [])
+
+    // Navigation state
+    const hasPrevious = currentIndex > 0
+    const hasNext = currentIndex >= 0 && currentIndex < filteredEntries.length - 1
+
+    // Handle keyboard navigation
+    useEffect(() => {
+        // Only add keyboard listeners if an entry is selected
+        if (!selectedEntryId) return
+
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'ArrowUp') {
+                event.preventDefault()
+                if (hasPrevious) handlePrevious()
+            } else if (event.key === 'ArrowDown') {
+                event.preventDefault()
+                if (hasNext) handleNext()
+            }
+        }
+
+        window.addEventListener('keydown', handleKeyDown)
+        return () => window.removeEventListener('keydown', handleKeyDown)
+    }, [selectedEntryId, handlePrevious, handleNext, hasPrevious, hasNext])
 
     if (entries.length === 0) {
         return <EmptyState />
     }
 
+    // Phase filter dropdown
+    const phaseFilterDropdown = (
+        <div className="tw-mb-4 tw-flex tw-items-center tw-gap-2">
+            <label htmlFor="phase-filter" className="tw-text-sm tw-font-medium">
+                Filter by phase:
+            </label>
+            <select
+                id="phase-filter"
+                className="tw-rounded tw-border tw-border-gray-300 tw-py-1 tw-px-2 tw-text-sm tw-dark:tw-border-gray-700 tw-dark:tw-bg-gray-800"
+                value={phaseFilter}
+                onChange={handlePhaseFilterChange}
+            >
+                {ALL_PHASES.map(phase => (
+                    <option key={phase} value={phase}>
+                        {phase}
+                    </option>
+                ))}
+            </select>
+            {phaseFilter !== 'All Phases' && (
+                <div className="tw-text-sm tw-text-gray-500">
+                    Showing {filteredEntries.length} of {entries.length} entries
+                </div>
+            )}
+        </div>
+    )
+
     // Render the entries list component to avoid duplication
     const entriesList = (
         <div className="tw-flex tw-flex-col tw-gap-2 tw-p-2">
-            {entries.map(entry => (
-                <AutoeditListItem
-                    key={entry.state.requestId}
-                    entry={entry}
-                    isSelected={entry.state.requestId === selectedEntryId}
-                    onSelect={handleEntrySelect}
-                />
-            ))}
+            {filteredEntries.length === 0 ? (
+                <div className="tw-p-4 tw-text-center tw-text-gray-500">
+                    No entries match the selected phase filter
+                </div>
+            ) : (
+                filteredEntries.map(entry => (
+                    <AutoeditListItem
+                        key={entry.state.requestId}
+                        entry={entry}
+                        isSelected={entry.state.requestId === selectedEntryId}
+                        onSelect={handleEntrySelect}
+                    />
+                ))
+            )}
         </div>
     )
 
     // When no entry is selected, display the list at full width
     if (!selectedEntry) {
-        return <div className="tw-h-full tw-overflow-y-auto">{entriesList}</div>
+        return (
+            <div className="tw-h-full tw-overflow-y-auto">
+                {phaseFilterDropdown}
+                {entriesList}
+            </div>
+        )
     }
 
     // When an entry is selected, display the split view
@@ -71,6 +187,7 @@ export const AutoeditDebugPanel: FC<{ entries: AutoeditRequestDebugState[] }> = 
         <div className="tw-flex tw-h-full tw-overflow-hidden">
             {/* List panel (left side) */}
             <div className="tw-w-2/5 tw-overflow-y-auto tw-border-r tw-border-gray-200 tw-dark:tw-border-gray-700 tw-pr-2">
+                {phaseFilterDropdown}
                 {entriesList}
             </div>
 
@@ -81,11 +198,8 @@ export const AutoeditDebugPanel: FC<{ entries: AutoeditRequestDebugState[] }> = 
                     onPrevious={handlePrevious}
                     onNext={handleNext}
                     onClose={handleClose}
-                    hasPrevious={entries.findIndex(e => e.state.requestId === selectedEntryId) > 0}
-                    hasNext={
-                        entries.findIndex(e => e.state.requestId === selectedEntryId) <
-                        entries.length - 1
-                    }
+                    hasPrevious={hasPrevious}
+                    hasNext={hasNext}
                 />
             </div>
         </div>

--- a/vscode/webviews/autoedit-debug/autoedit-data-sdk.ts
+++ b/vscode/webviews/autoedit-debug/autoedit-data-sdk.ts
@@ -131,7 +131,7 @@ export const getPositionInfo = (entry: AutoeditRequestDebugState): string => {
         const line = entry.state.position.line !== undefined ? entry.state.position.line + 1 : '?'
         const character =
             entry.state.position.character !== undefined ? entry.state.position.character : '?'
-        return `Line ${line}:${character}`
+        return `${line}:${character}`
     }
     return ''
 }

--- a/vscode/webviews/autoedit-debug/components/AutoeditDetailView.tsx
+++ b/vscode/webviews/autoedit-debug/components/AutoeditDetailView.tsx
@@ -10,6 +10,7 @@ import { Button } from '../../components/shadcn/ui/button'
 import { AutoeditDataSDK } from '../autoedit-data-sdk'
 import { getStatusColor } from '../autoedit-ui-utils'
 import { AutoeditsConfigSection } from '../sections/AutoeditsConfigSection'
+import { CodeToRewriteDataSection } from '../sections/CodeToRewriteDataSection'
 import { ContextInfoSection } from '../sections/ContextInfoSection'
 import { NetworkRequestSection, NetworkResponseSection } from '../sections/NetworkRequestSection'
 import { PromptSection } from '../sections/PromptSection'
@@ -142,6 +143,9 @@ export const AutoeditDetailView: FC<{
                         <TabButton value="prompt" activeTab={activeTab}>
                             Prompt
                         </TabButton>
+                        <TabButton value="code-to-rewrite-data" activeTab={activeTab}>
+                            Code To Rewrite Data
+                        </TabButton>
                         <TabButton value="context" activeTab={activeTab}>
                             Context
                         </TabButton>
@@ -180,6 +184,10 @@ export const AutoeditDetailView: FC<{
 
                     <TabsPrimitive.Content value="config" className="tw-space-y-8">
                         <AutoeditsConfigSection entry={entry} />
+                    </TabsPrimitive.Content>
+
+                    <TabsPrimitive.Content value="code-to-rewrite-data" className="tw-space-y-8">
+                        <CodeToRewriteDataSection entry={entry} />
                     </TabsPrimitive.Content>
                 </div>
             </TabsPrimitive.Root>

--- a/vscode/webviews/autoedit-debug/sections/CodeToRewriteDataSection.tsx
+++ b/vscode/webviews/autoedit-debug/sections/CodeToRewriteDataSection.tsx
@@ -1,0 +1,204 @@
+import type { FC } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import type { AutoeditRequestDebugState } from '../../../src/autoedits/debug-panel/debug-store'
+
+export const CodeToRewriteDataSection: FC<{ entry: AutoeditRequestDebugState }> = ({ entry }) => {
+    // State to track whether the prompt is shown in fullscreen modal
+    const [isModalOpen, setIsModalOpen] = useState(false)
+    const [copySuccess, setCopySuccess] = useState(false)
+    const codeToRewriteDataRef = useRef<HTMLPreElement>(null)
+
+    const codeToRewriteData = 'codeToReplaceData' in entry.state ? entry.state.codeToReplaceData : null
+
+    // Format the prompt content
+    const formattedCodeToRewriteData = formatCodeToRewriteData()
+
+    // Close modal with Escape key
+    const handleKeyDown = useCallback(
+        (event: KeyboardEvent) => {
+            if (event.key === 'Escape' && isModalOpen) {
+                setIsModalOpen(false)
+            }
+        },
+        [isModalOpen]
+    )
+
+    // Add and remove event listener
+    useEffect(() => {
+        if (isModalOpen) {
+            document.addEventListener('keydown', handleKeyDown)
+            // Prevent scrolling of the background when modal is open
+            document.body.style.overflow = 'hidden'
+        }
+        return () => {
+            document.removeEventListener('keydown', handleKeyDown)
+            document.body.style.overflow = ''
+        }
+    }, [isModalOpen, handleKeyDown])
+
+    // Handle copying code to rewrite data
+    const handleCopyCodeToRewriteData = () => {
+        if (formattedCodeToRewriteData) {
+            navigator.clipboard
+                .writeText(formattedCodeToRewriteData)
+                .then(() => {
+                    setCopySuccess(true)
+                    setTimeout(() => setCopySuccess(false), 2000)
+                })
+                .catch(err => console.error('Failed to copy text: ', err))
+        }
+    }
+
+    // Format the code to rewrite data based on its type
+    function formatCodeToRewriteData(): string {
+        if (!codeToRewriteData) {
+            return 'No code to rewrite data available'
+        }
+
+        // Custom formatter for the code to rewrite data with XML tags
+        try {
+            const obj =
+                typeof codeToRewriteData === 'string' ? JSON.parse(codeToRewriteData) : codeToRewriteData
+
+            // Define the display order of fields
+            const fieldOrder = [
+                'prefixBeforeArea',
+                'suffixAfterArea',
+                'prefixInArea',
+                'codeToRewrite',
+                'suffixInArea',
+            ]
+
+            let result = ''
+
+            // Process fields in the specified order
+            for (const field of fieldOrder) {
+                if (field in obj) {
+                    const value = obj[field]
+                    result += `<${field}>\n${value}\n</${field}>\n`
+                }
+            }
+
+            // Add any remaining fields not in the specified order
+            for (const [key, value] of Object.entries(obj)) {
+                if (!fieldOrder.includes(key)) {
+                    result += `<${key}>\n${
+                        typeof value === 'string' ? value : JSON.stringify(value, null, 2)
+                    }\n</${key}>\n`
+                }
+            }
+
+            return result
+        } catch (error) {
+            // Fallback to standard JSON formatting if anything goes wrong
+            return JSON.stringify(codeToRewriteData, null, 2)
+        }
+    }
+
+    // Don't render anything if there's no code to rewrite data
+    if (!codeToRewriteData) {
+        return null
+    }
+
+    // CSS classes for code to rewrite data - always using full height now
+    const codeToRewriteDataClass =
+        'tw-bg-gray-50 tw-dark:tw-bg-gray-800 tw-p-4 tw-rounded tw-text-xs tw-font-mono tw-border-0 tw-m-0 tw-text-gray-800 dark:tw-text-gray-200 tw-leading-relaxed tw-whitespace-pre-wrap tw-h-full tw-overflow-y-auto'
+
+    return (
+        <>
+            {/* Prompt display section */}
+            <div className="tw-mb-4 tw-flex tw-flex-col tw-h-full">
+                <div className="tw-flex tw-justify-end tw-items-center tw-mb-2">
+                    <div className="tw-flex tw-space-x-2">
+                        {/* Copy button */}
+                        <button
+                            type="button"
+                            onClick={handleCopyCodeToRewriteData}
+                            className="tw-text-xs tw-text-gray-600 hover:tw-text-gray-800 dark:tw-text-gray-400 dark:hover:tw-text-gray-200 tw-rounded tw-px-2 tw-py-1 tw-bg-gray-100 hover:tw-bg-gray-200 dark:tw-bg-gray-700 dark:hover:tw-bg-gray-600 tw-transition-colors tw-duration-150"
+                            title="Copy prompt to clipboard"
+                            aria-label="Copy prompt to clipboard"
+                        >
+                            {copySuccess ? 'Copied!' : 'Copy'}
+                        </button>
+
+                        {/* Fullscreen button */}
+                        <button
+                            type="button"
+                            onClick={() => setIsModalOpen(true)}
+                            className="tw-text-xs tw-text-gray-600 hover:tw-text-gray-800 dark:tw-text-gray-400 dark:hover:tw-text-gray-200 tw-rounded tw-px-2 tw-py-1 tw-bg-gray-100 hover:tw-bg-gray-200 dark:tw-bg-gray-700 dark:hover:tw-bg-gray-600 tw-transition-colors tw-duration-150"
+                            title="View in fullscreen"
+                            aria-label="View code to rewrite data in fullscreen"
+                        >
+                            Fullscreen
+                        </button>
+                    </div>
+                </div>
+
+                {/* Prompt content with enhanced styling using CSS classes instead of inline styles */}
+                <div
+                    className="tw-border tw-border-gray-200 dark:tw-border-gray-700 tw-rounded-md tw-max-h-100 tw-overflow-y-auto"
+                    role="region"
+                    aria-label="Prompt content"
+                >
+                    <pre ref={codeToRewriteDataRef} className={codeToRewriteDataClass}>
+                        {formattedCodeToRewriteData}
+                    </pre>
+                </div>
+            </div>
+
+            {/* Fullscreen modal with improved UX */}
+            {isModalOpen && (
+                <div
+                    className="tw-fixed tw-inset-0 tw-z-50 tw-flex tw-items-center tw-justify-center tw-p-4 tw-bg-black tw-bg-opacity-80 tw-backdrop-blur-sm tw-transition-opacity tw-duration-300"
+                    role="dialog"
+                    aria-modal="true"
+                    aria-labelledby="modal-title"
+                >
+                    <div className="tw-bg-white tw-dark:tw-bg-gray-900 tw-rounded-lg tw-shadow-xl tw-w-full tw-h-full tw-max-w-screen-xl tw-max-h-screen tw-flex tw-flex-col">
+                        {/* Modal header */}
+                        <div className="tw-flex tw-justify-between tw-items-center tw-p-4 tw-border-b tw-border-gray-200 tw-dark:tw-border-gray-700">
+                            <h2
+                                id="modal-title"
+                                className="tw-text-lg tw-font-medium tw-text-gray-900 dark:tw-text-gray-100"
+                            >
+                                Code To Rewrite Data
+                            </h2>
+
+                            <div className="tw-flex tw-space-x-2">
+                                {/* Copy button in modal */}
+                                <button
+                                    type="button"
+                                    onClick={handleCopyCodeToRewriteData}
+                                    className="tw-flex tw-items-center tw-px-3 tw-py-1.5 tw-text-sm tw-font-medium tw-rounded-md tw-bg-gray-100 hover:tw-bg-gray-200 tw-text-gray-700 dark:tw-bg-gray-700 dark:hover:tw-bg-gray-600 dark:tw-text-gray-200 tw-transition-colors tw-duration-150"
+                                    aria-label="Copy code to rewrite data to clipboard"
+                                >
+                                    {copySuccess ? 'Copied!' : 'Copy code to rewrite data'}
+                                </button>
+
+                                {/* Close button */}
+                                <button
+                                    type="button"
+                                    onClick={() => setIsModalOpen(false)}
+                                    className="tw-flex tw-items-center tw-px-3 tw-py-1.5 tw-text-sm tw-font-medium tw-rounded-md tw-bg-gray-100 hover:tw-bg-gray-200 tw-text-gray-700 dark:tw-bg-gray-700 dark:hover:tw-bg-gray-600 dark:tw-text-gray-200 tw-transition-colors tw-duration-150"
+                                    aria-label="Close modal"
+                                >
+                                    Close (Esc)
+                                </button>
+                            </div>
+                        </div>
+
+                        {/* Modal body */}
+                        <div className="tw-flex-grow tw-overflow-hidden">
+                            <div className="tw-h-full tw-overflow-auto tw-rounded-md tw-bg-gray-50 tw-dark:tw-bg-gray-800 tw-border tw-border-gray-200 dark:tw-border-gray-700">
+                                <pre className="tw-whitespace-pre-wrap tw-font-mono tw-text-sm tw-p-5 tw-m-0 tw-h-full tw-overflow-y-auto tw-text-gray-800 dark:tw-text-gray-200 tw-leading-relaxed">
+                                    {formattedCodeToRewriteData}
+                                </pre>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            )}
+        </>
+    )
+}

--- a/vscode/webviews/autoedit-debug/sections/NetworkRequestSection.tsx
+++ b/vscode/webviews/autoedit-debug/sections/NetworkRequestSection.tsx
@@ -30,7 +30,7 @@ export const NetworkRequestSection: FC<{
             {modelResponse?.requestHeaders && (
                 <div className="tw-col-span-2">
                     <h4 className="tw-text-sm tw-font-medium tw-mb-2">Request Headers</h4>
-                    <div className="tw-bg-gray-100 tw-dark:tw-bg-gray-800 tw-p-3 tw-rounded tw-text-xs tw-max-h-60 tw-overflow-y-auto">
+                    <div className="tw-bg-gray-100 tw-dark:tw-bg-gray-800 tw-p-3 tw-rounded tw-text-xs tw-max-h-160 tw-overflow-y-auto">
                         {Object.entries(modelResponse.requestHeaders).map(([key, value]) => (
                             <div key={key} className="tw-mb-1">
                                 <span className="tw-font-medium">{key}:</span>{' '}

--- a/vscode/webviews/autoedit-debug/sections/TimelineSection.tsx
+++ b/vscode/webviews/autoedit-debug/sections/TimelineSection.tsx
@@ -80,7 +80,7 @@ export const TimelineSection: FC<TimelineSectionProps> = ({ entry }) => {
                                     segment.duration
                                 )}`}
                             >
-                                <span className="tw-text-sm tw-font-medium tw-text-white tw-drop-shadow-md">
+                                <span className="tw-text-xxs tw-font-medium tw-text-white tw-drop-shadow-md">
                                     {formatLatency(segment.duration)}
                                 </span>
                             </div>

--- a/vscode/webviews/components/codeSnippet/CodeSnippet.tsx
+++ b/vscode/webviews/components/codeSnippet/CodeSnippet.tsx
@@ -17,12 +17,7 @@ import type { ChunkMatch, HighlightLineRange, MatchGroup, SearchMatch } from './
 
 import { FileMatchChildren } from './components/FileMatchChildren'
 import { RepoFileLink } from './components/RepoLink'
-import {
-    type ForwardReferenceExoticComponent,
-    formatRepositoryStarCount,
-    getRevision,
-    pluralize,
-} from './utils'
+import { type ForwardReferenceExoticComponent, formatRepositoryStarCount, getRevision } from './utils'
 
 import { CodyIDE } from '@sourcegraph/cody-shared'
 import type {
@@ -123,7 +118,6 @@ export const FileMatchSearchResult: FC<PropsWithChildren<FileMatchSearchResultPr
     const collapsedGroups = truncateGroups(expandedGroups, 1, 1)
     const expandedHighlightCount = countHighlightRanges(expandedGroups)
     const collapsedHighlightCount = countHighlightRanges(collapsedGroups)
-    const hiddenMatchesCount = expandedHighlightCount - collapsedHighlightCount
     const expandable = !showAllMatches && expandedHighlightCount > collapsedHighlightCount
 
     useEffect(() => setExpanded(allExpanded || defaultExpanded), [allExpanded, defaultExpanded])
@@ -276,13 +270,7 @@ export const FileMatchSearchResult: FC<PropsWithChildren<FileMatchSearchResultPr
                         onClick={toggleExpand}
                     >
                         <span className={styles.toggleMatchesButtonText}>
-                            {expanded
-                                ? 'Show less'
-                                : `Show ${hiddenMatchesCount} more ${pluralize(
-                                      'match',
-                                      hiddenMatchesCount,
-                                      'matches'
-                                  )}`}
+                            {expanded ? 'Show less' : 'Show more'}
                         </span>
                     </button>
                 )}


### PR DESCRIPTION
- Adds inference time to the list view of the debug panel.
- Adds an ability to filter out items from the list view the stage they reached. (e.g., show only suggested+ items).
- Adds code to rewrite data section that allows inspecting parts of the prompt (used for the dynamic document prefix and suffix debugging).
- Mostly implemented with Claude 3.7 and agents 😛
- Closes [CODY-5330: Add inference time to the auto-edit debug panel list view](https://linear.app/sourcegraph/issue/CODY-5330/add-inference-time-to-the-auto-edit-debug-panel-list-view)

<img width="1498" alt="Screenshot 2025-03-13 at 19 54 42" src="https://github.com/user-attachments/assets/107a7849-61db-429b-ac0d-b062db459c0b" />

## Test plan

CI + manual testing with the debug panel locally
