### PR TITLE
Add in-memory cache for autoedit suggestion images

### DIFF
--- a/vscode/src/autoedits/renderer/decorators/default-decorator.ts
+++ b/vscode/src/autoedits/renderer/decorators/default-decorator.ts
@@ -225,6 +225,8 @@ export class DefaultDecorator implements AutoEditsDecorator {
             diff,
             lang: this.editor.document.languageId,
             mode: diffMode,
+            // DefaultDecorator doesn't have access to requestId
+            // requestId is undefined - this is OK as it will just not use the cache
         })
         const startLineEndColumn = getEndColumnForLine(
             this.editor.document.lineAt(target.line),
@@ -272,8 +274,12 @@ export class DefaultDecorator implements AutoEditsDecorator {
                         margin: `0 0 0 ${decorationMargin}ch`,
                     },
                     // Provide different highlighting for dark/light themes
-                    dark: { before: { contentIconPath: vscode.Uri.parse(dark) } },
-                    light: { before: { contentIconPath: vscode.Uri.parse(light) } },
+                    dark: {
+                        before: { contentIconPath: vscode.Uri.parse(dark) },
+                    },
+                    light: {
+                        before: { contentIconPath: vscode.Uri.parse(light) },
+                    },
                 },
             },
         ])

--- a/vscode/src/autoedits/renderer/image-gen/test/index.test.ts
+++ b/vscode/src/autoedits/renderer/image-gen/test/index.test.ts
@@ -1,8 +1,14 @@
 import { toMatchImageSnapshot } from 'jest-image-snapshot'
-import { describe, expect, it } from 'vitest'
-import { generateSuggestionAsImage, initImageSuggestionService } from '..'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+    clearCachedImage,
+    clearImageCache,
+    generateSuggestionAsImage,
+    initImageSuggestionService,
+} from '..'
 import { document } from '../../../../completions/test-helpers'
 import { mockLocalStorage } from '../../../../services/LocalStorageProvider'
+import type { AutoeditRequestID } from '../../../analytics-logger'
 import type { DecorationInfo } from '../../decorators/base'
 import { makeVisualDiff } from '../visual-diff'
 import type { DiffMode } from '../visual-diff/types'
