### PR TITLE
Fix current selection in ContextRetriever

### DIFF
--- a/vscode/src/chat/chat-view/ContextRetriever.ts
+++ b/vscode/src/chat/chat-view/ContextRetriever.ts
@@ -65,6 +65,12 @@ export function toStructuredMentions(mentions: ContextItem[]): StructuredMention
             case 'openctx':
                 openCtx.push(mention)
                 break
+            case 'current-selection':
+                files.push({
+                    ...mention,
+                    type: 'file',
+                } as ContextItemFile)
+                break
         }
     }
     return { repos, trees, files, symbols, openCtx, mediaFiles }


### PR DESCRIPTION
closes: https://linear.app/sourcegraph/issue/CODY-5282/current-selection-mention-not-fetching-context-from-code-range

The current selection context item was ignored while converting to structured mentions. 

## Test plan

- Mention current selection
- Make sure the context file is included