### PR TITLE
chore(auto-edit): ensure aborts are propagated to the provider

### DIFF
--- a/lib/shared/src/inferenceClient/misc.ts
+++ b/lib/shared/src/inferenceClient/misc.ts
@@ -38,6 +38,10 @@ export type CompletionResponseWithMetaData = {
     completionResponse?: CompletionResponse
     metadata?: {
         /**
+         * Whether the request was aborted before we got any response.
+         */
+        isAborted?: boolean
+        /**
          * Yield response from HTTP clients to a logic shared across providers to
          * extract metadata required for analytics in one place.
          */
@@ -57,10 +61,7 @@ export type CompletionResponseWithMetaData = {
     }
 }
 
-export type CompletionResponseGenerator = AsyncGenerator<
-    CompletionResponseWithMetaData,
-    CompletionResponseWithMetaData
->
+export type CompletionResponseGenerator = AsyncGenerator<CompletionResponseWithMetaData, void>
 
 export interface CodeCompletionProviderOptions {
     /**

--- a/lib/shared/src/llm-providers/ollama/completions-client.ts
+++ b/lib/shared/src/llm-providers/ollama/completions-client.ts
@@ -75,7 +75,8 @@ export function createOllamaClient(
             completionResponse.stopReason = CompletionStopReason.RequestFinished
             log?.onComplete(completionResponse)
 
-            return { completionResponse }
+            yield { completionResponse }
+            return
         } catch (error) {
             if (!isAbortError(error) && isError(error)) {
                 log?.onError(error.message, error)

--- a/vscode/src/autoedits/adapters/sourcegraph-completions.ts
+++ b/vscode/src/autoedits/adapters/sourcegraph-completions.ts
@@ -46,7 +46,7 @@ export class SourcegraphCompletionsAdapter implements AutoeditsModelAdapter {
             let responseHeaders: Record<string, string> = {}
             let requestHeaders: Record<string, string> = {}
             let requestUrl = options.url
-            let stopReason: string | undefined = undefined
+            let isAborted = false
 
             for await (const msg of completionResponseGenerator) {
                 const newText = msg.completionResponse?.completion
@@ -73,10 +73,13 @@ export class SourcegraphCompletionsAdapter implements AutoeditsModelAdapter {
                         requestUrl = msg.metadata.requestUrl
                     }
 
+                    if (msg.metadata.isAborted) {
+                        isAborted = true
+                    }
+
                     // Store the full response body if available
                     if (msg.completionResponse) {
                         responseBody = msg.completionResponse
-                        stopReason = msg.completionResponse.stopReason
                     }
                 }
             }
@@ -89,7 +92,7 @@ export class SourcegraphCompletionsAdapter implements AutoeditsModelAdapter {
                 responseBody,
             }
 
-            if (stopReason === 'cody-request-aborted') {
+            if (isAborted) {
                 return {
                     ...sharedResult,
                     type: 'aborted',

--- a/vscode/src/autoedits/adapters/utils.ts
+++ b/vscode/src/autoedits/adapters/utils.ts
@@ -1,4 +1,10 @@
-import { type Message, type PromptString, charsToTokens, isAbortError } from '@sourcegraph/cody-shared'
+import {
+    type Message,
+    type PromptString,
+    charsToTokens,
+    fetch,
+    isAbortError,
+} from '@sourcegraph/cody-shared'
 import type { AbortedModelResponse, ModelResponseShared, SuccessModelResponse } from './base'
 import type { InceptionLabsRequestParams } from './inceptionlabs'
 

--- a/vscode/src/autoedits/autoedits-provider.ts
+++ b/vscode/src/autoedits/autoedits-provider.ts
@@ -289,6 +289,19 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
                 return null
             }
 
+            const initialPrediction = predictionResult.prediction
+
+            autoeditAnalyticsLogger.markAsLoaded({
+                requestId,
+                prompt,
+                modelResponse: predictionResult,
+                payload: {
+                    source: autoeditSource.network,
+                    isFuzzyMatch: false,
+                    prediction: initialPrediction,
+                },
+            })
+
             if (predictionResult.prediction.length === 0) {
                 autoeditsOutputChannelLogger.logDebugIfVerbose(
                     'provideInlineCompletionItems',
@@ -302,18 +315,6 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
                 return null
             }
 
-            const initialPrediction = predictionResult.prediction
-
-            autoeditAnalyticsLogger.markAsLoaded({
-                requestId,
-                prompt,
-                modelResponse: predictionResult,
-                payload: {
-                    source: autoeditSource.network,
-                    isFuzzyMatch: false,
-                    prediction: initialPrediction,
-                },
-            })
             autoeditsOutputChannelLogger.logDebug(
                 'provideInlineCompletionItems',
                 `"${requestId}" ============= Response:\n${initialPrediction}\n` +

--- a/vscode/src/completions/get-inline-completions-tests/helpers.ts
+++ b/vscode/src/completions/get-inline-completions-tests/helpers.ts
@@ -139,16 +139,18 @@ export function params(
             }
 
             if (responses === 'never-resolve') {
-                return new Promise(() => {})
+                yield new Promise<CompletionResponseWithMetaData>(() => {})
+                return
             }
 
             const response = responses[requestCounter++]
 
             if (response && 'completionResponse' in response) {
-                return response
+                yield response
+                return
             }
 
-            return {
+            yield {
                 completionResponse: (response as CompletionResponse) || {
                     completion: '',
                     stopReason: 'unknown',


### PR DESCRIPTION
- The diff is much smaller with hidden whitespace changes.
- Closes [CODY-5399: Fix network request abort error propagation to the auto-edit provider](https://linear.app/sourcegraph/issue/CODY-5399/fix-network-request-abort-error-propagation-to-the-auto-edit-provider)
- Wraps `fetch` calls into try/catch blocks to catch abort errors that happen before we reach the network.
- Updates the code completions API clients to `yield` abort errors from the generator as a part of the iteration loop instead of ending the generator and `return`ing the value which required an additional check which we do not have in many places: 

```ts
const finalResult = await generator.next();
if (finalResult.done) {
  console.log("Final return value:", finalResult.value);
}
```

This ensures that `for await (const msg of completionResponseGenerator) { ... }` consumes all the values consistently. 

## Test plan

CI + manually inspect with the auto-edit debug panel to see if more "client aborted" items are added to the list.