### PR TITLE
feat(auto-edit): Add optimized prompt structure to leverage the prompt cache

### DIFF
--- a/vscode/src/autoedits/autoedits-config.ts
+++ b/vscode/src/autoedits/autoedits-config.ts
@@ -31,11 +31,11 @@ const defaultTokenLimit = {
     codeToRewritePrefixLines: 1,
     codeToRewriteSuffixLines: 2,
     contextSpecificTokenLimit: {
-        [RetrieverIdentifier.RecentEditsRetriever]: 2500,
+        [RetrieverIdentifier.RecentEditsRetriever]: 1500,
         [RetrieverIdentifier.JaccardSimilarityRetriever]: 0,
         [RetrieverIdentifier.RecentCopyRetriever]: 500,
         [RetrieverIdentifier.DiagnosticsRetriever]: 250,
-        [RetrieverIdentifier.RecentViewPortRetriever]: 2500,
+        [RetrieverIdentifier.RecentViewPortRetriever]: 1000,
     },
 } as const satisfies AutoEditsTokenLimit
 

--- a/vscode/src/autoedits/autoedits-provider.ts
+++ b/vscode/src/autoedits/autoedits-provider.ts
@@ -25,8 +25,8 @@ import {
 import { autoeditsProviderConfig } from './autoedits-config'
 import { FilterPredictionBasedOnRecentEdits } from './filter-prediction-edits'
 import { autoeditsOutputChannelLogger } from './output-channel-logger'
+import { PromptCacheOptimizedV1 } from './prompt/prompt-cache-optimized-v1'
 import { type CodeToReplaceData, getCodeToReplaceData } from './prompt/prompt-utils'
-import { ShortTermPromptStrategy } from './prompt/short-term-diff-prompt-strategy'
 import type { DecorationInfo } from './renderer/decorators/base'
 import { DefaultDecorator } from './renderer/decorators/default-decorator'
 import { InlineDiffDecorator } from './renderer/decorators/inline-diff-decorator'
@@ -69,7 +69,7 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
     public readonly rendererManager: AutoEditsRendererManager
     private readonly modelAdapter: AutoeditsModelAdapter
 
-    private readonly promptStrategy = new ShortTermPromptStrategy()
+    private readonly promptStrategy = new PromptCacheOptimizedV1()
     public readonly filterPrediction = new FilterPredictionBasedOnRecentEdits()
     private readonly contextMixer = new ContextMixer({
         strategyFactory: new DefaultContextStrategyFactory(Observable.of(AUTOEDIT_CONTEXT_STRATEGY)),

--- a/vscode/src/autoedits/prompt/prompt-cache-optimized-v1.test.ts
+++ b/vscode/src/autoedits/prompt/prompt-cache-optimized-v1.test.ts
@@ -1,0 +1,402 @@
+import { beforeEach } from 'node:test'
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+    type AutoEditsTokenLimit,
+    type AutocompleteContextSnippet,
+    testFileUri,
+} from '@sourcegraph/cody-shared'
+
+import { RetrieverIdentifier } from '../../completions/context/utils'
+import { getCurrentDocContext } from '../../completions/get-current-doc-context'
+import { documentAndPosition } from '../../completions/test-helpers'
+
+import type { UserPromptArgs } from './base'
+import { PromptCacheOptimizedV1 } from './prompt-cache-optimized-v1'
+import { getCodeToReplaceData } from './prompt-utils'
+
+describe('PromptCacheOptimizedV1', () => {
+    beforeEach(() => {
+        vi.useFakeTimers()
+    })
+
+    const getContextItem = (
+        content: string,
+        timeSinceActionMs: number,
+        identifier: string,
+        filePath = 'foo.ts'
+    ): AutocompleteContextSnippet => ({
+        type: 'file',
+        content,
+        identifier,
+        uri: testFileUri(filePath),
+        startLine: 0,
+        endLine: 0,
+        metadata: {
+            timeSinceActionMs,
+        },
+    })
+
+    const getUserPromptData = ({
+        shouldIncludeContext,
+    }: { shouldIncludeContext: boolean }): UserPromptArgs => {
+        const prefix = Array.from({ length: 50 }, (_, i) => `line ${i + 1}`).join('\n')
+        const suffix = Array.from({ length: 50 }, (_, i) => `line ${50 + i + 1}`).join('\n')
+        const textContent = `${prefix}█\n${suffix}`
+
+        const { document, position } = documentAndPosition(textContent)
+        const docContext = getCurrentDocContext({
+            document,
+            position,
+            maxPrefixLength: 100,
+            maxSuffixLength: 100,
+        })
+
+        const tokenBudget: AutoEditsTokenLimit = {
+            prefixTokens: 10,
+            suffixTokens: 10,
+            maxPrefixLinesInArea: 20,
+            maxSuffixLinesInArea: 20,
+            codeToRewritePrefixLines: 3,
+            codeToRewriteSuffixLines: 3,
+            contextSpecificTokenLimit: {
+                [RetrieverIdentifier.RecentViewPortRetriever]: 100,
+                [RetrieverIdentifier.RecentEditsRetriever]: 100,
+                [RetrieverIdentifier.RecentCopyRetriever]: 100,
+                [RetrieverIdentifier.JaccardSimilarityRetriever]: 100,
+                [RetrieverIdentifier.DiagnosticsRetriever]: 100,
+            },
+        }
+
+        const codeToReplaceData = getCodeToReplaceData({
+            docContext,
+            document,
+            position,
+            tokenBudget,
+        })
+
+        const context: AutocompleteContextSnippet[] = shouldIncludeContext
+            ? [
+                  getContextItem(
+                      'view port context 1',
+                      100,
+                      RetrieverIdentifier.RecentViewPortRetriever,
+                      'test0.ts'
+                  ),
+                  getContextItem(
+                      'view port context 2',
+                      100,
+                      RetrieverIdentifier.RecentViewPortRetriever,
+                      'test1.ts'
+                  ),
+                  getContextItem(
+                      'view port context 3',
+                      60 * 1000,
+                      RetrieverIdentifier.RecentViewPortRetriever,
+                      'test2.ts'
+                  ),
+                  getContextItem(
+                      'view port context 4',
+                      120 * 1000,
+                      RetrieverIdentifier.RecentViewPortRetriever,
+                      'test3.ts'
+                  ),
+
+                  getContextItem(
+                      'recent edits context 1',
+                      100,
+                      RetrieverIdentifier.RecentEditsRetriever,
+                      'test0.ts'
+                  ),
+                  getContextItem(
+                      'recent edits context 2',
+                      100,
+                      RetrieverIdentifier.RecentEditsRetriever,
+                      'test0.ts'
+                  ),
+                  getContextItem(
+                      'recent edits context 3',
+                      60 * 1000,
+                      RetrieverIdentifier.RecentEditsRetriever,
+                      'test3.ts'
+                  ),
+                  getContextItem(
+                      'recent edits context 4',
+                      120 * 1000,
+                      RetrieverIdentifier.RecentEditsRetriever,
+                      'test3.ts'
+                  ),
+                  getContextItem(
+                      'recent edits context 5',
+                      120 * 1000,
+                      RetrieverIdentifier.RecentEditsRetriever,
+                      'test2.ts'
+                  ),
+
+                  getContextItem(
+                      'diagnostics context 1',
+                      60 * 1000,
+                      RetrieverIdentifier.DiagnosticsRetriever,
+                      'test1.ts'
+                  ),
+                  getContextItem(
+                      'diagnostics context 2',
+                      120 * 1000,
+                      RetrieverIdentifier.DiagnosticsRetriever,
+                      'test1.ts'
+                  ),
+                  getContextItem(
+                      'diagnostics context 3',
+                      120 * 1000,
+                      RetrieverIdentifier.DiagnosticsRetriever,
+                      'test2.ts'
+                  ),
+                  getContextItem(
+                      'diagnostics context 4',
+                      120 * 1000,
+                      RetrieverIdentifier.DiagnosticsRetriever,
+                      'test2.ts'
+                  ),
+                  getContextItem(
+                      'diagnostics context 5',
+                      120 * 1000,
+                      RetrieverIdentifier.DiagnosticsRetriever,
+                      'test2.ts'
+                  ),
+                  getContextItem(
+                      'diagnostics context 6',
+                      120 * 1000,
+                      RetrieverIdentifier.DiagnosticsRetriever,
+                      'test2.ts'
+                  ),
+                  getContextItem(
+                      'diagnostics context 7',
+                      120 * 1000,
+                      RetrieverIdentifier.DiagnosticsRetriever,
+                      'test2.ts'
+                  ),
+              ]
+            : []
+
+        return {
+            context,
+            codeToReplaceData,
+            document,
+            tokenBudget,
+        }
+    }
+
+    describe('getUserPrompt', () => {
+        const strategy = new PromptCacheOptimizedV1()
+
+        it('creates prompt without context', () => {
+            const userPromptData = getUserPromptData({ shouldIncludeContext: false })
+            const prompt = strategy.getUserPrompt(userPromptData)
+            expect(prompt.toString()).toMatchInlineSnapshot(`
+              "Help me finish a coding change. You will see snippets from current open files in my editor, files I have recently viewed, the file I am editing, then a history of my recent codebase changes, then current compiler and linter errors, content I copied from my codebase. You will then rewrite the <code_to_rewrite>, to match what you think I would do next in the codebase. Note: I might have stopped in the middle of typing.
+              Code snippets just I viewed:
+
+              The file currently open:(\`test.ts\`)
+              <file>
+
+              <<<AREA_AROUND_CODE_TO_REWRITE_WILL_BE_INSERTED_HERE>>>
+
+              </file>
+              <area_around_code_to_rewrite>
+              line 37
+              line 38
+              line 39
+              line 40
+              line 41
+              line 42
+              line 43
+              line 44
+              line 45
+              line 46
+
+              <code_to_rewrite>
+              line 47
+              line 48
+              line 49
+              line 50
+              line 51
+              line 52
+              line 53
+
+              </code_to_rewrite>
+              line 54
+              line 55
+              line 56
+              line 57
+              line 58
+              line 59
+              line 60
+              line 61
+              line 62
+              line 63
+              line 64
+
+              </area_around_code_to_rewrite>
+              Continue where I left off and finish my change by rewriting "code_to_rewrite":"
+            `)
+        })
+
+        it('creates prompt with context', () => {
+            const userPromptData = getUserPromptData({ shouldIncludeContext: true })
+            const prompt = strategy.getUserPrompt(userPromptData)
+            expect(prompt.toString()).toMatchInlineSnapshot(`
+              "Help me finish a coding change. You will see snippets from current open files in my editor, files I have recently viewed, the file I am editing, then a history of my recent codebase changes, then current compiler and linter errors, content I copied from my codebase. You will then rewrite the <code_to_rewrite>, to match what you think I would do next in the codebase. Note: I might have stopped in the middle of typing.
+              Code snippets just I viewed:
+              <recently_viewed_snippets>
+              <snippet>
+              (\`test1.ts\`)
+
+              view port context 2
+              </snippet>
+              <snippet>
+              (\`test0.ts\`)
+
+              view port context 1
+              </snippet>
+              </recently_viewed_snippets>
+              My recent edits, from oldest to newest:
+              <diff_history>
+              test2.ts
+              recent edits context 5
+              test3.ts
+              recent edits context 4
+              then
+              recent edits context 3
+              </diff_history>
+              The file currently open:(\`test.ts\`)
+              <file>
+
+              <<<AREA_AROUND_CODE_TO_REWRITE_WILL_BE_INSERTED_HERE>>>
+
+              </file>
+              My recent edits, from oldest to newest:
+              <diff_history>
+              test0.ts
+              recent edits context 2
+              </diff_history>
+              Linter errors from the code that you will rewrite:
+              <lint_errors>
+              (\`test1.ts\`)
+
+              diagnostics context 1
+
+              diagnostics context 2
+
+              (\`test2.ts\`)
+
+              diagnostics context 3
+
+              diagnostics context 4
+              </lint_errors>
+              <area_around_code_to_rewrite>
+              line 37
+              line 38
+              line 39
+              line 40
+              line 41
+              line 42
+              line 43
+              line 44
+              line 45
+              line 46
+
+              <code_to_rewrite>
+              line 47
+              line 48
+              line 49
+              line 50
+              line 51
+              line 52
+              line 53
+
+              </code_to_rewrite>
+              line 54
+              line 55
+              line 56
+              line 57
+              line 58
+              line 59
+              line 60
+              line 61
+              line 62
+              line 63
+              line 64
+
+              </area_around_code_to_rewrite>
+              <diff_history>
+              test0.ts
+              recent edits context 1
+              </diff_history>
+              Continue where I left off and finish my change by rewriting "code_to_rewrite":"
+            `)
+        })
+    })
+
+    describe('getRecentEditsPromptComponents', () => {
+        const strategy = new PromptCacheOptimizedV1()
+
+        it('returns empty prompts when no context items are provided', () => {
+            const result = (strategy as any).getRecentEditsPromptComponents([])
+            expect(result.mostRecentEditsPrompt.toString()).toBe('')
+            expect(result.shortTermEditsPrompt.toString()).toBe('')
+            expect(result.longTermEditsPrompt.toString()).toBe('')
+        })
+
+        it('splits edits into most recent, short term and long term', () => {
+            const contextItems = [
+                getContextItem(
+                    'most recent edit',
+                    100,
+                    RetrieverIdentifier.RecentEditsRetriever,
+                    'test0.ts'
+                ),
+                getContextItem(
+                    'short term edit',
+                    30 * 1000,
+                    RetrieverIdentifier.RecentEditsRetriever,
+                    'test1.ts'
+                ),
+                getContextItem(
+                    'long term edit',
+                    120 * 1000,
+                    RetrieverIdentifier.RecentEditsRetriever,
+                    'test2.ts'
+                ),
+            ]
+
+            const result = (strategy as any).getRecentEditsPromptComponents(contextItems)
+            expect(result.mostRecentEditsPrompt.toString()).toContain('most recent edit')
+            expect(result.shortTermEditsPrompt.toString()).toContain('short term edit')
+            expect(result.longTermEditsPrompt.toString()).toContain('long term edit')
+        })
+    })
+
+    describe('getDiagnosticsPrompt', () => {
+        const strategy = new PromptCacheOptimizedV1()
+
+        it('returns empty prompt when no diagnostics are provided', () => {
+            const result = (strategy as any).getDiagnosticsPrompt([])
+            expect(result.toString()).toBe('')
+        })
+
+        it('limits the number of diagnostics to DIAGNOSTICS_MAX_COUNT', () => {
+            const diagnostics = Array.from({ length: 6 }, (_, i) =>
+                getContextItem(
+                    `diagnostic ${i}`,
+                    100,
+                    RetrieverIdentifier.DiagnosticsRetriever,
+                    `test${i}.ts`
+                )
+            )
+
+            const result = (strategy as any).getDiagnosticsPrompt(diagnostics)
+            const matches = result.toString().match(/diagnostic \d/g) || []
+            expect(matches.length).toBe(4) // DIAGNOSTICS_MAX_COUNT is 4
+        })
+    })
+})

--- a/vscode/src/autoedits/prompt/prompt-cache-optimized-v1.ts
+++ b/vscode/src/autoedits/prompt/prompt-cache-optimized-v1.ts
@@ -1,0 +1,198 @@
+import { type AutocompleteContextSnippet, PromptString, ps } from '@sourcegraph/cody-shared'
+
+import { groupConsecutiveItemsByPredicate } from '../../completions/context/retrievers/recent-user-actions/recent-edits-diff-helpers/utils'
+import { RetrieverIdentifier } from '../../completions/context/utils'
+import { shortenPromptForOutputChannel } from '../../completions/output-channel-logger'
+import { autoeditsOutputChannelLogger } from '../output-channel-logger'
+
+import { AutoeditsUserPromptStrategy, type UserPromptArgs } from './base'
+import * as constants from './constants'
+import {
+    getContextItemMappingWithTokenLimit,
+    getContextItemsForIdentifier,
+    getCurrentFilePromptComponents,
+    getLintErrorsPrompt,
+    getPromptForTheContextSource,
+    getPromptWithNewline,
+    getRecentEditsPrompt,
+    getRecentlyViewedSnippetsPrompt,
+    joinPromptsWithNewlineSeparator,
+} from './prompt-utils'
+
+interface RecentEditsPromptComponents {
+    mostRecentEditsPrompt: PromptString
+    shortTermEditsPrompt: PromptString
+    longTermEditsPrompt: PromptString
+}
+
+export class PromptCacheOptimizedV1 extends AutoeditsUserPromptStrategy {
+    // Recent edits with timestamp older than this will be included at the top of the prompt to reuse the cached.
+    // Other recent edits will be included near the bottom of the prompt as they are more important.
+    private readonly RECENT_EDIT_SHORT_TERM_TIME_MS = 60 * 1000 // 1 minute
+    // Oldest timestamp for a snippet view that can be included in the prompt.
+    private readonly SNIPPET_VIEW_MAX_TIMESTAMP_MS = 10 * 60 * 1000 // 10 minutes
+    // Maximum number of snippet views that can be included in the prompt.
+    private readonly SNIPPET_VIEW_MAX_COUNT = 2
+    // Diagnostics are ordered based on the absolute distance from the current cursor position.
+    // This is the maximum number of diagnostics that can be included in the prompt.
+    private readonly DIAGNOSTICS_MAX_COUNT = 4
+
+    getUserPrompt({ context, tokenBudget, codeToReplaceData, document }: UserPromptArgs): PromptString {
+        const contextItemMapping = getContextItemMappingWithTokenLimit(
+            context,
+            tokenBudget.contextSpecificTokenLimit
+        )
+        const recentViewedSnippetsPrompt = this.getRecentSnippetViewPrompt(
+            contextItemMapping.get(RetrieverIdentifier.RecentViewPortRetriever) || []
+        )
+        const recentEditsPromptComponents = this.getRecentEditsPromptComponents(
+            contextItemMapping.get(RetrieverIdentifier.RecentEditsRetriever) || []
+        )
+        const lintErrorsPrompt = this.getDiagnosticsPrompt(
+            contextItemMapping.get(RetrieverIdentifier.DiagnosticsRetriever) || []
+        )
+
+        const { fileWithMarkerPrompt, areaPrompt } = getCurrentFilePromptComponents({
+            document,
+            codeToReplaceDataRaw: codeToReplaceData,
+        })
+        const currentFilePrompt = ps`${constants.CURRENT_FILE_INSTRUCTION}${fileWithMarkerPrompt}`
+
+        const promptParts = [
+            getPromptWithNewline(constants.BASE_USER_PROMPT),
+            getPromptWithNewline(recentViewedSnippetsPrompt),
+            getPromptWithNewline(recentEditsPromptComponents.longTermEditsPrompt),
+            getPromptWithNewline(currentFilePrompt),
+            getPromptWithNewline(recentEditsPromptComponents.shortTermEditsPrompt),
+            getPromptWithNewline(lintErrorsPrompt),
+            getPromptWithNewline(areaPrompt),
+            getPromptWithNewline(recentEditsPromptComponents.mostRecentEditsPrompt),
+            constants.FINAL_USER_PROMPT,
+        ]
+
+        const finalPrompt = PromptString.join(promptParts, ps``)
+
+        autoeditsOutputChannelLogger.logDebugIfVerbose('PromptCacheOptimizedV1', 'getUserPrompt', {
+            verbose: shortenPromptForOutputChannel(finalPrompt.toString(), []),
+        })
+
+        return finalPrompt
+    }
+
+    private getDiagnosticsPrompt(diagnosticsItems: AutocompleteContextSnippet[]): PromptString {
+        const diagnostics = diagnosticsItems.slice(0, this.DIAGNOSTICS_MAX_COUNT)
+        return getPromptForTheContextSource(
+            diagnostics,
+            constants.LINT_ERRORS_INSTRUCTION,
+            getLintErrorsPrompt
+        )
+    }
+
+    private getRecentSnippetViewPrompt(contextItems: AutocompleteContextSnippet[]): PromptString {
+        const recentViewedSnippets = getContextItemsForIdentifier(
+            contextItems,
+            RetrieverIdentifier.RecentViewPortRetriever
+        )
+            .filter(
+                item =>
+                    item.metadata?.timeSinceActionMs !== undefined &&
+                    item.metadata.timeSinceActionMs < this.SNIPPET_VIEW_MAX_TIMESTAMP_MS
+            )
+            .slice(0, this.SNIPPET_VIEW_MAX_COUNT)
+
+        return joinPromptsWithNewlineSeparator(
+            constants.SHORT_TERM_SNIPPET_VIEWS_INSTRUCTION,
+            getRecentlyViewedSnippetsPrompt(recentViewedSnippets)
+        )
+    }
+
+    private getRecentEditsPromptComponents(
+        contextItems: AutocompleteContextSnippet[]
+    ): RecentEditsPromptComponents {
+        const recentEditsSnippets = getContextItemsForIdentifier(
+            contextItems,
+            RetrieverIdentifier.RecentEditsRetriever
+        )
+
+        const mostRecentEditsPrompt =
+            recentEditsSnippets.length > 0 ? ps`${getRecentEditsPrompt([recentEditsSnippets[0]])}` : ps``
+
+        const otherRecentEditsContextItems =
+            recentEditsSnippets.length > 1 ? recentEditsSnippets.slice(1) : []
+
+        const groupedContextItems = this.groupConsecutiveEditsFromSameFile(otherRecentEditsContextItems)
+
+        const { shortTermSnippets, longTermSnippets } = this.splitContextItemsIntoShortAndLongTerm(
+            groupedContextItems,
+            this.RECENT_EDIT_SHORT_TERM_TIME_MS
+        )
+
+        return {
+            mostRecentEditsPrompt,
+            shortTermEditsPrompt: this.getRecentEditPromptWithInstruction(shortTermSnippets),
+            longTermEditsPrompt: this.getRecentEditPromptWithInstruction(longTermSnippets),
+        }
+    }
+
+    private getRecentEditPromptWithInstruction(snippets: AutocompleteContextSnippet[]): PromptString {
+        if (snippets.length === 0) {
+            return ps``
+        }
+        return joinPromptsWithNewlineSeparator(
+            constants.RECENT_EDITS_INSTRUCTION,
+            getRecentEditsPrompt(snippets)
+        )
+    }
+
+    private splitContextItemsIntoShortAndLongTerm(
+        contextItems: AutocompleteContextSnippet[],
+        shortTermTimeMs: number
+    ): {
+        shortTermSnippets: AutocompleteContextSnippet[]
+        longTermSnippets: AutocompleteContextSnippet[]
+    } {
+        const shortTermSnippets: AutocompleteContextSnippet[] = []
+        const longTermSnippets: AutocompleteContextSnippet[] = []
+        for (const item of contextItems) {
+            if (
+                item.metadata?.timeSinceActionMs !== undefined &&
+                item.metadata.timeSinceActionMs < shortTermTimeMs
+            ) {
+                shortTermSnippets.push(item)
+            } else {
+                longTermSnippets.push(item)
+            }
+        }
+        return {
+            shortTermSnippets,
+            longTermSnippets,
+        }
+    }
+
+    private groupConsecutiveEditsFromSameFile(
+        contextItems: AutocompleteContextSnippet[]
+    ): AutocompleteContextSnippet[] {
+        if (contextItems.length === 0) {
+            return []
+        }
+        // Group consecutive items by file name
+        const groupedContextItems = groupConsecutiveItemsByPredicate(
+            contextItems,
+            (a, b) => a.uri.toString() === b.uri.toString()
+        )
+        const combinedContextItems: AutocompleteContextSnippet[] = []
+        for (const group of groupedContextItems) {
+            const combinedItem = {
+                ...group[0],
+                // The group content is from the latest to the oldest item.
+                // We need to reverse the order of the content to get diff from old to new.
+                content: group
+                    .map(item => item.content)
+                    .reverse()
+                    .join('\nthen\n'),
+            }
+            combinedContextItems.push(combinedItem)
+        }
+        return combinedContextItems
+    }
+}


### PR DESCRIPTION
As part of the prefil optimization, add the prompt structure to leverage the maximum KV cache.
The new prompt provider add the prompt in the following order:
- Other files prompt components are added to the top. Since most of the edits happen in the current file, most of the prompt from the other files (`view-port` and `recent-edits`) are added to the top.
- For the most recent added `recent-edits` it sets a minimum time. They are still added in the usual location i.e. near the end of the file since they are important.
- Adds a cap on the number of snippets for the `recent-view-port`. Check the [details here](https://sourcegraph.slack.com/archives/C08GUBSHMKN/p1742306288375029) for more details.

## Test plan
- Added unit tests