### PR TITLE
[JetBrains] Custom global key handler supporting Enter/Delete/Backspace and Enter+Shift in all IntelliJ IDEs flavors in the uniform way

### DIFF
--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/ui/web/WebUIProxy.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/ui/web/WebUIProxy.kt
@@ -3,7 +3,6 @@ package com.sourcegraph.cody.ui.web
 import com.google.gson.GsonBuilder
 import com.google.gson.JsonParser
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.ide.CopyPasteManager
 import com.intellij.openapi.project.ProjectManager
@@ -67,7 +66,6 @@ private const val MAIN_RESOURCE_URL = "${PSEUDO_HOST_URL_PREFIX}main-resource-no
 internal class WebUIProxy(private val host: WebUIHost, private val browser: JBCefBrowserBase) {
   companion object {
     private val logger = Logger.getInstance(WebUIProxy::class.java)
-    private val sentryService = service<SentryService>()
 
     /**
      * TODO: Hopefully this can be removed when JetBrains will patch focus handler implementation
@@ -147,7 +145,7 @@ internal class WebUIProxy(private val host: WebUIHost, private val browser: JBCe
             } catch (e: Exception) {
               val message = "Un-consuming the event keys failed."
               logger.warn(message, e)
-              // sentryService.report(e, message)
+              SentryService.report(e, message, null)
             }
           }
           false // Don't consume the event

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/ui/web/WebUIProxy.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/ui/web/WebUIProxy.kt
@@ -116,8 +116,8 @@ internal class WebUIProxy(private val host: WebUIHost, private val browser: JBCe
 
     /**
      * WORKAROUND: Rider, and potentially other IDEs, has a bug where they don't properly handle key
-     * events that should go to the Cef component, but instead they are swallowed (by others
-     * dispatchers - KeyboardFocusManager.keyEventDispatcher - like ToolWindowDragHelper) . This is
+     * events that should go to the Cef component, but instead they are swallowed, probably by others
+     * dispatchers from KeyboardFocusManager.keyEventDispatcher) . This is
      * a workaround to make sure that the Cef component gets the key events like Enter, Shift+Enter,
      * Delete, and Backspace even when they will be consumed by the processing pipeline.
      */
@@ -130,10 +130,8 @@ internal class WebUIProxy(private val host: WebUIHost, private val browser: JBCe
         if (!isCefComponent) {
           false
         } else {
-          if (event.isConsumed) {
+          if (event.isConsumed) { // if the event is already consumed, try to un-consume it
             try {
-              println("Key event: " + event.keyCode + ", consumed: " + event.isConsumed)
-
               if (event.keyCode == KeyEvent.VK_ENTER ||
                   event.keyCode == KeyEvent.VK_DELETE ||
                   event.keyCode == KeyEvent.VK_BACK_SPACE) {
@@ -142,11 +140,9 @@ internal class WebUIProxy(private val host: WebUIHost, private val browser: JBCe
                 val consumedField = AWTEvent::class.java.getDeclaredField("consumed")
                 consumedField.isAccessible = true
                 consumedField.setBoolean(event, false)
-                println("Successfully un-consumed the event")
               }
             } catch (e: Exception) {
-              e.printStackTrace()
-              logger.error("Un-consuming the event keys failed.", e)
+              logger.warn("Un-consuming the event keys failed.", e)
             }
           }
           false // Don't consume the event

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/ui/web/WebUIProxy.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/ui/web/WebUIProxy.kt
@@ -128,6 +128,7 @@ internal class WebUIProxy(private val host: WebUIHost, private val browser: JBCe
         val isCefComponent =
             event.component.javaClass.name ==
                 "com.intellij.ui.jcef.JBCefOsrComponent" // about 30% faster than
+        // browser.uiComponent.hasFocus()
         try {
           // if the event is destined for Cef component and it's already consumed, try to un-consume
           // it

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/ui/web/WebUIProxy.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/ui/web/WebUIProxy.kt
@@ -129,7 +129,8 @@ internal class WebUIProxy(private val host: WebUIHost, private val browser: JBCe
             event.component.javaClass.name ==
                 "com.intellij.ui.jcef.JBCefOsrComponent" // about 30% faster than
         try {
-          // if the event is destined for Cef component and it's already consumed, try to un-consume it
+          // if the event is destined for Cef component and it's already consumed, try to un-consume
+          // it
           if (isCefComponent &&
               event.isConsumed &&
               (event.keyCode == KeyEvent.VK_ENTER ||

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/ui/web/WebUIProxy.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/ui/web/WebUIProxy.kt
@@ -128,28 +128,25 @@ internal class WebUIProxy(private val host: WebUIHost, private val browser: JBCe
         val isCefComponent =
             event.component.javaClass.name ==
                 "com.intellij.ui.jcef.JBCefOsrComponent" // about 30% faster than
-        if (!isCefComponent) {
-          false
-        } else {
-          if (event.isConsumed) { // if the event is already consumed, try to un-consume it
-            try {
-              if (event.keyCode == KeyEvent.VK_ENTER ||
+        try {
+          // if the event is destined for Cef component and it's already consumed, try to un-consume it
+          if (isCefComponent &&
+              event.isConsumed &&
+              (event.keyCode == KeyEvent.VK_ENTER ||
                   event.keyCode == KeyEvent.VK_DELETE ||
-                  event.keyCode == KeyEvent.VK_BACK_SPACE) {
+                  event.keyCode == KeyEvent.VK_BACK_SPACE)) {
 
-                // trying to un-consume the event via reflection
-                val consumedField = AWTEvent::class.java.getDeclaredField("consumed")
-                consumedField.isAccessible = true
-                consumedField.setBoolean(event, false)
-              }
-            } catch (e: Exception) {
-              val message = "Un-consuming the event keys failed."
-              logger.warn(message, e)
-              SentryService.report(e, message, null)
-            }
+            // trying to un-consume the event via reflection
+            val consumedField = AWTEvent::class.java.getDeclaredField("consumed")
+            consumedField.isAccessible = true
+            consumedField.setBoolean(event, false)
           }
-          false // Don't consume the event
+        } catch (e: Exception) {
+          val message = "Un-consuming the event keys failed."
+          logger.warn(message, e)
+          SentryService.report(e, message, null)
         }
+        false // Don't consume the event
       }
     }
 


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-4704/backspace-and-enter-keys-not-working-in-rider-cody-window-macos

Special global handler for `Backspace`, `Delete`, `Enter`, and `Shift+Enter` which are not working properly in the CEF instance in Rider and potentially in other IntelliJ IDEs flavors. Even, when there are  no shortcuts defined for these keys in the current keymap, press key events still aren't forwarded to the CEF instance, but looks like they are swallowed by other dispatchers (`DefaultKeyboardFocusManager.keyEventDispatcher`) in the pipeline:

![image](https://github.com/user-attachments/assets/64b6c995-7c07-4127-a6d6-ac413dcb7a8b)

The implementation un-consume a key event (via reflection), already consumed by other dispatchers, which allow a key event to be later handled by Cef component (webview).

Detecting the event source using `JBCefOsrComponent` type, which is about 30% faster than calling `browser.uiComponent.hasFocus()`, 2080.00 ns. vs  2923.53 ns. on average (handler is called for every keystroke, but the execution is narrowed only for `JBCefOsrComponent` to make minimal performance impact on IDE UI.

## Test plan

1. Run Rider
2. Check if modifier keys are working in the Cody tool window:
   - Enter
   - Delete
   - Backspace
   - Enter + Shift
