### PR TITLE
CODY-4631: remove compatibility override after experimental release

### DIFF
--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -52,17 +52,6 @@ export function getConfiguration(
         CodyAutoSuggestionMode.Autocomplete
     )
 
-    // Backward compatibility with the older config for autocomplete.
-    // If autocomplete was turned off - override the suggestion mode to "off".
-    // TODO (Hitesh): Remove the manual override once the updated config is communicated after experimental release
-    // https://linear.app/sourcegraph/issue/CODY-4701/clean-up-backwards-compatbility-settings-after-the-release
-    if (
-        codyAutoSuggestionsMode === CodyAutoSuggestionMode.Autocomplete &&
-        vscode.workspace.getConfiguration().get<boolean>('cody.autocomplete.enabled') === false
-    ) {
-        codyAutoSuggestionsMode = CodyAutoSuggestionMode.Off
-    }
-
     // Backward compatibility with the older auto-edit config name.
     // If auto-edit was turned on - override the suggestion mode to "auto-edit".
     // TODO: clean up after the experimental release


### PR DESCRIPTION
The `cody.autocomplete.enabled` no longer exists. As a result, the override [condition](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/cody/-/blob/vscode/src/configuration.ts?L60-62) is always false.


## Test plan

- unit testing only