### PR TITLE
Revert "Fix assertion error from webview (closes #2845) (#7257)"

### DIFF
--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
@@ -85,8 +85,6 @@ class CodyAgentService(private val project: Project) : Disposable {
       token: String?,
       secondsTimeout: Long = 45
   ): CompletableFuture<CodyAgent> {
-    WebUIService.getInstance(project).reset()
-
     ApplicationManager.getApplication().executeOnPooledThread {
       try {
         val future =


### PR DESCRIPTION
This reverts commit a31acd06580fe300a2623d4baf75578fb0da54cd.

I'm reverting this as we get few reports of multiple agent processes being spawned, and this is only recent change in this area of code. 

There is a chance that my fix is solving the underlaying issue:
https://github.com/sourcegraph/cody/pull/7466
But if my fix is proper, then we do no need `WebUIService.getInstance(project).reset()` in both `start` and `stop` methods.
I believe before my PR it was sometimes beneficial because there was race between `stop` and `start` code.
But there is also a chance that it was breaking something is timing was slightly different.

## Test plan

N/A
