### PR TITLE
feat(chat): Disable smart apply toolbar in agentic chat

### DIFF
--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -558,7 +558,8 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
             serverEndpoint: auth.serverEndpoint,
             endpointHistory: [...endpoints],
             experimentalNoodle: configuration.experimentalNoodle,
-            smartApply: this.isSmartApplyEnabled(),
+            // Disable smart apply codeblock toolbar when agentic chat is enabled.
+            smartApply: this.isSmartApplyEnabled() && !experimentalAgenticChatEnabled,
             hasEditCapability: this.hasEditCapability(),
             webviewType,
             multipleWebviewsEnabled: !sidebarViewOnly,


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-5389/in-agentic-mode-never-show-the-smart-apply-bar

Disables the smart apply codeblock toolbar when the experimental agentic chat feature is enabled. This prevents potential conflicts or usability issues between the two features.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

1. Switch 2 S2 and ask cody to output a code block
2. confirm the code block doesnt come with a smart apply button


<img width="653" alt="image" src="https://github.com/user-attachments/assets/7ecca015-c082-4793-a531-9ff7c9577b9c" />