@@ -97,6 +103,154 @@ describe('generateSuggestionAsImage', () => {
             expect(darkBuffer).toMatchImageSnapshot({
                 customSnapshotIdentifier: 'no-highlighting-unified-suggestion-dark',
             })
+        })
+    })
+
+    describe('image caching', () => {
+        beforeEach(() => {
+            // Clear cache before each test
+            clearImageCache()
+        })
+
+        it('caches images by requestId', async () => {
+            // Setup test conditions
+            mockLocalStorage()
+            await initImageSuggestionService()
+
+            // Create a mock requestId
+            const mockRequestId = 'test-request-id' as AutoeditRequestID
+
+            // Create sample diff
+            const doc = document('')
+            const exampleDiff = MIXED_ADDITIONS_AND_DELETIONS.diff
+            const { diff } = makeVisualDiff(exampleDiff, 'unified', doc)
+
+            // Initial generation - should calculate and cache the image
+            const firstResult = generateSuggestionAsImage({
+                diff,
+                lang: 'typescript',
+                mode: 'unified',
+                requestId: mockRequestId,
+                config: {
+                    fontSize: 12,
+                    lineHeight: 18,
+                    backgroundColor: {
+                        dark: '#212121',
+                        light: '#f0f0f0',
+                    },
+                },
+            })
+
+            // Second generation with same requestId - should use cached version
+            const secondResult = generateSuggestionAsImage({
+                diff,
+                lang: 'typescript',
+                mode: 'unified',
+                requestId: mockRequestId,
+                config: {
+                    // Change config to verify cache is used (these changes should be ignored)
+                    fontSize: 14,
+                    lineHeight: 20,
+                    backgroundColor: {
+                        dark: '#000000',
+                        light: '#ffffff',
+                    },
+                },
+            })
+
+            // Images should be identical since the cache was used
+            expect(secondResult.dark).toBe(firstResult.dark)
+            expect(secondResult.light).toBe(firstResult.light)
+            expect(secondResult.pixelRatio).toBe(firstResult.pixelRatio)
+
+            // Verify with different requestId generates new image
+            const thirdResult = generateSuggestionAsImage({
+                diff,
+                lang: 'typescript',
+                mode: 'unified',
+                requestId: 'different-id' as AutoeditRequestID,
+                config: {
+                    // Same config as second call
+                    fontSize: 14,
+                    lineHeight: 20,
+                    backgroundColor: {
+                        dark: '#000000',
+                        light: '#ffffff',
+                    },
+                },
+            })
+
+            // Different requestId should generate different image
+            expect(thirdResult.dark).not.toBe(firstResult.dark)
+        })
+
+        it('clears specific images from cache', async () => {
+            // Setup
+            mockLocalStorage()
+            await initImageSuggestionService()
+
+            const mockRequestId = 'to-be-cleared' as AutoeditRequestID
+            const doc = document('')
+            const exampleDiff = MIXED_ADDITIONS_AND_DELETIONS.diff
+            const { diff } = makeVisualDiff(exampleDiff, 'unified', doc)
+
+            // Spy on the makeDecoratedDiff function to verify cache usage
+            const makeDecoratedDiffSpy = vi.spyOn(require('../decorated-diff'), 'makeDecoratedDiff')
+
+            // Generate and cache image
+            const firstResult = generateSuggestionAsImage({
+                diff,
+                lang: 'typescript',
+                mode: 'unified',
+                requestId: mockRequestId,
+                config: {
+                    fontSize: 12,
+                    lineHeight: 18,
+                    backgroundColor: { dark: '#212121', light: '#f0f0f0' },
+                },
+            })
+
+            expect(makeDecoratedDiffSpy).toHaveBeenCalledTimes(1)
+            makeDecoratedDiffSpy.mockClear()
+
+            // Generate again with same requestId - should use cache
+            generateSuggestionAsImage({
+                diff,
+                lang: 'typescript',
+                mode: 'unified',
+                requestId: mockRequestId,
+                config: {
+                    fontSize: 12,
+                    lineHeight: 18,
+                    backgroundColor: { dark: '#212121', light: '#f0f0f0' },
+                },
+            })
+
+            // Should not call makeDecoratedDiff again (using cache)
+            expect(makeDecoratedDiffSpy).not.toHaveBeenCalled()
+            makeDecoratedDiffSpy.mockClear()
+
+            // Clear the cache for this requestId
+            clearCachedImage(mockRequestId)
+
+            // Generate again - should create new image
+            generateSuggestionAsImage({
+                diff,
+                lang: 'typescript',
+                mode: 'unified',
+                requestId: mockRequestId,
+                config: {
+                    fontSize: 12,
+                    lineHeight: 18,
+                    backgroundColor: { dark: '#212121', light: '#f0f0f0' },
+                },
+            })
+
+            // Should call makeDecoratedDiff again after cache is cleared
+            expect(makeDecoratedDiffSpy).toHaveBeenCalledTimes(1)
+
+            // Clean up
+            makeDecoratedDiffSpy.mockRestore()
         })
     })
 })

--- a/vscode/src/autoedits/renderer/inline-manager.ts
+++ b/vscode/src/autoedits/renderer/inline-manager.ts
@@ -39,7 +39,8 @@ export class AutoEditsInlineRendererManager
         const { deletionDecorations } = this.getInlineDecorations(args.decorationInfo)
         const { insertionDecorations, insertMarkerDecorations } = this.createModifiedImageDecorations(
             args.document,
-            args.decorationInfo
+            args.decorationInfo,
+            args.requestId
         )
         return {
             type: 'image',

--- a/vscode/src/autoedits/renderer/render-output.ts
+++ b/vscode/src/autoedits/renderer/render-output.ts
@@ -305,7 +305,8 @@ export class AutoEditsRenderOutput {
 
     protected createModifiedImageDecorations(
         document: vscode.TextDocument,
-        decorationInfo: DecorationInfo
+        decorationInfo: DecorationInfo,
+        requestId?: AutoeditRequestID
     ): Omit<AutoEditDecorations, 'deletionDecorations'> {
         // TODO: Diff mode will likely change depending on the environment.
         // This should be determined by client capabilities.
@@ -317,6 +318,7 @@ export class AutoEditsRenderOutput {
             diff,
             lang: document.languageId,
             mode: diffMode,
+            requestId,
         })
         const startLineEndColumn = getEndColumnForLine(document.lineAt(target.line), document)
 


### PR DESCRIPTION
## Description

This PR implements an in-memory cache for autoedit suggestion images using the `AutoeditRequestID` as the cache key. The cache prevents regenerating the same image for repeated requests, improving performance.

## Changes

- Added Map to store generated images keyed by `AutoeditRequestID`
- Updated `generateSuggestionAsImage` function to check the cache first
- Added cache clearing functions for both individual images and the entire cache
- Updated all call sites to pass the requestId parameter when available
- Added tests for the caching functionality

## Testing

Added tests that verify:
- Images are cached correctly when using the same requestId
- Cache is properly invalidated when clearing specific images

These tests verify both the caching functionality and cache invalidation works as expected.