### PR TITLE
feat(auto-edit): Add beta onboarding for auto-edit

### DIFF
--- a/vscode/src/autoedits/autoedit-onboarding.ts
+++ b/vscode/src/autoedits/autoedit-onboarding.ts
@@ -12,62 +12,44 @@ import * as vscode from 'vscode'
 import { localStorage } from '../services/LocalStorageProvider'
 import { isUserEligibleForAutoeditsFeature } from './create-autoedits-provider'
 
-export interface AutoEditNotificationInfo {
-    lastNotifiedTime: number
-    timesShown: number
-}
-
-const userNotificationAction = {
-    notificationAccepted: 1,
-    notificationRejected: 2,
-    notificationIgnored: 3,
-} as const
-
-interface AutoEditNotificationPayload {
-    timesNotified: number
-    actionTaken: (typeof userNotificationAction)[keyof typeof userNotificationAction]
-}
-
-export class AutoEditOnboarding implements vscode.Disposable {
-    private readonly MAX_AUTO_EDITS_ONBOARDING_NOTIFICATIONS = 3
-    private readonly MIN_TIME_DIFF_AUTO_EDITS_BETWEEN_NOTIFICATIONS_MS = 60 * 60 * 1000 // 1 hour
-
+export class AutoEditBetaOnboarding implements vscode.Disposable {
     private featureFlagAutoEditExperimental = storeLastValue(
         featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.CodyAutoEditExperimentEnabledFeatureFlag)
     )
 
-    public async showAutoEditOnboardingIfEligible(): Promise<void> {
-        const shouldShowOnboardingPopup = await this.shouldShowAutoEditOnboardingPopup()
-        if (shouldShowOnboardingPopup) {
-            await this.showAutoEditOnboardingPopup()
+    public async enrollUserToAutoEditBetaIfEligible(): Promise<void> {
+        const isUserEligibleForAutoeditBeta = await this.isUserEligibleForAutoeditBetaOverride()
+        if (isUserEligibleForAutoeditBeta) {
+            await this.enrollUserToAutoEditBeta()
         }
     }
 
-    private async showAutoEditOnboardingPopup(): Promise<void> {
-        const { timesShown } = await this.getAutoEditOnboardingNotificationInfo()
+    private async enrollUserToAutoEditBeta(): Promise<void> {
+        const switchToAutocompleteText = 'Switch to autocomplete'
 
-        const enableAutoeditText = 'Enable Auto-edit'
-        const dontShowAgainText = "Don't Show Again"
+        await vscode.workspace
+            .getConfiguration()
+            .update(
+                'cody.suggestions.mode',
+                CodyAutoSuggestionMode.Autoedit,
+                vscode.ConfigurationTarget.Global
+            )
+        // Set Enroll to true in local storage so that we don't override the setting if the user changes it
+        await localStorage.setAutoeditBetaEnrollment()
+        this.writeAutoeditNotificationEvent()
 
-        const selection = await Promise.race([
-            vscode.window.showInformationMessage(
-                'Try Cody Auto-edit (experimental)? Cody will intelligently suggest next edits as you navigate the codebase.',
-                enableAutoeditText,
-                dontShowAgainText
-            ),
-            new Promise<string | undefined>(
-                resolve => setTimeout(() => resolve(undefined), 30_000) // 30 seconds timeout
-            ),
-        ])
-        await this.incrementAutoEditOnboardingNotificationCount({ incrementCount: 1 })
+        const selection = await vscode.window.showInformationMessage(
+            'You have been enrolled to Cody Auto-edit! Cody will intelligently suggest next edits as you navigate the codebase.',
+            switchToAutocompleteText
+        )
 
-        if (selection === enableAutoeditText) {
+        if (selection === switchToAutocompleteText) {
             // Enable the setting programmatically
             await vscode.workspace
                 .getConfiguration()
                 .update(
                     'cody.suggestions.mode',
-                    CodyAutoSuggestionMode.Autoedit,
+                    CodyAutoSuggestionMode.Autocomplete,
                     vscode.ConfigurationTarget.Global
                 )
 
@@ -76,57 +58,31 @@ export class AutoEditOnboarding implements vscode.Disposable {
                 'workbench.action.openSettings',
                 'cody.suggestions.mode'
             )
-        } else if (selection === dontShowAgainText) {
-            // If user doesn't want to see the notification again, increase number of shown notification by max limit + 1
-            // to prevent showing the notification again until the user restarts VS Code.
-            await this.incrementAutoEditOnboardingNotificationCount({
-                incrementCount: this.MAX_AUTO_EDITS_ONBOARDING_NOTIFICATIONS + 1,
-            })
         }
-
-        const notificationPayload: AutoEditNotificationPayload = {
-            timesNotified: timesShown,
-            actionTaken:
-                selection === enableAutoeditText
-                    ? userNotificationAction.notificationAccepted
-                    : selection === dontShowAgainText
-                      ? userNotificationAction.notificationRejected
-                      : userNotificationAction.notificationIgnored,
-        }
-        this.writeAutoeditNotificationEvent(notificationPayload)
     }
 
-    private writeAutoeditNotificationEvent(payload: AutoEditNotificationPayload): void {
-        telemetryRecorder.recordEvent('cody.autoedit', 'notified', {
+    private writeAutoeditNotificationEvent(): void {
+        // Track that the user has been enrolled to auto edit beta for monitoring purposes
+        telemetryRecorder.recordEvent('cody.autoedit', 'beta-enrolled', {
             version: 0,
-            metadata: {
-                timesNotified: payload.timesNotified,
-                userActionTaken: payload.actionTaken,
-            },
         })
     }
 
-    private async shouldShowAutoEditOnboardingPopup(): Promise<boolean> {
+    private async isUserEligibleForAutoeditBetaOverride(): Promise<boolean> {
         const isAutoEditEnabled = await this.isAutoEditEnabled()
         if (isAutoEditEnabled) {
             return false
         }
-        const isUserEligible = await this.isUserEligibleForAutoEditOnboarding()
+        const isUserEligible = await this.isUserEligibleForAutoEditFeature()
         if (!isUserEligible) {
             return false
         }
-        const isUnderNotificationLimit = await this.isAutoEditNotificationsUnderLimit()
-        return isUnderNotificationLimit
-    }
-
-    private async incrementAutoEditOnboardingNotificationCount(param: {
-        incrementCount: number
-    }): Promise<void> {
-        const info = await this.getAutoEditOnboardingNotificationInfo()
-        await localStorage.setAutoEditOnboardingNotificationInfo({
-            timesShown: info.timesShown + param.incrementCount,
-            lastNotifiedTime: Date.now(),
-        })
+        // If a user have already been enrolled to auto edit beta, don't show the onboarding again
+        const isAlreadyBetaEnrolled = await localStorage.isAutoEditBetaEnrolled()
+        if (isAlreadyBetaEnrolled) {
+            return false
+        }
+        return true
     }
 
     private async isAutoEditEnabled(): Promise<boolean> {
@@ -134,19 +90,7 @@ export class AutoEditOnboarding implements vscode.Disposable {
         return config.configuration.experimentalAutoEditEnabled
     }
 
-    private async isAutoEditNotificationsUnderLimit(): Promise<boolean> {
-        const info = await this.getAutoEditOnboardingNotificationInfo()
-        return (
-            info.timesShown < this.MAX_AUTO_EDITS_ONBOARDING_NOTIFICATIONS &&
-            Date.now() - info.lastNotifiedTime > this.MIN_TIME_DIFF_AUTO_EDITS_BETWEEN_NOTIFICATIONS_MS
-        )
-    }
-
-    private async getAutoEditOnboardingNotificationInfo(): Promise<AutoEditNotificationInfo> {
-        return localStorage.getAutoEditOnboardingNotificationInfo()
-    }
-
-    private async isUserEligibleForAutoEditOnboarding(): Promise<boolean> {
+    private async isUserEligibleForAutoEditFeature(): Promise<boolean> {
         const authStatus = currentAuthStatus()
         const productSubscription = await currentUserProductSubscription()
         const autoEditFeatureFlag = this.isAutoEditFeatureFlagEnabled()

--- a/vscode/src/autoedits/autoedit-onboarding.ts
+++ b/vscode/src/autoedits/autoedit-onboarding.ts
@@ -91,6 +91,9 @@ export class AutoEditBetaOnboarding implements vscode.Disposable {
     }
 
     private async isUserEligibleForAutoEditFeature(): Promise<boolean> {
+        if (process.env.CODY_TESTING === 'true') {
+            return false
+        }
         const authStatus = currentAuthStatus()
         const productSubscription = await currentUserProductSubscription()
         const autoEditFeatureFlag = this.isAutoEditFeatureFlagEnabled()

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -23,7 +23,7 @@ import { autocompleteStageCounterLogger } from '../services/autocomplete-stage-c
 import { recordExposedExperimentsToSpan } from '../services/open-telemetry/utils'
 
 import { AuthError } from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
-import { AutoEditOnboarding } from '../autoedits/autoedit-onboarding'
+import { AutoEditBetaOnboarding } from '../autoedits/autoedit-onboarding'
 import { ContextRankingStrategy } from '../completions/context/completions-context-ranker'
 import type { CompletionBookkeepingEvent, CompletionItemID, CompletionLogID } from './analytics-logger'
 import * as CompletionAnalyticsLogger from './analytics-logger'
@@ -143,8 +143,8 @@ export class InlineCompletionItemProvider
     }: CodyCompletionItemProviderConfig) {
         // Show the autoedit onboarding message if the user hasn't enabled autoedits
         // but is eligible to use them as an alternative to autocomplete
-        const autoeditsOnboarding = new AutoEditOnboarding()
-        autoeditsOnboarding.showAutoEditOnboardingIfEligible()
+        const autoeditsOnboarding = new AutoEditBetaOnboarding()
+        autoeditsOnboarding.enrollUserToAutoEditBetaIfEligible()
         this.disposables.push(autoeditsOnboarding)
 
         // This is a static field to allow for easy access in the static `configuration` getter.

--- a/vscode/src/services/LocalStorageProvider.ts
+++ b/vscode/src/services/LocalStorageProvider.ts
@@ -17,7 +17,6 @@ import {
     startWith,
 } from '@sourcegraph/cody-shared'
 import { type Observable, map } from 'observable-fns'
-import type { AutoEditNotificationInfo } from '../../src/autoedits/autoedit-onboarding'
 import { isSourcegraphToken } from '../chat/protocol'
 import type { GitHubDotComRepoMetaData } from '../repository/githubRepoMetadata'
 import { EventEmitter } from '../testutils/mocks'
@@ -37,7 +36,7 @@ class LocalStorage implements LocalStorageForModelPreferences {
     public readonly LAST_USED_ENDPOINT = 'SOURCEGRAPH_CODY_ENDPOINT'
     private readonly MODEL_PREFERENCES_KEY = 'cody-model-preferences'
     private readonly CODY_CHAT_MEMORY = 'cody-chat-memory'
-    private readonly AUTO_EDITS_ONBOARDING_NOTIFICATION_COUNT = 'cody-auto-edit-notification-info'
+    private readonly AUTO_EDITS_BETA_ENROLLED = 'cody-auto-edit-beta-onboard'
     private readonly DEVICE_PIXEL_RATIO = 'device-pixel-ratio'
 
     public readonly keys = {
@@ -231,17 +230,13 @@ class LocalStorage implements LocalStorageForModelPreferences {
         }
     }
 
-    public async getAutoEditOnboardingNotificationInfo(): Promise<AutoEditNotificationInfo> {
-        return (
-            this.get<AutoEditNotificationInfo>(this.AUTO_EDITS_ONBOARDING_NOTIFICATION_COUNT) ?? {
-                lastNotifiedTime: 0,
-                timesShown: 0,
-            }
-        )
+    public async isAutoEditBetaEnrolled(): Promise<boolean> {
+        const isAutoeditBetaEnrolled = this.get<boolean>(this.AUTO_EDITS_BETA_ENROLLED)
+        return !!isAutoeditBetaEnrolled
     }
 
-    public async setAutoEditOnboardingNotificationInfo(info: AutoEditNotificationInfo): Promise<void> {
-        await this.set(this.AUTO_EDITS_ONBOARDING_NOTIFICATION_COUNT, info)
+    public async setAutoeditBetaEnrollment(): Promise<void> {
+        await this.set(this.AUTO_EDITS_BETA_ENROLLED, true)
     }
 
     public async setGitHubRepoAccessibility(data: GitHubDotComRepoMetaData[]): Promise<void> {


### PR DESCRIPTION
- PR adds the onboarding setup for the eligible auto-edit users for the beta rollout.
- By default the `cody.suggestions.mode` is set to `autocomplete` for most of the users, this enrolls all the eligible users to `auto-edit` one time, and displays a notification, that they have been switched to `auto-edits`.

![CleanShot 2025-03-20 at 5  41 05@2x](https://github.com/user-attachments/assets/f06a3bf2-369a-4df5-b3ad-2dcea79275f0)

## Test plan
- Switching between modes in the debug mode and observe the notification.
- Check the telemetry event for the onboarding notification `cody.autoedit:beta-enrolled`
