### PR TITLE
fix(chat): prevent keyboard shortcut from selecting disabled chat modes

### DIFF
--- a/vscode/test/e2e/chat-keyboard-shortcuts.test.ts
+++ b/vscode/test/e2e/chat-keyboard-shortcuts.test.ts
@@ -1,4 +1,5 @@
 import { expect } from '@playwright/test'
+import * as mockServer from '../fixtures/mock-server'
 import {
     chatInputMentions,
     clickEditorTab,
@@ -9,7 +10,7 @@ import {
     selectLineRangeInEditorTab,
     sidebarSignin,
 } from './common'
-import { executeCommandInPalette, test } from './helpers'
+import { type DotcomUrlOverride, executeCommandInPalette, test } from './helpers'
 
 test.skip('chat keyboard shortcuts for sidebar chat', async ({ page, sidebar }) => {
     await page.bringToFront()
@@ -52,3 +53,63 @@ test.skip('re-opening chat adds selection', async ({ page, sidebar }) => {
     await page.keyboard.press('Shift+Alt+l')
     await expect(chatInputMentions(lastChatInput)).toHaveText(/^buzz.ts:2-4$/)
 })
+
+test.extend<DotcomUrlOverride>({ dotcomUrl: mockServer.SERVER_URL })(
+    'chat mode keyboard shortcut respects permissions',
+    async ({ page, sidebar }) => {
+        await sidebarSignin(page, sidebar)
+        const chatFrame = getChatSidebarPanel(page)
+        const chatInput = getChatInputs(chatFrame).last()
+
+        // Get the initial mode (should be "Chat" by default)
+        await chatFrame.getByLabel('switch-mode').click()
+        await expect(chatFrame.getByText('ChatSearchEnterprise')).toBeVisible()
+        await expect(chatFrame.getByRole('option', { name: 'Search Enterprise' })).toBeDisabled()
+
+        // Escape to close the mode selector
+        await page.keyboard.press('Escape')
+        await expect(chatFrame.getByRole('option', { name: 'Search Enterprise' })).not.toBeVisible()
+
+        // Try to cycle through modes using keyboard shortcut
+        await page.keyboard.press(process.platform === 'darwin' ? 'Meta+.' : 'Control+.')
+
+        // Wait a moment for any state changes
+        await page.waitForTimeout(500)
+
+        // Check if the mode changed based on user permissions
+        // For dotcom users, it should stay as "Chat"
+        const modeSelectorButton = chatFrame.getByLabel('switch-mode')
+        await expect(modeSelectorButton).toHaveText('Chat')
+
+        // Get the current mode after shortcut
+        const newMode = await modeSelectorButton.textContent()
+
+        // Check which options are available and not disabled in the dropdown
+        const availableOptions = await page.locator('.tw-command-item:not([disabled])').count()
+
+        // If there are multiple available options, the keyboard shortcut should have changed the mode
+        if (availableOptions > 1) {
+            // The mode should have changed from the default "Chat"
+            expect(newMode).not.toBe('Chat')
+        } else {
+            // If only one option is available, the mode should still be "Chat"
+            expect(newMode).toBe('Chat')
+        }
+
+        // Close the dropdown
+        await page.keyboard.press('Escape')
+
+        // Try cycling through modes multiple times to ensure we don't get stuck
+        for (let i = 0; i < 3; i++) {
+            await page.keyboard.press(process.platform === 'darwin' ? 'Meta+.' : 'Control+.')
+            await page.waitForTimeout(300)
+        }
+
+        // Verify we can still interact with the chat after cycling
+        await chatInput.fill('Test message after cycling modes')
+        await chatInput.press('Enter')
+
+        // Verify a response is received
+        await expect(chatFrame.getByText('hello from the assistant')).toBeVisible()
+    }
+)

--- a/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/ModeSelectorButton.test.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/ModeSelectorButton.test.tsx
@@ -44,7 +44,7 @@ describe('ModeSelectorField', () => {
         omniBoxEnabled: true,
         isDotComUser: false,
         isCodyProUser: true,
-        intent: 'chat' as const,
+        _intent: 'chat' as const,
         manuallySelectIntent: vi.fn(),
     }
 
@@ -70,7 +70,7 @@ describe('ModeSelectorField', () => {
     it('displays agentic intent when selected', () => {
         render(
             <TestWrapper>
-                <ModeSelectorField {...defaultProps} intent="agentic" />
+                <ModeSelectorField {...defaultProps} _intent="agentic" />
             </TestWrapper>
         )
 
@@ -80,7 +80,7 @@ describe('ModeSelectorField', () => {
     it('toggles between intents when keyboard shortcut is used', () => {
         render(
             <TestWrapper>
-                <ModeSelectorField {...defaultProps} intent="chat" omniBoxEnabled={true} />
+                <ModeSelectorField {...defaultProps} _intent="chat" omniBoxEnabled={true} />
             </TestWrapper>
         )
 

--- a/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/ModeSelectorButton.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/ModeSelectorButton.tsx
@@ -1,8 +1,7 @@
 import type { ChatMessage } from '@sourcegraph/cody-shared'
 import { isMacOS } from '@sourcegraph/cody-shared'
 import { BetweenHorizonalEnd, MessageSquare, Pencil, Search, Sparkle } from 'lucide-react'
-import type { FC } from 'react'
-import { useCallback, useEffect, useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Badge } from '../../../../../../components/shadcn/ui/badge'
 import { Command, CommandItem, CommandList } from '../../../../../../components/shadcn/ui/command'
 import { ToolbarPopoverItem } from '../../../../../../components/shadcn/ui/toolbar'
@@ -36,141 +35,122 @@ interface IntentOption {
     hidden?: boolean
     disabled?: boolean
     agent?: string
-}
-
-const chatIntent: IntentOption = {
-    title: 'Chat',
-    icon: MessageSquare,
-    intent: 'chat',
-}
-
-function getIntentOptions({
-    isEditEnabled,
-    isDotComUser,
-    omniBoxEnabled,
-    agenticChatEnabled,
-}: {
-    isEditEnabled: boolean
-    isDotComUser: boolean
-    omniBoxEnabled: boolean
-    agenticChatEnabled: boolean
-}): IntentOption[] {
-    return [
-        chatIntent,
-        {
-            title: 'Search',
-            badge: isDotComUser ? 'Enterprise' : 'Beta',
-            icon: Search,
-            intent: 'search',
-            hidden: !omniBoxEnabled,
-            disabled: isDotComUser,
-        },
-        {
-            title: 'Agentic',
-            badge: agenticChatEnabled ? 'Experimental' : 'Pro',
-            icon: Sparkle,
-            intent: 'agentic',
-            hidden: !agenticChatEnabled,
-            disabled: !agenticChatEnabled,
-        },
-        {
-            title: 'Edit Code',
-            badge: 'Experimental',
-            icon: Pencil,
-            intent: 'edit',
-            hidden: true,
-            disabled: !isEditEnabled,
-        },
-        {
-            title: 'Insert Code',
-            badge: 'Experimental',
-            icon: BetweenHorizonalEnd,
-            intent: 'insert',
-            hidden: true,
-            disabled: !isEditEnabled,
-        },
-    ]
+    value: IntentEnum
 }
 
 export const ModeSelectorField: React.FunctionComponent<{
     omniBoxEnabled: boolean
     isDotComUser: boolean
     isCodyProUser: boolean
-    intent: ChatMessage['intent']
+    _intent: ChatMessage['intent']
     className?: string
     manuallySelectIntent: (intent?: ChatMessage['intent']) => void
-}> = ({ isDotComUser, className, intent, omniBoxEnabled, manuallySelectIntent }) => {
+}> = ({ isDotComUser, className, _intent = 'chat', omniBoxEnabled, manuallySelectIntent }) => {
     const {
         clientCapabilities: { edit },
         config,
     } = useConfig()
 
-    const intentOptions = useMemo(
-        () =>
-            getIntentOptions({
-                isEditEnabled: edit !== 'none',
-                isDotComUser,
-                omniBoxEnabled,
-                agenticChatEnabled: !!config?.experimentalAgenticChatEnabled,
-            }).filter(option => !option.hidden),
-        [edit, isDotComUser, omniBoxEnabled, config?.experimentalAgenticChatEnabled]
+    // Generate intent options based on current configuration
+    const intentOptions = useMemo(() => {
+        const isEditEnabled = edit !== 'none'
+        const agenticChatEnabled = !!config?.experimentalAgenticChatEnabled
+
+        return [
+            {
+                title: 'Chat',
+                icon: MessageSquare,
+                intent: 'chat',
+                value: IntentEnum.Chat,
+            },
+            {
+                title: 'Search',
+                badge: isDotComUser ? 'Enterprise' : 'Beta',
+                icon: Search,
+                intent: 'search',
+                hidden: !omniBoxEnabled,
+                disabled: isDotComUser,
+                value: IntentEnum.Search,
+            },
+            {
+                title: 'Agentic',
+                badge: agenticChatEnabled ? 'Experimental' : 'Pro',
+                icon: Sparkle,
+                intent: 'agentic',
+                hidden: !agenticChatEnabled,
+                disabled: !agenticChatEnabled,
+                value: IntentEnum.Agentic,
+            },
+            {
+                title: 'Edit Code',
+                badge: 'Experimental',
+                icon: Pencil,
+                intent: 'edit',
+                hidden: true,
+                disabled: !isEditEnabled,
+                value: IntentEnum.Edit,
+            },
+            {
+                title: 'Insert Code',
+                badge: 'Experimental',
+                icon: BetweenHorizonalEnd,
+                intent: 'insert',
+                hidden: true,
+                disabled: !isEditEnabled,
+                value: IntentEnum.Insert,
+            },
+        ].filter(option => !option.hidden) as IntentOption[]
+    }, [edit, config?.experimentalAgenticChatEnabled, isDotComUser, omniBoxEnabled])
+
+    // Get available (non-disabled) options
+    const availableOptions = useMemo(
+        () => intentOptions.filter(option => !option.disabled),
+        [intentOptions]
     )
 
-    // Memoize the handler to avoid recreating on each render
-    const handleItemClick = useCallback(
-        (close: () => void) => (item: ChatMessage['intent']) => {
-            manuallySelectIntent(item)
-            close()
+    // Initialize with the provided intent or fallback to chat
+    const [currentSelectedIntent, setCurrentSelectedIntent] = useState(() => {
+        const mappedIntent = INTENT_MAPPING[_intent || 'chat']
+        // Check if the intent is available and not disabled
+        const isValidIntent = intentOptions.some(
+            option => option.value === mappedIntent && !option.disabled
+        )
+        return isValidIntent ? mappedIntent : IntentEnum.Chat
+    })
+
+    // Handle intent selection
+    const handleSelectIntent = useCallback(
+        (intent: ChatMessage['intent'], close?: () => void) => {
+            manuallySelectIntent(intent)
+            setCurrentSelectedIntent(INTENT_MAPPING[intent || 'chat'])
+            close?.()
         },
         [manuallySelectIntent]
     )
 
-    // Handle keyboard shortcut to cycle through intent options
-    const handleKeyDown = useCallback(
-        (event: KeyboardEvent) => {
-            // Check for ⌘. (Command+Period on macOS, Ctrl+Period on other platforms)
+    // Handle keyboard shortcut
+    useEffect(() => {
+        // Only enable shortcut if there are multiple available options
+        if (availableOptions.length <= 1) return
+
+        const handleKeyDown = (event: KeyboardEvent) => {
             if ((isMac ? event.metaKey : event.ctrlKey) && event.key === '.') {
                 event.preventDefault()
-                // Find the current index and select the next intent option
-                const currentIntent = intent || 'chat'
-                const currentIndex = intentOptions.findIndex(option => option.intent === currentIntent)
 
-                // Find the next enabled option
-                let nextIndex = (currentIndex + 1) % intentOptions.length
-                let attempts = 0
+                // Find current index in available options
+                const currentIndex = availableOptions.findIndex(
+                    option => option.value === currentSelectedIntent
+                )
 
-                // Loop until we find an enabled option or we've checked all options
-                while (intentOptions[nextIndex].disabled && attempts < intentOptions.length) {
-                    nextIndex = (nextIndex + 1) % intentOptions.length
-                    attempts++
-                }
-
-                // Only change the intent if we found an enabled option
-                if (!intentOptions[nextIndex].disabled) {
-                    manuallySelectIntent(intentOptions[nextIndex].intent)
-                }
-            }
-        },
-        [intent, intentOptions, manuallySelectIntent]
-    )
-
-    // Add event listener for keyboard shortcut only if user has appropriate permissions
-    useEffect(() => {
-        // Only add the keyboard shortcut if:
-        // 1. User is not a dotcom user (has enterprise features) OR
-        // 2. OmniBox is enabled AND there are multiple enabled intent options available
-        const hasMultipleEnabledOptions = intentOptions.filter(option => !option.disabled).length > 1
-        const shouldEnableShortcut = (!isDotComUser || omniBoxEnabled) && hasMultipleEnabledOptions
-
-        if (shouldEnableShortcut) {
-            document.addEventListener('keydown', handleKeyDown)
-            return () => {
-                document.removeEventListener('keydown', handleKeyDown)
+                // Select next option in the list
+                const nextIndex = (currentIndex + 1) % availableOptions.length
+                handleSelectIntent(availableOptions[nextIndex].intent)
             }
         }
-        // Empty cleanup function when event listener is not added
-        return () => {}
-    }, [handleKeyDown, isDotComUser, omniBoxEnabled, intentOptions])
+
+        document.addEventListener('keydown', handleKeyDown)
+        return () => document.removeEventListener('keydown', handleKeyDown)
+    }, [availableOptions, currentSelectedIntent, handleSelectIntent])
 
     return (
         <ToolbarPopoverItem
@@ -181,7 +161,24 @@ export const ModeSelectorField: React.FunctionComponent<{
             aria-label="switch-mode"
             popoverContent={close => (
                 <div className="tw-flex tw-flex-col tw-max-h-[500px] tw-overflow-auto">
-                    <ModeList onClick={handleItemClick(close)} intentOptions={intentOptions} />
+                    <Command>
+                        <CommandList className="tw-p-2">
+                            {intentOptions.map(option => (
+                                <CommandItem
+                                    key={option.intent}
+                                    onSelect={() => handleSelectIntent(option.intent, close)}
+                                    disabled={option.disabled}
+                                    className="tw-flex tw-text-left tw-justify-between tw-rounded-sm tw-cursor-pointer tw-px-4"
+                                >
+                                    <div className="tw-flex tw-gap-4">
+                                        <option.icon className="tw-size-8 tw-mt-1" />
+                                        {option.title}
+                                    </div>
+                                    {option.badge && <Badge>{option.badge}</Badge>}
+                                </CommandItem>
+                            ))}
+                        </CommandList>
+                    </Command>
                 </div>
             )}
             popoverContentProps={{
@@ -191,31 +188,7 @@ export const ModeSelectorField: React.FunctionComponent<{
                 },
             }}
         >
-            {INTENT_MAPPING[intent || 'chat'] || IntentEnum.Chat}
+            {currentSelectedIntent}
         </ToolbarPopoverItem>
     )
 }
-
-export const ModeList: FC<{
-    onClick: (intent?: ChatMessage['intent']) => void
-    intentOptions: IntentOption[]
-}> = ({ onClick, intentOptions }) => (
-    <Command>
-        <CommandList className="tw-p-2">
-            {intentOptions.map(option => (
-                <CommandItem
-                    key={option.intent || 'auto'}
-                    onSelect={() => onClick(option.intent)}
-                    disabled={option.disabled}
-                    className="tw-flex tw-text-left tw-justify-between tw-rounded-sm tw-cursor-pointer tw-px-4"
-                >
-                    <div className="tw-flex tw-gap-4">
-                        <option.icon className="tw-size-8 tw-mt-1" />
-                        {option.title}
-                    </div>
-                    {option.badge && <Badge>{option.badge}</Badge>}
-                </CommandItem>
-            ))}
-        </CommandList>
-    </Command>
-)

--- a/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/ModeSelectorField.stories.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/ModeSelectorField.stories.tsx
@@ -11,7 +11,7 @@ const meta: Meta<typeof ModeSelectorField> = {
         omniBoxEnabled: true,
         isDotComUser: false,
         isCodyProUser: true,
-        intent: 'chat',
+        _intent: 'chat',
         manuallySelectIntent: () => {},
     },
 }
@@ -24,13 +24,13 @@ export const Default: Story = {}
 
 export const WithSearchSelected: Story = {
     args: {
-        intent: 'search',
+        _intent: 'search',
     },
 }
 
 export const WithAgenticSelected: Story = {
     args: {
-        intent: 'agentic',
+        _intent: 'agentic',
     },
 }
 

--- a/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/Toolbar.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/Toolbar.tsx
@@ -143,7 +143,7 @@ export const Toolbar: FunctionComponent<{
                 <ModeSelectorField
                     className={className}
                     omniBoxEnabled={omniBoxEnabled}
-                    intent={intent}
+                    _intent={intent}
                     isDotComUser={userInfo?.isDotComUser}
                     isCodyProUser={userInfo?.isCodyProUser}
                     manuallySelectIntent={manuallySelectIntent}


### PR DESCRIPTION
FIX https://linear.app/sourcegraph/issue/QA-545

This commit fixes an issue where users could use the keyboard shortcut (⌘. or Ctrl+.) 
to cycle through and select chat modes (intents) that should be disabled for them based 
on their permission level.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Added e2e test for dotcom users.