### PR TITLE
fix(edit): initialize edit tool history for S2 only

### DIFF
--- a/vscode/src/chat/chat-view/ChatsController.ts
+++ b/vscode/src/chat/chat-view/ChatsController.ts
@@ -12,6 +12,7 @@ import {
     currentAuthStatus,
     currentAuthStatusAuthed,
     editorStateFromPromptString,
+    isS2,
     subscriptionDisposable,
     telemetryRecorder,
 } from '@sourcegraph/cody-shared'
@@ -40,6 +41,7 @@ import {
 } from './ChatController'
 import { chatHistory } from './ChatHistoryManager'
 import type { ContextRetriever } from './ContextRetriever'
+import { initializeEditToolHistory } from './tools/edit-history'
 
 export const CodyChatEditorViewType = 'cody.editorPanel'
 
@@ -85,6 +87,14 @@ export class ChatsController implements vscode.Disposable {
                     }
 
                     this.currentAuthAccount = authStatus.authenticated ? { ...authStatus } : undefined
+
+                    // Initialize the edit source control UI for S2 users only.
+                    if (authStatus.authenticated && isS2(authStatus.endpoint)) {
+                        const editSourceControl = initializeEditToolHistory()
+                        if (editSourceControl?.length) {
+                            this.disposables.push(...editSourceControl)
+                        }
+                    }
                 })
             )
         )

--- a/vscode/src/chat/chat-view/tools/edit-history.ts
+++ b/vscode/src/chat/chat-view/tools/edit-history.ts
@@ -25,7 +25,11 @@ const historyStore = new Map<string, HistoryItem>()
 /**
  * Initialize the edit history source control UI
  */
-export function initializeEditToolHistory(context: vscode.ExtensionContext): void {
+export function initializeEditToolHistory(): vscode.Disposable[] {
+    if (editSourceControl) {
+        return []
+    }
+
     // Create source control for edit history
     const workspaceUri = vscode.workspace.workspaceFolders?.[0]?.uri
     editSourceControl = vscode.scm.createSourceControl(
@@ -130,7 +134,7 @@ export function initializeEditToolHistory(context: vscode.ExtensionContext): voi
     }
 
     // Add all disposables to context
-    context.subscriptions.push(...disposables)
+    return disposables
 }
 
 /**

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -61,7 +61,6 @@ import { CodyToolProvider } from './chat/agentic/CodyToolProvider'
 import { ChatsController, CodyChatEditorViewType } from './chat/chat-view/ChatsController'
 import { ContextRetriever } from './chat/chat-view/ContextRetriever'
 import { SourcegraphRemoteFileProvider } from './chat/chat-view/sourcegraphRemoteFile'
-import { initializeEditToolHistory } from './chat/chat-view/tools/edit-history'
 import {
     ACCOUNT_LIMITS_INFO_URL,
     ACCOUNT_UPGRADE_URL,
@@ -238,7 +237,7 @@ const register = async (
     disposables.push(manageDisplayPathEnvInfoForExtension())
 
     // Initialize singletons
-    await initializeSingletons(context, platform, disposables)
+    await initializeSingletons(platform, disposables)
 
     setOpenCtxControllerObservable(observeOpenCtxController(context, platform.createOpenCtxController))
 
@@ -330,7 +329,6 @@ const register = async (
 }
 
 async function initializeSingletons(
-    context: vscode.ExtensionContext,
     platform: PlatformContext,
     disposables: vscode.Disposable[]
 ): Promise<void> {
@@ -341,7 +339,6 @@ async function initializeSingletons(
     if (platform.otherInitialization) {
         disposables.push(platform.otherInitialization())
     }
-    initializeEditToolHistory(context)
 }
 
 // Registers listeners to trigger parsing of visible documents


### PR DESCRIPTION
This commit initializes the edit tool history feature, but only for S2 users. This is done by:

-   Moving the `initializeEditToolHistory` function to `ChatsController.ts`
-   Conditionally initializing the edit source control UI based on the user's authentication status and endpoint.
-   Updating the `initializeEditToolHistory` function to return disposables.
-   Removing the initialization from `main.ts`

This ensures that the edit history feature is only available to the intended users during dogfood period.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

<img width="617" alt="image" src="https://github.com/user-attachments/assets/9eb3696e-0293-48ab-add3-0f3975171dd3" />


1. Log into S2 and confirm you can see the Cody Edit History panel in your source control tab
2. Log into a non-S2 instance and restart VS Code
3. Verify the Cody Edit History panel  doesn't show up

<img width="616" alt="image" src="https://github.com/user-attachments/assets/e2cb897d-2d6e-4370-9fdf-8e35a26a4958" />
