### PR TITLE
fix(models): prevent reasoning models from being set as default model

### DIFF
--- a/lib/shared/src/models/model.ts
+++ b/lib/shared/src/models/model.ts
@@ -231,7 +231,7 @@ export function getServerModelTags(
         tags.push(ModelTag.Vision)
     }
 
-    if(capabilities.includes('reasoning')) {
+    if (capabilities.includes('reasoning')) {
         tags.push(ModelTag.Reasoning)
     }
     // TODO (bee) removes once o1 is rolled out.

--- a/lib/shared/src/models/model.ts
+++ b/lib/shared/src/models/model.ts
@@ -230,6 +230,10 @@ export function getServerModelTags(
     if (capabilities.includes('vision')) {
         tags.push(ModelTag.Vision)
     }
+
+    if(capabilities.includes('reasoning')) {
+        tags.push(ModelTag.Reasoning)
+    }
     // TODO (bee) removes once o1 is rolled out.
     // HACK: Currently only o1 models are waitlisted,
     // so we can use this to determine if a model is stream-disabled.

--- a/lib/shared/src/models/modelsService.ts
+++ b/lib/shared/src/models/modelsService.ts
@@ -431,11 +431,14 @@ export class ModelsService {
                     return pendingOperation
                 }
 
-                // Free users can only use the default free model, so we just find the first model they can use
+                // Remove deprecated models from the list
+                models = models.filter(model => !model.tags.includes(ModelTag.Deprecated))
+
+                // Find the first model the user can use that isn't a reasoning model
                 const firstModelUserCanUse = models.find(
                     m =>
                         this._isModelAvailable(modelsData, authStatus, userProductSubscription, m) ===
-                        true
+                            true && !m.tags.includes(ModelTag.Reasoning)
                 )
 
                 if (modelsData.preferences) {
@@ -447,6 +450,12 @@ export class ModelsService {
                     )
                     if (
                         selected &&
+                        // Don't set default model for ModelUsage.Edit if the model has certain tags
+                        !(
+                            type === ModelUsage.Edit &&
+                            (selected.tags.includes(ModelTag.Reasoning) ||
+                                selected.tags.includes(ModelTag.Deprecated))
+                        ) &&
                         this._isModelAvailable(
                             modelsData,
                             authStatus,
@@ -477,7 +486,18 @@ export class ModelsService {
                 if (editModel === pendingOperation || chatModel === pendingOperation) {
                     return pendingOperation
                 }
-                return editModel?.id || chatModel?.id
+
+                // Filter out reasoning models
+                if (editModel && !editModel.tags.includes(ModelTag.Reasoning)) {
+                    return editModel?.id
+                }
+
+                // If edit model is not available or is a reasoning model, check chat model
+                if (chatModel && !chatModel.tags.includes(ModelTag.Reasoning)) {
+                    return chatModel?.id
+                }
+
+                return undefined
             })
         )
     }

--- a/lib/shared/src/models/modelsService.ts
+++ b/lib/shared/src/models/modelsService.ts
@@ -451,9 +451,10 @@ export class ModelsService {
                     if (
                         selected &&
                         // Don't set default model for ModelUsage.Edit if the model has certain tags
-                        !(
+                        (
                             type === ModelUsage.Edit &&
-                            (selected.tags.includes(ModelTag.Reasoning) ||
+                            (selected.usage.includes(ModelUsage.Edit)) &&
+                            !(selected.tags.includes(ModelTag.Reasoning) ||
                                 selected.tags.includes(ModelTag.Deprecated))
                         ) &&
                         this._isModelAvailable(

--- a/lib/shared/src/models/modelsService.ts
+++ b/lib/shared/src/models/modelsService.ts
@@ -451,10 +451,9 @@ export class ModelsService {
                     if (
                         selected &&
                         // Don't set default model for ModelUsage.Edit if the model has certain tags
-                        (
+                        !(
                             type === ModelUsage.Edit &&
-                            (selected.usage.includes(ModelUsage.Edit)) &&
-                            !(selected.tags.includes(ModelTag.Reasoning) ||
+                            (selected.tags.includes(ModelTag.Reasoning) ||
                                 selected.tags.includes(ModelTag.Deprecated))
                         ) &&
                         this._isModelAvailable(


### PR DESCRIPTION
This PR fixes a critical issue where reasoning models could be incorrectly set as the default model for Edit operations, causing the application to break for users.

This commit addresses an issue where reasoning models could be incorrectly set as the default model for Edit operations. The problem occurred because when Edit model is not available, Edit would fallback to the `firstModelUserCanUse` logic which doesn't filter out reasoning models for Edit usage. This could cause Inline Edit to use reasoning model even when they are not assigned for Edit usage.

### The Problem

The issue occurred in the `getDefaultModel` and `getDefaultEditModel` methods in `modelsService.ts`. When a user didn't have a selected model preference for Edit and the server didn't provide a default Edit model, the code would use the first available model that the user could access. However, this logic didn't properly filter out reasoning models, which are not suitable for Edit operations.

This resulted in scenarios where reasoning models were being used for Edit operations, causing unexpected behavior or application failures.

### The Solution

The fix includes:

1. Enhanced filtering in `getDefaultModel` to explicitly exclude reasoning models when finding the first available model for Edit usage
2. Improved fallback logic in `getDefaultEditModel` to:
   - First try to use a valid Edit model (non-reasoning)
   - If that's not available, fall back to a valid Chat model (non-reasoning)
   - If neither is available, return undefined

3. Added comprehensive test coverage to ensure:
   - Reasoning models are never used for Edit operations
   - Models with problematic tags (Waitlist, OnWaitlist, Deprecated) are not used for Edit
   - The fallback mechanism to Chat models works correctly
   - User preferences are respected when valid
   - Invalid user preferences (like reasoning models) are ignored

## Changes

- Added filtering to exclude reasoning models from being used for Edit operations
- Improved fallback logic to use valid Chat models when no suitable Edit models are available
- Added comprehensive test coverage to ensure reasoning models and other problematic model types (waitlist, deprecated) are never used for Edit
- Updated existing tests to reflect the new behavior
-   Filtering out deprecated models from the available models list.
-   Preventing the selection of reasoning models for Edit usage.
-   Prioritizing chat models as a fallback when no valid edit model is available.
-   Ensuring that user preferences for edit models are respected unless the selected model is a reasoning model.
-   Handling the scenario where only reasoning models are available.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->


Added a new test suite `Default model selection for Edit and Chat` with 8 test cases covering all the scenarios mentioned above. Updated existing tests to reflect the new behavior.
