### PR TITLE
Update subscription type when switching acc without endpoint change

### DIFF
--- a/lib/shared/src/sourcegraph-api/userProductSubscription.ts
+++ b/lib/shared/src/sourcegraph-api/userProductSubscription.ts
@@ -3,7 +3,6 @@ import { authStatus } from '../auth/authStatus'
 import { logError } from '../logger'
 import {
     debounceTime,
-    distinctUntilChanged,
     firstValueFrom,
     pick,
     promiseFactoryToObservable,
@@ -39,7 +38,6 @@ export const userProductSubscription: Observable<
     UserProductSubscription | null | typeof pendingOperation
 > = authStatus.pipe(
     pick('authenticated', 'endpoint', 'pendingValidation'),
-    distinctUntilChanged(),
     debounceTime(0),
     switchMapReplayOperation(
         (authStatus): Observable<UserProductSubscription | Error | null | typeof pendingOperation> => {


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/QA-488

## Changes

Since [that change](https://github.com/sourcegraph/cody/commit/dba304ff31f183d00db50baa4d07ad4e3767eab5) `AuthStatus` does not contain `userCanUpgrade` flag. Thus just relying on `AuthStatus` when updating `userProductSubscription` is working if endpoint is changing, but not otherwise.

QA bisect points to my PR as the source of the problem, but I think that was strictly because of subtle changes in timing/debounce.
I suspect previously it could register `pendingValidation` state in between, and thus registering the change, and now it doesn't. Removing `distinctUntilChanged` fixes the problem.

## Test plan

As described in https://linear.app/sourcegraph/issue/QA-488
1. Switch acc from free to pro (or from pro to free on the same account)
2. Pro label should appear (or disappear )