### PR TITLE
chore(auto-edit): fix accept/reject analytics events

### DIFF
--- a/vscode/src/autoedits/analytics-logger/analytics-logger.test.ts
+++ b/vscode/src/autoedits/analytics-logger/analytics-logger.test.ts
@@ -21,6 +21,7 @@ import { AutoeditAnalyticsLogger } from './analytics-logger'
 import {
     type AutoeditRequestID,
     autoeditDiscardReason,
+    autoeditRejectReason,
     autoeditSource,
     autoeditTriggerKind,
 } from './types'
@@ -138,7 +139,10 @@ describe('AutoeditAnalyticsLogger', () => {
         }
 
         if (finalPhase === 'rejected') {
-            autoeditLogger.markAsRejected(requestId)
+            autoeditLogger.markAsRejected({
+                requestId,
+                rejectReason: autoeditRejectReason.dismissCommand,
+            })
         }
 
         return requestId
@@ -345,7 +349,10 @@ describe('AutoeditAnalyticsLogger', () => {
 
         // Both calls below are invalid transitions, so the logger logs debug events
         autoeditLogger.markAsSuggested(requestId)
-        autoeditLogger.markAsRejected(requestId)
+        autoeditLogger.markAsRejected({
+            requestId,
+            rejectReason: autoeditRejectReason.dismissCommand,
+        })
 
         expect(recordSpy).toHaveBeenCalledTimes(2)
         expect(recordSpy).toHaveBeenNthCalledWith(1, 'cody.autoedit', 'invalidTransitionToSuggested', {

--- a/vscode/src/autoedits/analytics-logger/analytics-logger.ts
+++ b/vscode/src/autoedits/analytics-logger/analytics-logger.ts
@@ -31,6 +31,7 @@ import { autoeditIdRegistry } from './suggestion-id-registry'
 import {
     type AcceptedState,
     type AutoeditDiscardReasonMetadata,
+    type AutoeditRejectReasonMetadata,
     type AutoeditRequestID,
     type ContextLoadedState,
     type DiscardedState,
@@ -292,7 +293,13 @@ export class AutoeditAnalyticsLogger {
         }
     }
 
-    public markAsRejected(requestId: AutoeditRequestID): void {
+    public markAsRejected({
+        requestId,
+        rejectReason,
+    }: {
+        requestId: AutoeditRequestID
+        rejectReason: AutoeditRejectReasonMetadata
+    }): void {
         const rejectedAt = getTimeNowInMillis()
 
         const result = this.tryTransitionTo(requestId, 'rejected', request => ({
@@ -304,6 +311,7 @@ export class AutoeditAnalyticsLogger {
                 isRead: 'readAt' in request,
                 timeFromSuggestedAt: rejectedAt - request.suggestedAt,
                 suggestionsStartedSinceLastSuggestion: this.autoeditsStartedSinceLastSuggestion,
+                rejectReason,
             },
         }))
 

--- a/vscode/src/autoedits/analytics-logger/types.ts
+++ b/vscode/src/autoedits/analytics-logger/types.ts
@@ -118,6 +118,20 @@ export const autoeditDiscardReason = {
 export type AutoeditDiscardReasonMetadata =
     (typeof autoeditDiscardReason)[keyof typeof autoeditDiscardReason]
 
+export const autoeditRejectReason = {
+    dismissCommand: 1,
+    onDidChangeTextDocument: 2,
+    onDidChangeActiveTextEditor: 3,
+    onDidCloseTextDocument: 4,
+    onDidChangeTextEditorSelection: 5,
+    handleDidShowSuggestion: 6,
+    acceptActiveEdit: 7,
+    disposal: 8,
+} as const
+
+export type AutoeditRejectReasonMetadata =
+    (typeof autoeditRejectReason)[keyof typeof autoeditRejectReason]
+
 /**
  * A stable ID that identifies a particular autoedit suggestion. If the same text
  * and context recurs, we reuse this ID to avoid double-counting.
@@ -307,7 +321,10 @@ export interface RejectedState extends Omit<SuggestedState, 'phase' | 'payload'>
     suggestionLoggedAt?: number
     /** Optional because it might be accepted before the read timeout */
     readAt?: number
-    payload: FinalPayload
+    payload: FinalPayload & {
+        /** Reason why the suggestion was rejected. */
+        rejectReason: AutoeditRejectReasonMetadata
+    }
 }
 
 export interface DiscardedState extends Omit<StartedState, 'phase' | 'payload'> {

--- a/vscode/src/autoedits/autoedits-provider.test.ts
+++ b/vscode/src/autoedits/autoedits-provider.test.ts
@@ -275,6 +275,7 @@ describe('AutoeditsProvider', () => {
               "latency": 120,
               "otherCompletionProviderEnabled": 0,
               "recordsPrivateMetadataTranscript": 1,
+              "rejectReason": 1,
               "source": 1,
               "suggestionsStartedSinceLastSuggestion": 2,
               "timeFromSuggestedAt": 375,

--- a/vscode/src/autoedits/renderer/inline-manager.ts
+++ b/vscode/src/autoedits/renderer/inline-manager.ts
@@ -75,15 +75,7 @@ export class AutoEditsInlineRendererManager
         event: vscode.TextEditorSelectionChangeEvent
     ): Promise<void> {
         if (
-            this.hasInlineCompletionItems() &&
-            // If we do not have inline decorations, the dismissal of the completion will
-            // automatically be handled by VS Code. Without this check, we will falsely
-            // reject an inline completion, because the `onDidChangeTextEditorSelection` callback
-            // can be fired before the inline-completion acceptance callback.
-            //
-            // I was not able to reproduce it in the E2E tests. For some reason the order of callbacks
-            // is different.
-            this.hasInlineDecorations() &&
+            this.activeRequest?.renderOutput.type === 'completion-with-decorations' &&
             areSameUriDocs(event.textEditor.document, this.activeRequest?.document)
         ) {
             // We are showing a completion alongisde decorations. The dismissal of the completion will


### PR DESCRIPTION
- @umpox, when an inline completion is accepted, the `onDocumentSelectionChange` callback is triggered before the acceptance callback, which means we were marking suggestions as rejected right after they were accepted and right before the acceptance callback was triggered. For some reason, the order of the callbacks is different in E2E tests (I tried to capture this bug there). But you can verify the unexpected behavior locally in the extension host with the auto-edit debug panel by generating suggestions with inline completions only and accepting them.
- Adds reject reason fields to the analytics events.
- Closes [CODY-4719: Investigate analytics logger invalid state transitions](https://linear.app/sourcegraph/issue/CODY-4719/investigate-analytics-logger-invalid-state-transitions)

## Test plan

CI + manually test this change locally because I was not able to catch it in E2E tests.
