### PR TITLE
feat(agentic chat): add internal feature flag

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -134,6 +134,12 @@ export enum FeatureFlag {
 
     // Extend context window for Cody Clients
     LongContextWindow = 'long-context-window',
+
+    /**
+     * Internal use only. Enables the next agentic chat experience.
+     * This is not for external use and should not be exposed to users.
+     */
+    NextAgenticChatInternal = 'next-agentic-chat-internal',
 }
 
 const ONE_HOUR = 60 * 60 * 1000

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -547,10 +547,15 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
 
     private async getConfigForWebview(): Promise<ConfigurationSubsetForWebview & LocalEnv> {
         const { configuration, auth } = await currentResolvedConfig()
-        const experimentalPromptEditorEnabled = await firstValueFrom(
-            featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.CodyExperimentalPromptEditor)
-        )
-        const experimentalAgenticChatEnabled = isS2(auth.serverEndpoint)
+        const [experimentalPromptEditorEnabled, internalAgenticChatEnabled] = await Promise.all([
+            firstValueFrom(
+                featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.CodyExperimentalPromptEditor)
+            ),
+            firstValueFrom(
+                featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.NextAgenticChatInternal)
+            ),
+        ])
+        const experimentalAgenticChatEnabled = internalAgenticChatEnabled && isS2(auth.serverEndpoint)
         const sidebarViewOnly = this.extensionClient.capabilities?.webviewNativeConfig?.view === 'single'
         const isEditorViewType = this.webviewPanelOrView?.viewType === 'cody.editorPanel'
         const webviewType = isEditorViewType && !sidebarViewOnly ? 'editor' : 'sidebar'


### PR DESCRIPTION
This commit introduces an internal feature flag, `NextAgenticChatInternal`, to control the availability of the new agentic chat experience. This flag is intended for internal use only and will not be exposed to users.

The changes include:

-   Adding the `NextAgenticChatInternal` feature flag to the `FeatureFlag` enum.
-   Updating the `ChatController` to use the new feature flag to enable the experimental agentic chat features.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Simple change. Check if feature flag is correct
