### PR TITLE
feat(agentic chat): use different models for first turn and subsequent turns

### DIFF
--- a/vscode/src/chat/chat-view/handlers/AgenticHandler.ts
+++ b/vscode/src/chat/chat-view/handlers/AgenticHandler.ts
@@ -18,6 +18,13 @@ import { ChatHandler } from './ChatHandler'
 import type { AgentHandler, AgentHandlerDelegate, AgentRequest } from './interfaces'
 import { buildAgentPrompt } from './prompts'
 
+const AGENT_MODELS = {
+    // Loop 0 will be run with Claude 3.7 Sonnet with Extended Thinking.
+    0: 'anthropic::2024-10-22::claude-3-7-sonnet-extended-thinking',
+    // Loop 1+ will be run with Claude 3.7 Sonnet.
+    1: 'anthropic::2024-10-22::claude-3-7-sonnet',
+}
+
 /**
  * Base AgenticHandler class that manages tool execution state
  * and implements the core agentic conversation loop
@@ -234,7 +241,7 @@ export class AgenticHandler extends ChatHandler implements AgentHandler {
                 },
             })),
             stream: true,
-            model,
+            model: AGENT_MODELS[this.turnCount === 0 ? 0 : 1],
         }
 
         // Track tool calls across stream chunks
@@ -246,6 +253,7 @@ export class AgenticHandler extends ChatHandler implements AgentHandler {
                 speaker: 'assistant',
                 text: PromptString.unsafe_fromLLMResponse(streamed.text),
                 model,
+                intent: 'agentic',
             }) satisfies ChatMessage
 
         // Process stream chunks

--- a/vscode/src/chat/chat-view/handlers/AgenticHandler.ts
+++ b/vscode/src/chat/chat-view/handlers/AgenticHandler.ts
@@ -18,11 +18,9 @@ import { ChatHandler } from './ChatHandler'
 import type { AgentHandler, AgentHandlerDelegate, AgentRequest } from './interfaces'
 import { buildAgentPrompt } from './prompts'
 
-const AGENT_MODELS = {
-    // Loop 0 will be run with Claude 3.7 Sonnet with Extended Thinking.
-    0: 'anthropic::2024-10-22::claude-3-7-sonnet-extended-thinking',
-    // Loop 1+ will be run with Claude 3.7 Sonnet.
-    1: 'anthropic::2024-10-22::claude-3-7-sonnet',
+enum AGENT_MODELS {
+    ExtendedThinking = 'anthropic::2024-10-22::claude-3-7-sonnet-extended-thinking',
+    Base = 'anthropic::2024-10-22::claude-3-7-sonnet',
 }
 
 /**
@@ -241,7 +239,7 @@ export class AgenticHandler extends ChatHandler implements AgentHandler {
                 },
             })),
             stream: true,
-            model: AGENT_MODELS[this.turnCount === 0 ? 0 : 1],
+            model: this.turnCount === 0 ? AGENT_MODELS.ExtendedThinking : AGENT_MODELS.Base,
         }
 
         // Track tool calls across stream chunks


### PR DESCRIPTION

This commit updates the agentic chat handler to use a different LLM model for the first turn of a conversation compared to subsequent turns. The first turn will use `anthropic::2024-10-22::claude-3-7-sonnet-extended-thinking` and subsequent turns will use `anthropic::2024-10-22::claude-3-7-sonnet-latest`. This allows for extended thinking on the first turn.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

When running the agent, confirm that:
1. The first message you sent in aan empty chat should show you there is a thinking process 
2. All the follow up should not have the Thought Process header to indicate the thinking mode l is not being used

<img width="637" alt="image" src="https://github.com/user-attachments/assets/ef6e9be0-5466-42f2-8f13-0ba0b5c05f3d" />
