### PR TITLE
Pass full filepath in prompt to the LLM. 

### DIFF
--- a/lib/prompt-editor/src/PromptEditor.test.tsx
+++ b/lib/prompt-editor/src/PromptEditor.test.tsx
@@ -3,6 +3,7 @@ import {
     type SerializedContextItem,
     contextItemsFromPromptEditorValue,
     serializedPromptEditorStateFromText,
+    testFileUri,
 } from '@sourcegraph/cody-shared'
 import { describe, expect, test } from 'vitest'
 
@@ -18,7 +19,7 @@ describe('serializedPromptEditorStateFromText', () => {
         >([
             {
                 type: 'symbol',
-                uri: 'file:///a/b/file1.go',
+                uri: testFileUri('a/b/file1.go').toString(),
                 range: {
                     start: {
                         line: 2,
@@ -34,11 +35,11 @@ describe('serializedPromptEditorStateFromText', () => {
             },
             {
                 type: 'file',
-                uri: 'file:///dir/dir/file-a-1.py',
+                uri: testFileUri('dir/dir/file-a-1.py').toString(),
             },
             {
                 type: 'file',
-                uri: 'file:///dir/dir/README.md',
+                uri: testFileUri('dir/dir/README.md').toString(),
                 range: {
                     end: {
                         character: 0,

--- a/lib/prompt-editor/src/v2/lexical-interop.test.ts
+++ b/lib/prompt-editor/src/v2/lexical-interop.test.ts
@@ -18,7 +18,7 @@ test('lexical -> prosemirror -> lexical', () => {
             paragraph.append(
                 $createTextNode('before '),
                 $createContextItemMentionNode(
-                    { type: 'file', uri: 'test.ts' },
+                    { type: 'file', uri: '/test.ts' },
                     { isFromInitialContext: true }
                 ),
                 $createTextNode(' after')

--- a/lib/prompt-editor/src/v2/lexical-interop.test.ts
+++ b/lib/prompt-editor/src/v2/lexical-interop.test.ts
@@ -1,4 +1,4 @@
-import { toSerializedPromptEditorValue } from '@sourcegraph/cody-shared'
+import { testFileUri, toSerializedPromptEditorValue } from '@sourcegraph/cody-shared'
 import { $createParagraphNode, $createTextNode, $getRoot, createEditor } from 'lexical'
 import { expect, test } from 'vitest'
 import { RICH_EDITOR_NODES } from '../nodes'
@@ -18,7 +18,7 @@ test('lexical -> prosemirror -> lexical', () => {
             paragraph.append(
                 $createTextNode('before '),
                 $createContextItemMentionNode(
-                    { type: 'file', uri: '/test.ts' },
+                    { type: 'file', uri: testFileUri('test.ts') },
                     { isFromInitialContext: true }
                 ),
                 $createTextNode(' after')

--- a/lib/shared/src/lexicalEditor/editorState.test.ts
+++ b/lib/shared/src/lexicalEditor/editorState.test.ts
@@ -15,6 +15,9 @@ import {
 } from './fixtures'
 import type { SerializedContextItemMentionNode } from './nodes'
 
+const testFileDisplayPath = (path: string) =>
+    PromptString.fromDisplayPath(testFileUri(path)).toString().replaceAll('\\', '/')
+
 describe('textContentFromSerializedLexicalNode', () => {
     test('empty root', () => {
         expect(
@@ -36,9 +39,9 @@ describe('textContentFromSerializedLexicalNode', () => {
                 wrapMention
             )
         ).toBe(
-            `What does <<Symbol1>> in <<${PromptString.fromDisplayPath(
-                testFileUri('dir/dir/file-a-1.py')
-            )}>> do? Also use <<${PromptString.fromDisplayPath(testFileUri('dir/dir/README.md'))}:2-8>>.`
+            `What does <<Symbol1>> in <<${testFileDisplayPath(
+                'dir/dir/file-a-1.py'
+            )}>> do? Also use <<${testFileDisplayPath('dir/dir/README.md')}:2-8>>.`
         )
     })
 
@@ -49,9 +52,9 @@ describe('textContentFromSerializedLexicalNode', () => {
                 wrapMention
             )
         ).toBe(
-            `What does <<Symbol1>> in <<${PromptString.fromDisplayPath(
-                testFileUri('dir/dir/file-a-1.py')
-            )}>> do? Also use <<${PromptString.fromDisplayPath(testFileUri('dir/dir/README.md'))}:2-8>>.`
+            `What does <<Symbol1>> in <<${testFileDisplayPath(
+                'dir/dir/file-a-1.py'
+            )}>> do? Also use <<${testFileDisplayPath('dir/dir/README.md')}:2-8>>.`
         )
     })
 
@@ -62,8 +65,8 @@ describe('textContentFromSerializedLexicalNode', () => {
                 wrapMention
             )
         ).toBe(
-            `Your task is to generate a suit of multiple unit tests for the functions defined inside the <<${PromptString.fromDisplayPath(
-                testFileUri('a/b/file1.go')
+            `Your task is to generate a suit of multiple unit tests for the functions defined inside the <<${testFileDisplayPath(
+                'a/b/file1.go'
             )}>> file.\n\nUse the <<mention the testing framework>> framework to generate the unit tests. Follow the example tests from the <<mention an example test file>> test file. Include unit tests for the following cases: <<list test cases>>.\n\nEnsure that the unit tests cover all the edge cases and validate the expected functionality of the functions`
         )
     })

--- a/lib/shared/src/lexicalEditor/editorState.test.ts
+++ b/lib/shared/src/lexicalEditor/editorState.test.ts
@@ -1,5 +1,6 @@
 import type { SerializedLexicalNode, SerializedRootNode } from 'lexical'
 import { describe, expect, test } from 'vitest'
+import { URI } from 'vscode-uri'
 import { ContextItemSource } from '../codebase-context/messages'
 import { PromptString, ps } from '../prompt/prompt-string'
 import { testFileUri } from '../test/path-helpers'
@@ -165,7 +166,7 @@ describe('editorStateFromPromptString', () => {
 
     test('parse templates', () => {
         const input = ps`Generate tests for @${PromptString.fromDisplayPath(
-            testFileUri('foo.go')
+            URI.file('foo.go')
         )} using {{mention framework}} framework to generate the unit tests`
         const editorState = editorStateFromPromptString(input, {
             parseTemplates: true,

--- a/lib/shared/src/lexicalEditor/editorState.test.ts
+++ b/lib/shared/src/lexicalEditor/editorState.test.ts
@@ -36,7 +36,9 @@ describe('textContentFromSerializedLexicalNode', () => {
                 wrapMention
             )
         ).toBe(
-            'What does <<Symbol1>> in <<dir/dir/file-a-1.py>> do? Also use <<dir/dir/README.md:2-8>>.'
+            `What does <<Symbol1>> in <<${testFileUri(
+                'dir/dir/file-a-1.py'
+            )}>> do? Also use <<${testFileUri('dir/dir/README.md')}:2-8>>.`
         )
     })
 
@@ -47,7 +49,9 @@ describe('textContentFromSerializedLexicalNode', () => {
                 wrapMention
             )
         ).toBe(
-            'What does <<Symbol1>> in <<dir/dir/file-a-1.py>> do? Also use <<dir/dir/README.md:2-8>>.'
+            `What does <<Symbol1>> in <<${testFileUri(
+                'dir/dir/file-a-1.py'
+            )}>> do? Also use <<${testFileUri('dir/dir/README.md')}:2-8>>.`
         )
     })
 
@@ -58,7 +62,11 @@ describe('textContentFromSerializedLexicalNode', () => {
                 wrapMention
             )
         ).toBe(
-            'Your task is to generate a suit of multiple unit tests for the functions defined inside the <<a/b/file1.go>> file.\n\nUse the <<mention the testing framework>> framework to generate the unit tests. Follow the example tests from the <<mention an example test file>> test file. Include unit tests for the following cases: <<list test cases>>.\n\nEnsure that the unit tests cover all the edge cases and validate the expected functionality of the functions'
+            `Your task is to generate a suit of multiple unit tests for the functions defined inside the <<${testFileUri(
+                'a/b/file1.go'
+            )}>> file.\n\nUse the <<mention the testing framework>> framework to generate the unit tests. Follow the example tests from the <<${testFileUri(
+                'an example test file'
+            )}>> test file. Include unit tests for the following cases: <<list test cases>>.\n\nEnsure that the unit tests cover all the edge cases and validate the expected functionality of the functions`
         )
     })
 })

--- a/lib/shared/src/lexicalEditor/editorState.test.ts
+++ b/lib/shared/src/lexicalEditor/editorState.test.ts
@@ -36,7 +36,7 @@ describe('textContentFromSerializedLexicalNode', () => {
                 wrapMention
             )
         ).toBe(
-            'What does <<Symbol1>> in <<dir/dir/file-a-1.py>> do? Also use <<dir/dir/README.md:2-8>>.'
+            'What does <<Symbol1>> in <</dir/dir/file-a-1.py>> do? Also use <</dir/dir/README.md:2-8>>.'
         )
     })
 
@@ -47,7 +47,7 @@ describe('textContentFromSerializedLexicalNode', () => {
                 wrapMention
             )
         ).toBe(
-            'What does <<Symbol1>> in <<dir/dir/file-a-1.py>> do? Also use <<dir/dir/README.md:2-8>>.'
+            'What does <<Symbol1>> in <</dir/dir/file-a-1.py>> do? Also use <</dir/dir/README.md:2-8>>.'
         )
     })
 
@@ -58,7 +58,7 @@ describe('textContentFromSerializedLexicalNode', () => {
                 wrapMention
             )
         ).toBe(
-            'Your task is to generate a suit of multiple unit tests for the functions defined inside the <<a/b/file1.go>> file.\n\nUse the <<mention the testing framework>> framework to generate the unit tests. Follow the example tests from the <<mention an example test file>> test file. Include unit tests for the following cases: <<list test cases>>.\n\nEnsure that the unit tests cover all the edge cases and validate the expected functionality of the functions'
+            'Your task is to generate a suit of multiple unit tests for the functions defined inside the <</a/b/file1.go>> file.\n\nUse the <<mention the testing framework>> framework to generate the unit tests. Follow the example tests from the <<mention an example test file>> test file. Include unit tests for the following cases: <<list test cases>>.\n\nEnsure that the unit tests cover all the edge cases and validate the expected functionality of the functions'
         )
     })
 })

--- a/lib/shared/src/lexicalEditor/editorState.test.ts
+++ b/lib/shared/src/lexicalEditor/editorState.test.ts
@@ -36,7 +36,7 @@ describe('textContentFromSerializedLexicalNode', () => {
                 wrapMention
             )
         ).toBe(
-            'What does <<Symbol1>> in <</dir/dir/file-a-1.py>> do? Also use <</dir/dir/README.md:2-8>>.'
+            'What does <<Symbol1>> in <<dir/dir/file-a-1.py>> do? Also use <<dir/dir/README.md:2-8>>.'
         )
     })
 
@@ -47,7 +47,7 @@ describe('textContentFromSerializedLexicalNode', () => {
                 wrapMention
             )
         ).toBe(
-            'What does <<Symbol1>> in <</dir/dir/file-a-1.py>> do? Also use <</dir/dir/README.md:2-8>>.'
+            'What does <<Symbol1>> in <<dir/dir/file-a-1.py>> do? Also use <<dir/dir/README.md:2-8>>.'
         )
     })
 
@@ -58,7 +58,7 @@ describe('textContentFromSerializedLexicalNode', () => {
                 wrapMention
             )
         ).toBe(
-            'Your task is to generate a suit of multiple unit tests for the functions defined inside the <</a/b/file1.go>> file.\n\nUse the <<mention the testing framework>> framework to generate the unit tests. Follow the example tests from the <<mention an example test file>> test file. Include unit tests for the following cases: <<list test cases>>.\n\nEnsure that the unit tests cover all the edge cases and validate the expected functionality of the functions'
+            'Your task is to generate a suit of multiple unit tests for the functions defined inside the <<a/b/file1.go>> file.\n\nUse the <<mention the testing framework>> framework to generate the unit tests. Follow the example tests from the <<mention an example test file>> test file. Include unit tests for the following cases: <<list test cases>>.\n\nEnsure that the unit tests cover all the edge cases and validate the expected functionality of the functions'
         )
     })
 })

--- a/lib/shared/src/lexicalEditor/editorState.test.ts
+++ b/lib/shared/src/lexicalEditor/editorState.test.ts
@@ -1,8 +1,8 @@
 import type { SerializedLexicalNode, SerializedRootNode } from 'lexical'
 import { describe, expect, test } from 'vitest'
-import { URI } from 'vscode-uri'
 import { ContextItemSource } from '../codebase-context/messages'
 import { PromptString, ps } from '../prompt/prompt-string'
+import { testFileUri } from '../test/path-helpers'
 import {
     editorStateFromPromptString,
     editorStateToText,
@@ -66,8 +66,8 @@ describe('textContentFromSerializedLexicalNode', () => {
 describe('editorStateFromPromptString', () => {
     test('converts to rich mentions', async () => {
         const input = ps`What are @${PromptString.fromDisplayPath(
-            URI.file('foo.go')
-        )}:3-5 and @${PromptString.fromDisplayPath(URI.file('bar.go'))} about?`
+            testFileUri('foo.go')
+        )}:3-5 and @${PromptString.fromDisplayPath(testFileUri('bar.go'))} about?`
         const editorState = editorStateFromPromptString(input)
         expect(editorState.lexicalEditorState.root).toEqual<SerializedRootNode>({
             children: [
@@ -87,7 +87,7 @@ describe('editorStateFromPromptString', () => {
                             version: 1,
                             contextItem: {
                                 type: 'file',
-                                uri: 'file:///foo.go',
+                                uri: testFileUri('foo.go').toString(),
                                 content: undefined,
                                 source: ContextItemSource.User,
                                 range: {
@@ -118,7 +118,7 @@ describe('editorStateFromPromptString', () => {
                             version: 1,
                             contextItem: {
                                 type: 'file',
-                                uri: 'file:///bar.go',
+                                uri: testFileUri('bar.go').toString(),
                                 content: undefined,
                                 range: undefined,
                                 source: ContextItemSource.Editor,
@@ -156,7 +156,7 @@ describe('editorStateFromPromptString', () => {
 
     test('parse templates', () => {
         const input = ps`Generate tests for @${PromptString.fromDisplayPath(
-            URI.file('foo.go')
+            testFileUri('foo.go')
         )} using {{mention framework}} framework to generate the unit tests`
         const editorState = editorStateFromPromptString(input, {
             parseTemplates: true,
@@ -227,7 +227,7 @@ describe('editorStateToText', () => {
                                     version: 1,
                                     contextItem: {
                                         type: 'file',
-                                        uri: 'file:///foo/bar/baz.go',
+                                        uri: testFileUri('foo/bar/baz.go').toString(),
                                         content: undefined,
                                         source: ContextItemSource.User,
                                         range: {
@@ -287,7 +287,7 @@ describe('editorStateToText', () => {
                                     version: 1,
                                     contextItem: {
                                         type: 'file',
-                                        uri: 'file:///foo/bar/file1.go',
+                                        uri: testFileUri('foo/bar/file1.go').toString(),
                                         content: undefined,
                                         source: ContextItemSource.User,
                                         range: {
@@ -312,7 +312,7 @@ describe('editorStateToText', () => {
                                     version: 1,
                                     contextItem: {
                                         type: 'file',
-                                        uri: 'file:///foo/bar/file2.go',
+                                        uri: testFileUri('foo/bar/file2.go').toString(),
                                         content: undefined,
                                         source: ContextItemSource.User,
                                         range: {

--- a/lib/shared/src/lexicalEditor/editorState.test.ts
+++ b/lib/shared/src/lexicalEditor/editorState.test.ts
@@ -3,7 +3,11 @@ import { describe, expect, test } from 'vitest'
 import { URI } from 'vscode-uri'
 import { ContextItemSource } from '../codebase-context/messages'
 import { PromptString, ps } from '../prompt/prompt-string'
-import { editorStateFromPromptString, textContentFromSerializedLexicalNode } from './editorState'
+import {
+    editorStateFromPromptString,
+    editorStateToText,
+    textContentFromSerializedLexicalNode,
+} from './editorState'
 import {
     FILE_MENTION_EDITOR_STATE_FIXTURE,
     GENERATE_UNIT_TEST_EDITOR_STATE_FIXTURE,
@@ -31,7 +35,9 @@ describe('textContentFromSerializedLexicalNode', () => {
                 FILE_MENTION_EDITOR_STATE_FIXTURE.lexicalEditorState.root,
                 wrapMention
             )
-        ).toBe('What does <<Symbol1>> in <<file-a-1.py>> do? Also use <<README.md:2-8>>.')
+        ).toBe(
+            'What does <<Symbol1>> in <<dir/dir/file-a-1.py>> do? Also use <<dir/dir/README.md:2-8>>.'
+        )
     })
 
     test('fixture from text mentions', () => {
@@ -40,7 +46,9 @@ describe('textContentFromSerializedLexicalNode', () => {
                 OLD_TEXT_FILE_MENTION_EDITOR_STATE_FIXTURE.lexicalEditorState.root,
                 wrapMention
             )
-        ).toBe('What does <<Symbol1>> in <<file-a-1.py>> do? Also use <<README.md:2-8>>.')
+        ).toBe(
+            'What does <<Symbol1>> in <<dir/dir/file-a-1.py>> do? Also use <<dir/dir/README.md:2-8>>.'
+        )
     })
 
     test('fixture from template', () => {
@@ -50,7 +58,7 @@ describe('textContentFromSerializedLexicalNode', () => {
                 wrapMention
             )
         ).toBe(
-            'Your task is to generate a suit of multiple unit tests for the functions defined inside the <<file1.go>> file.\n\nUse the <<mention the testing framework>> framework to generate the unit tests. Follow the example tests from the <<mention an example test file>> test file. Include unit tests for the following cases: <<list test cases>>.\n\nEnsure that the unit tests cover all the edge cases and validate the expected functionality of the functions'
+            'Your task is to generate a suit of multiple unit tests for the functions defined inside the <<a/b/file1.go>> file.\n\nUse the <<mention the testing framework>> framework to generate the unit tests. Follow the example tests from the <<mention an example test file>> test file. Include unit tests for the following cases: <<list test cases>>.\n\nEnsure that the unit tests cover all the edge cases and validate the expected functionality of the functions'
         )
     })
 })
@@ -158,6 +166,181 @@ describe('editorStateFromPromptString', () => {
             textContentFromSerializedLexicalNode(editorState.lexicalEditorState.root, wrapMention)
         ).toBe(
             'Generate tests for <<foo.go>> using <<mention framework>> framework to generate the unit tests'
+        )
+    })
+})
+
+describe('editorStateToText', () => {
+    test('converts simple text editor state', () => {
+        const mockEditorState = {
+            toJSON: () => ({
+                root: {
+                    children: [
+                        {
+                            children: [
+                                {
+                                    detail: 0,
+                                    format: 0,
+                                    mode: 'normal',
+                                    style: '',
+                                    text: 'Hello world',
+                                    type: 'text',
+                                    version: 1,
+                                },
+                            ],
+                            direction: null,
+                            format: '',
+                            indent: 0,
+                            type: 'paragraph',
+                            version: 1,
+                        },
+                    ],
+                    direction: null,
+                    format: '',
+                    indent: 0,
+                    type: 'root',
+                    version: 1,
+                },
+            }),
+        }
+        expect(editorStateToText(mockEditorState as any)).toBe('Hello world')
+    })
+
+    test('converts editor state with file context item', () => {
+        const mockEditorState = {
+            toJSON: () => ({
+                root: {
+                    children: [
+                        {
+                            children: [
+                                {
+                                    detail: 0,
+                                    format: 0,
+                                    mode: 'normal',
+                                    style: '',
+                                    text: 'What does ',
+                                    type: 'text',
+                                    version: 1,
+                                },
+                                {
+                                    type: 'contextItemMention',
+                                    version: 1,
+                                    contextItem: {
+                                        type: 'file',
+                                        uri: 'file:///foo/bar/baz.go',
+                                        content: undefined,
+                                        source: ContextItemSource.User,
+                                        range: {
+                                            start: { line: 2, character: 0 },
+                                            end: { line: 5, character: 0 },
+                                        },
+                                    },
+                                    isFromInitialContext: false,
+                                    text: 'baz.go:3-5',
+                                },
+                                {
+                                    detail: 0,
+                                    format: 0,
+                                    mode: 'normal',
+                                    style: '',
+                                    text: ' do?',
+                                    type: 'text',
+                                    version: 1,
+                                },
+                            ],
+                            direction: null,
+                            format: '',
+                            indent: 0,
+                            type: 'paragraph',
+                            version: 1,
+                        },
+                    ],
+                    direction: null,
+                    format: '',
+                    indent: 0,
+                    type: 'root',
+                    version: 1,
+                },
+            }),
+        }
+        expect(editorStateToText(mockEditorState as any)).toBe('What does foo/bar/baz.go:3-5 do?')
+    })
+
+    test('converts editor state with multiple file context items', () => {
+        const mockEditorState = {
+            toJSON: () => ({
+                root: {
+                    children: [
+                        {
+                            children: [
+                                {
+                                    detail: 0,
+                                    format: 0,
+                                    mode: 'normal',
+                                    style: '',
+                                    text: 'Compare ',
+                                    type: 'text',
+                                    version: 1,
+                                },
+                                {
+                                    type: 'contextItemMention',
+                                    version: 1,
+                                    contextItem: {
+                                        type: 'file',
+                                        uri: 'file:///foo/bar/file1.go',
+                                        content: undefined,
+                                        source: ContextItemSource.User,
+                                        range: {
+                                            start: { line: 1, character: 0 },
+                                            end: { line: 10, character: 0 },
+                                        },
+                                    },
+                                    isFromInitialContext: false,
+                                    text: 'file1.go:2-10',
+                                },
+                                {
+                                    detail: 0,
+                                    format: 0,
+                                    mode: 'normal',
+                                    style: '',
+                                    text: ' with ',
+                                    type: 'text',
+                                    version: 1,
+                                },
+                                {
+                                    type: 'contextItemMention',
+                                    version: 1,
+                                    contextItem: {
+                                        type: 'file',
+                                        uri: 'file:///foo/bar/file2.go',
+                                        content: undefined,
+                                        source: ContextItemSource.User,
+                                        range: {
+                                            start: { line: 1, character: 0 },
+                                            end: { line: 10, character: 0 },
+                                        },
+                                    },
+                                    isFromInitialContext: false,
+                                    text: 'file2.go:2-10',
+                                },
+                            ],
+                            direction: null,
+                            format: '',
+                            indent: 0,
+                            type: 'paragraph',
+                            version: 1,
+                        },
+                    ],
+                    direction: null,
+                    format: '',
+                    indent: 0,
+                    type: 'root',
+                    version: 1,
+                },
+            }),
+        }
+        expect(editorStateToText(mockEditorState as any)).toBe(
+            'Compare foo/bar/file1.go:2-10 with foo/bar/file2.go:2-10'
         )
     })
 })

--- a/lib/shared/src/lexicalEditor/editorState.test.ts
+++ b/lib/shared/src/lexicalEditor/editorState.test.ts
@@ -175,7 +175,9 @@ describe('editorStateFromPromptString', () => {
         expect(
             textContentFromSerializedLexicalNode(editorState.lexicalEditorState.root, wrapMention)
         ).toBe(
-            'Generate tests for <<foo.go>> using <<mention framework>> framework to generate the unit tests'
+            `Generate tests for <<${PromptString.fromDisplayPath(
+                URI.file('foo.go')
+            )}>> using <<mention framework>> framework to generate the unit tests`
         )
     })
 })

--- a/lib/shared/src/lexicalEditor/editorState.test.ts
+++ b/lib/shared/src/lexicalEditor/editorState.test.ts
@@ -165,13 +165,22 @@ describe('editorStateFromPromptString', () => {
     })
 
     test('parse templates', () => {
-        const input = ps`Generate tests for @${PromptString.fromDisplayPath(
+        const inputForSnapshot = ps`Generate tests for @${PromptString.fromDisplayPath(
             URI.file('foo.go')
+        )} using {{mention framework}} framework to generate the unit tests`
+        const editorStateForSnapshot = editorStateFromPromptString(inputForSnapshot, {
+            parseTemplates: true,
+        })
+
+        expect(editorStateForSnapshot.lexicalEditorState.root).matchSnapshot()
+
+        const input = ps`Generate tests for @${PromptString.fromDisplayPath(
+            testFileUri('foo.go')
         )} using {{mention framework}} framework to generate the unit tests`
         const editorState = editorStateFromPromptString(input, {
             parseTemplates: true,
         })
-        expect(editorState.lexicalEditorState.root).matchSnapshot()
+
         expect(
             textContentFromSerializedLexicalNode(editorState.lexicalEditorState.root, wrapMention)
         ).toBe(

--- a/lib/shared/src/lexicalEditor/editorState.test.ts
+++ b/lib/shared/src/lexicalEditor/editorState.test.ts
@@ -64,9 +64,7 @@ describe('textContentFromSerializedLexicalNode', () => {
         ).toBe(
             `Your task is to generate a suit of multiple unit tests for the functions defined inside the <<${PromptString.fromDisplayPath(
                 testFileUri('a/b/file1.go')
-            )}>> file.\n\nUse the <<mention the testing framework>> framework to generate the unit tests. Follow the example tests from the <<${PromptString.fromDisplayPath(
-                testFileUri('an example test file')
-            )}>> test file. Include unit tests for the following cases: <<list test cases>>.\n\nEnsure that the unit tests cover all the edge cases and validate the expected functionality of the functions`
+            )}>> file.\n\nUse the <<mention the testing framework>> framework to generate the unit tests. Follow the example tests from the <<mention an example test file>> test file. Include unit tests for the following cases: <<list test cases>>.\n\nEnsure that the unit tests cover all the edge cases and validate the expected functionality of the functions`
         )
     })
 })

--- a/lib/shared/src/lexicalEditor/editorState.test.ts
+++ b/lib/shared/src/lexicalEditor/editorState.test.ts
@@ -176,7 +176,7 @@ describe('editorStateFromPromptString', () => {
             textContentFromSerializedLexicalNode(editorState.lexicalEditorState.root, wrapMention)
         ).toBe(
             `Generate tests for <<${PromptString.fromDisplayPath(
-                URI.file('foo.go')
+                testFileUri('foo.go')
             )}>> using <<mention framework>> framework to generate the unit tests`
         )
     })

--- a/lib/shared/src/lexicalEditor/editorState.test.ts
+++ b/lib/shared/src/lexicalEditor/editorState.test.ts
@@ -36,9 +36,9 @@ describe('textContentFromSerializedLexicalNode', () => {
                 wrapMention
             )
         ).toBe(
-            `What does <<Symbol1>> in <<${testFileUri(
-                'dir/dir/file-a-1.py'
-            )}>> do? Also use <<${testFileUri('dir/dir/README.md')}:2-8>>.`
+            `What does <<Symbol1>> in <<${PromptString.fromDisplayPath(
+                testFileUri('dir/dir/file-a-1.py')
+            )}>> do? Also use <<${PromptString.fromDisplayPath(testFileUri('dir/dir/README.md'))}:2-8>>.`
         )
     })
 
@@ -49,9 +49,9 @@ describe('textContentFromSerializedLexicalNode', () => {
                 wrapMention
             )
         ).toBe(
-            `What does <<Symbol1>> in <<${testFileUri(
-                'dir/dir/file-a-1.py'
-            )}>> do? Also use <<${testFileUri('dir/dir/README.md')}:2-8>>.`
+            `What does <<Symbol1>> in <<${PromptString.fromDisplayPath(
+                testFileUri('dir/dir/file-a-1.py')
+            )}>> do? Also use <<${PromptString.fromDisplayPath(testFileUri('dir/dir/README.md'))}:2-8>>.`
         )
     })
 
@@ -62,10 +62,10 @@ describe('textContentFromSerializedLexicalNode', () => {
                 wrapMention
             )
         ).toBe(
-            `Your task is to generate a suit of multiple unit tests for the functions defined inside the <<${testFileUri(
-                'a/b/file1.go'
-            )}>> file.\n\nUse the <<mention the testing framework>> framework to generate the unit tests. Follow the example tests from the <<${testFileUri(
-                'an example test file'
+            `Your task is to generate a suit of multiple unit tests for the functions defined inside the <<${PromptString.fromDisplayPath(
+                testFileUri('a/b/file1.go')
+            )}>> file.\n\nUse the <<mention the testing framework>> framework to generate the unit tests. Follow the example tests from the <<${PromptString.fromDisplayPath(
+                testFileUri('an example test file')
             )}>> test file. Include unit tests for the following cases: <<list test cases>>.\n\nEnsure that the unit tests cover all the edge cases and validate the expected functionality of the functions`
         )
     })

--- a/lib/shared/src/lexicalEditor/editorState.ts
+++ b/lib/shared/src/lexicalEditor/editorState.ts
@@ -1,11 +1,10 @@
-import {
-    $getRoot,
-    type EditorState,
-    type LexicalEditor,
-    type SerializedEditorState,
-    type SerializedLexicalNode,
-    type SerializedRootNode,
-    type SerializedTextNode,
+import type {
+    EditorState,
+    LexicalEditor,
+    SerializedEditorState,
+    SerializedLexicalNode,
+    SerializedRootNode,
+    SerializedTextNode,
 } from 'lexical'
 import type { ChatMessage } from '../chat/transcript/messages'
 import { type ContextItem, ContextItemSource } from '../codebase-context/messages'
@@ -20,6 +19,7 @@ import {
     type SerializedTemplateInputNode,
     TEMPLATE_INPUT_NODE_TYPE,
     contextItemMentionNodeDisplayText,
+    contextItemMentionNodePromptText,
     isSerializedContextItemMentionNode,
     serializeContextItem,
     templateInputNodeDisplayText,
@@ -225,7 +225,7 @@ export function textContentFromSerializedLexicalNode(
     const text: string[] = []
     forEachPreOrder(root, node => {
         if ('type' in node && node.type === CONTEXT_ITEM_MENTION_NODE_TYPE) {
-            const nodeText = contextItemMentionNodeDisplayText(
+            const nodeText = contextItemMentionNodePromptText(
                 (node as SerializedContextItemMentionNode).contextItem
             )
             text.push(__testing_wrapText ? __testing_wrapText(nodeText) ?? nodeText : nodeText)
@@ -240,7 +240,7 @@ export function textContentFromSerializedLexicalNode(
 }
 
 export function editorStateToText(editorState: EditorState): string {
-    return editorState.read(() => $getRoot().getTextContent())
+    return textContentFromSerializedLexicalNode(editorState.toJSON().root)
 }
 
 interface EditorStateFromPromptStringOptions {

--- a/lib/shared/src/lexicalEditor/fixtures.ts
+++ b/lib/shared/src/lexicalEditor/fixtures.ts
@@ -1,4 +1,5 @@
 import type { SerializedLexicalNode, SerializedTextNode } from 'lexical'
+import { testFileUri } from '../test/path-helpers'
 import type { SerializedPromptEditorState } from './editorState'
 import type {
     SerializedContextItem,
@@ -28,7 +29,7 @@ export const FILE_MENTION_EDITOR_STATE_FIXTURE: SerializedPromptEditorState = {
                             version: 1,
                             contextItem: {
                                 type: 'symbol',
-                                uri: 'file:///a/b/file1.go',
+                                uri: testFileUri('a/b/file1.go').toString(),
                                 range: {
                                     start: {
                                         line: 2,
@@ -59,7 +60,7 @@ export const FILE_MENTION_EDITOR_STATE_FIXTURE: SerializedPromptEditorState = {
                             version: 1,
                             contextItem: {
                                 type: 'file',
-                                uri: 'file:///dir/dir/file-a-1.py',
+                                uri: testFileUri('dir/dir/file-a-1.py').toString(),
                             },
                             isFromInitialContext: false,
                             text: 'file-a-1.py',
@@ -78,7 +79,7 @@ export const FILE_MENTION_EDITOR_STATE_FIXTURE: SerializedPromptEditorState = {
                             version: 1,
                             contextItem: {
                                 type: 'file',
-                                uri: 'file:///dir/dir/README.md',
+                                uri: testFileUri('dir/dir/README.md').toString(),
                                 range: {
                                     start: {
                                         line: 1,
@@ -150,7 +151,7 @@ export const GENERATE_UNIT_TEST_EDITOR_STATE_FIXTURE: SerializedPromptEditorStat
                             type: 'contextItemMention',
                             contextItem: {
                                 type: 'file',
-                                uri: 'file:///a/b/file1.go',
+                                uri: testFileUri('a/b/file1.go').toString(),
                                 source: 'user',
                             },
                             text: 'file1.go',
@@ -253,7 +254,7 @@ export const OLD_TEXT_FILE_MENTION_EDITOR_STATE_FIXTURE: SerializedPromptEditorS
                             version: 1,
                             contextItem: {
                                 type: 'symbol',
-                                uri: 'file:///a/b/file1.go',
+                                uri: testFileUri('a/b/file1.go').toString(),
                                 range: {
                                     start: {
                                         line: 2,
@@ -291,7 +292,7 @@ export const OLD_TEXT_FILE_MENTION_EDITOR_STATE_FIXTURE: SerializedPromptEditorS
                             version: 1,
                             contextItem: {
                                 type: 'file',
-                                uri: 'file:///dir/dir/file-a-1.py',
+                                uri: testFileUri('dir/dir/file-a-1.py').toString(),
                             },
                             isFromInitialContext: false,
                         } satisfies SerializedTextNode & {
@@ -317,7 +318,7 @@ export const OLD_TEXT_FILE_MENTION_EDITOR_STATE_FIXTURE: SerializedPromptEditorS
                             version: 1,
                             contextItem: {
                                 type: 'file',
-                                uri: 'file:///dir/dir/README.md',
+                                uri: testFileUri('dir/dir/README.md').toString(),
                                 range: {
                                     start: {
                                         line: 1,

--- a/lib/shared/src/lexicalEditor/nodes.ts
+++ b/lib/shared/src/lexicalEditor/nodes.ts
@@ -303,7 +303,9 @@ export function contextItemMentionNodePromptText(contextItem: SerializedContextI
     if (contextItem.type === 'file' && !contextItem.provider) {
         const rangeText = contextItem.range?.start ? `:${displayLineRange(contextItem.range)}` : ''
 
-        return `${decodeURIComponent(displayPath(URI.parse(contextItem.uri)))}${rangeText}`
+        // Always use forward slashes for paths in tests, regardless of platform
+        const path = decodeURIComponent(displayPath(URI.parse(contextItem.uri)))
+        return `${path.replace(/\\/g, '/')}${rangeText}`
     }
 
     return contextItemMentionNodeDisplayText(contextItem)

--- a/lib/shared/src/lexicalEditor/nodes.ts
+++ b/lib/shared/src/lexicalEditor/nodes.ts
@@ -25,7 +25,7 @@ import {
     isRangeProperSubset,
     mergeRanges,
 } from '../common/range'
-import { displayPathBasename } from '../editor/displayPath'
+import { displayPath, displayPathBasename } from '../editor/displayPath'
 
 export const CONTEXT_ITEM_MENTION_NODE_TYPE = 'contextItemMention'
 export const TEMPLATE_INPUT_NODE_TYPE = 'templateInput'
@@ -297,6 +297,16 @@ function doesSerializedContextItemSubsume(a: SerializedContextItem, b: Serialize
     }
 
     return isRangeContained(a.range, b.range) || isRangeContained(b.range, a.range)
+}
+
+export function contextItemMentionNodePromptText(contextItem: SerializedContextItem): string {
+    if (contextItem.type === 'file' && !contextItem.provider) {
+        const rangeText = contextItem.range?.start ? `:${displayLineRange(contextItem.range)}` : ''
+
+        return `${decodeURIComponent(displayPath(URI.parse(contextItem.uri)))}${rangeText}`
+    }
+
+    return contextItemMentionNodeDisplayText(contextItem)
 }
 
 export function contextItemMentionNodeDisplayText(contextItem: SerializedContextItem): string {

--- a/vscode/webviews/components/promptList/PromptList.tsx
+++ b/vscode/webviews/components/promptList/PromptList.tsx
@@ -169,6 +169,7 @@ export const PromptList: FC<PromptListProps> = props => {
                 promptFilters?.promoted || promptFilters?.owner || promptFilters?.tags
 
             const isEditEnabled = clientCapabilities.edit === 'enabled'
+            console.log('isEditEnabled', isEditEnabled, clientCapabilities)
             // Prompts that perform edits are not usable on clients that don't support editing.
             // To avoid cluttering the list with unusable prompts we ignore them completely.
             if (!isEditEnabled) {

--- a/vscode/webviews/components/promptList/PromptList.tsx
+++ b/vscode/webviews/components/promptList/PromptList.tsx
@@ -169,7 +169,6 @@ export const PromptList: FC<PromptListProps> = props => {
                 promptFilters?.promoted || promptFilters?.owner || promptFilters?.tags
 
             const isEditEnabled = clientCapabilities.edit === 'enabled'
-            console.log('isEditEnabled', isEditEnabled, clientCapabilities)
             // Prompts that perform edits are not usable on clients that don't support editing.
             // To avoid cluttering the list with unusable prompts we ignore them completely.
             if (!isEditEnabled) {


### PR DESCRIPTION
closes: https://linear.app/sourcegraph/issue/CODY-5393/bug-fix-send-the-file-path-to-the-model-for-at-mentions

This PR updates the get text from editor state logic to include the full file display path and not just the file basename. 

The text is sent to the LLM as the human message text.

## Test plan

unit tests added. 

mention a file and debug & test if the full file display path is included in the prompt.