### PR TITLE
fix(auto-edit): Remove unnecessary prompt whitespace

### DIFF
--- a/vscode/src/autoedits/prompt/default-prompt-strategy.test.ts
+++ b/vscode/src/autoedits/prompt/default-prompt-strategy.test.ts
@@ -230,9 +230,7 @@ describe('DefaultUserPromptStrategy', () => {
 
           The file currently open:(\`test.ts\`)
           <file>
-
           <<<AREA_AROUND_CODE_TO_REWRITE_WILL_BE_INSERTED_HERE>>>
-
           </file>
 
           My recent edits, from oldest to newest:
@@ -319,17 +317,10 @@ describe('DefaultUserPromptStrategy', () => {
         expect(prompt.toString()).toMatchInlineSnapshot(`
           "Help me finish a coding change. You will see snippets from current open files in my editor, files I have recently viewed, the file I am editing, then a history of my recent codebase changes, then current compiler and linter errors, content I copied from my codebase. You will then rewrite the <code_to_rewrite>, to match what you think I would do next in the codebase. Note: I might have stopped in the middle of typing.
 
-
-
           The file currently open:(\`test.ts\`)
           <file>
-
           <<<AREA_AROUND_CODE_TO_REWRITE_WILL_BE_INSERTED_HERE>>>
-
           </file>
-
-
-
 
           <area_around_code_to_rewrite>
           line 37

--- a/vscode/src/autoedits/prompt/default-prompt-strategy.ts
+++ b/vscode/src/autoedits/prompt/default-prompt-strategy.ts
@@ -62,7 +62,7 @@ export class DefaultUserPromptStrategy extends AutoeditsUserPromptStrategy {
 
         const currentFilePrompt = ps`${constants.CURRENT_FILE_INSTRUCTION}${fileWithMarkerPrompt}`
 
-        const finalPrompt = joinPromptsWithNewlineSeparator(
+        const finalPrompt = joinPromptsWithNewlineSeparator([
             getPromptWithNewline(constants.BASE_USER_PROMPT),
             getPromptWithNewline(jaccardSimilarityPrompt),
             getPromptWithNewline(recentViewsPrompt),
@@ -71,8 +71,8 @@ export class DefaultUserPromptStrategy extends AutoeditsUserPromptStrategy {
             getPromptWithNewline(lintErrorsPrompt),
             getPromptWithNewline(recentCopyPrompt),
             getPromptWithNewline(areaPrompt),
-            constants.FINAL_USER_PROMPT
-        )
+            constants.FINAL_USER_PROMPT,
+        ])
 
         autoeditsOutputChannelLogger.logDebugIfVerbose('DefaultUserPromptStrategy', 'getUserPrompt', {
             verbose: shortenPromptForOutputChannel(finalPrompt.toString(), []),

--- a/vscode/src/autoedits/prompt/prompt-cache-optimized-v1.test.ts
+++ b/vscode/src/autoedits/prompt/prompt-cache-optimized-v1.test.ts
@@ -195,12 +195,9 @@ describe('PromptCacheOptimizedV1', () => {
             expect(prompt.toString()).toMatchInlineSnapshot(`
               "Help me finish a coding change. You will see snippets from current open files in my editor, files I have recently viewed, the file I am editing, then a history of my recent codebase changes, then current compiler and linter errors, content I copied from my codebase. You will then rewrite the <code_to_rewrite>, to match what you think I would do next in the codebase. Note: I might have stopped in the middle of typing.
               Code snippets just I viewed:
-
               The file currently open:(\`test.ts\`)
               <file>
-
               <<<AREA_AROUND_CODE_TO_REWRITE_WILL_BE_INSERTED_HERE>>>
-
               </file>
               <area_around_code_to_rewrite>
               line 37
@@ -270,9 +267,7 @@ describe('PromptCacheOptimizedV1', () => {
               </diff_history>
               The file currently open:(\`test.ts\`)
               <file>
-
               <<<AREA_AROUND_CODE_TO_REWRITE_WILL_BE_INSERTED_HERE>>>
-
               </file>
               My recent edits, from oldest to newest:
               <diff_history>

--- a/vscode/src/autoedits/prompt/prompt-cache-optimized-v1.ts
+++ b/vscode/src/autoedits/prompt/prompt-cache-optimized-v1.ts
@@ -100,10 +100,10 @@ export class PromptCacheOptimizedV1 extends AutoeditsUserPromptStrategy {
             )
             .slice(0, this.SNIPPET_VIEW_MAX_COUNT)
 
-        return joinPromptsWithNewlineSeparator(
+        return joinPromptsWithNewlineSeparator([
             constants.SHORT_TERM_SNIPPET_VIEWS_INSTRUCTION,
-            getRecentlyViewedSnippetsPrompt(recentViewedSnippets)
-        )
+            getRecentlyViewedSnippetsPrompt(recentViewedSnippets),
+        ])
     }
 
     private getRecentEditsPromptComponents(
@@ -138,10 +138,10 @@ export class PromptCacheOptimizedV1 extends AutoeditsUserPromptStrategy {
         if (snippets.length === 0) {
             return ps``
         }
-        return joinPromptsWithNewlineSeparator(
+        return joinPromptsWithNewlineSeparator([
             constants.RECENT_EDITS_INSTRUCTION,
-            getRecentEditsPrompt(snippets)
-        )
+            getRecentEditsPrompt(snippets),
+        ])
     }
 
     private splitContextItemsIntoShortAndLongTerm(

--- a/vscode/src/autoedits/prompt/prompt-utils.test.ts
+++ b/vscode/src/autoedits/prompt/prompt-utils.test.ts
@@ -164,9 +164,7 @@ describe('getCurrentFilePromptComponents', () => {
         expect(result.fileWithMarkerPrompt.toString()).toBe(dedent`
             (\`test.ts\`)
             <file>
-
             <<<AREA_AROUND_CODE_TO_REWRITE_WILL_BE_INSERTED_HERE>>>
-
             </file>
         `)
         expect(result.areaPrompt.toString()).toBe(dedent`
@@ -1074,9 +1072,19 @@ describe('getJaccardSimilarityPrompt', () => {
 
 describe('joinPromptsWithNewlineSeparator', () => {
     it('joins multiple prompt strings with a new line separator', () => {
-        const prompt = joinPromptsWithNewlineSeparator(ps`foo`, ps`bar`)
+        const prompt = joinPromptsWithNewlineSeparator([ps`foo`, ps`bar`])
         expect(prompt.toString()).toBe(dedent`
             foo
+            bar
+        `)
+    })
+
+    it('joins multiple prompt strings with a custom separator', () => {
+        const prompt = joinPromptsWithNewlineSeparator([ps`foo`, ps`bar`], ps`\n\n\n`)
+        expect(prompt.toString()).toBe(dedent`
+            foo
+
+
             bar
         `)
     })

--- a/vscode/src/autoedits/prompt/prompt-utils.ts
+++ b/vscode/src/autoedits/prompt/prompt-utils.ts
@@ -82,34 +82,34 @@ export function getCurrentFilePromptComponents({
         document.uri
     )
 
-    const fileWithMarker = joinPromptsWithNewlineSeparator(
+    const fileWithMarker = joinPromptsWithNewlineSeparator([
         codeToReplaceData.prefixBeforeArea,
         constants.AREA_FOR_CODE_MARKER,
-        codeToReplaceData.suffixAfterArea
-    )
+        codeToReplaceData.suffixAfterArea,
+    ])
 
     const fileWithMarkerPrompt = getCurrentFileContextPromptWithPath(
         filePath,
-        joinPromptsWithNewlineSeparator(
+        joinPromptsWithNewlineSeparator([
             constants.FILE_TAG_OPEN,
             fileWithMarker,
-            constants.FILE_TAG_CLOSE
-        )
+            constants.FILE_TAG_CLOSE,
+        ])
     )
 
     const codeToRewrite = includeCursor
         ? ps`${codeToReplaceData.codeToRewritePrefix}<CURSOR_IS_HERE>${codeToReplaceData.codeToRewriteSuffix}`
         : codeToReplaceData.codeToRewrite
 
-    const areaPrompt = joinPromptsWithNewlineSeparator(
+    const areaPrompt = joinPromptsWithNewlineSeparator([
         constants.AREA_FOR_CODE_MARKER_OPEN,
         codeToReplaceData.prefixInArea,
         constants.CODE_TO_REWRITE_TAG_OPEN,
         codeToRewrite,
         constants.CODE_TO_REWRITE_TAG_CLOSE,
         codeToReplaceData.suffixInArea,
-        constants.AREA_FOR_CODE_MARKER_CLOSE
-    )
+        constants.AREA_FOR_CODE_MARKER_CLOSE,
+    ])
 
     return {
         fileWithMarkerPrompt,
@@ -279,7 +279,7 @@ export function getLintErrorsPrompt(contextItems: AutocompleteContextSnippet[]):
         const snippetContents = snippets.map(
             item => PromptString.fromAutocompleteContextSnippet(item).content
         )
-        const combinedContent = PromptString.join(snippetContents, ps`\n\n`)
+        const combinedContent = joinPromptsWithNewlineSeparator(snippetContents, ps`\n\n`)
         const promptWithPath = getContextPromptWithPath(
             PromptString.fromDisplayPath(uri),
             combinedContent
@@ -287,12 +287,12 @@ export function getLintErrorsPrompt(contextItems: AutocompleteContextSnippet[]):
         combinedPrompts.push(promptWithPath)
     }
 
-    const lintErrorsPrompt = PromptString.join(combinedPrompts, ps`\n\n`)
-    return joinPromptsWithNewlineSeparator(
+    const lintErrorsPrompt = joinPromptsWithNewlineSeparator(combinedPrompts, ps`\n\n`)
+    return joinPromptsWithNewlineSeparator([
         constants.LINT_ERRORS_TAG_OPEN,
         lintErrorsPrompt,
-        constants.LINT_ERRORS_TAG_CLOSE
-    )
+        constants.LINT_ERRORS_TAG_CLOSE,
+    ])
 }
 
 export function getRecentCopyPrompt(contextItems: AutocompleteContextSnippet[]): PromptString {
@@ -309,12 +309,12 @@ export function getRecentCopyPrompt(contextItems: AutocompleteContextSnippet[]):
             PromptString.fromAutocompleteContextSnippet(item).content
         )
     )
-    const recentCopyPrompt = PromptString.join(recentCopyPrompts, ps`\n\n`)
-    return joinPromptsWithNewlineSeparator(
+    const recentCopyPrompt = joinPromptsWithNewlineSeparator(recentCopyPrompts, ps`\n\n`)
+    return joinPromptsWithNewlineSeparator([
         constants.RECENT_COPY_TAG_OPEN,
         recentCopyPrompt,
-        constants.RECENT_COPY_TAG_CLOSE
-    )
+        constants.RECENT_COPY_TAG_CLOSE,
+    ])
 }
 
 export function getRecentEditsPrompt(contextItems: AutocompleteContextSnippet[]): PromptString {
@@ -332,12 +332,12 @@ export function getRecentEditsPrompt(contextItems: AutocompleteContextSnippet[])
             PromptString.fromAutocompleteContextSnippet(item).content
         )
     )
-    const recentEditsPrompt = PromptString.join(recentEditsPrompts, ps`\n`)
-    return joinPromptsWithNewlineSeparator(
+    const recentEditsPrompt = joinPromptsWithNewlineSeparator(recentEditsPrompts)
+    return joinPromptsWithNewlineSeparator([
         constants.RECENT_EDITS_TAG_OPEN,
         recentEditsPrompt,
-        constants.RECENT_EDITS_TAG_CLOSE
-    )
+        constants.RECENT_EDITS_TAG_CLOSE,
+    ])
 }
 
 export function getRecentlyViewedSnippetsPrompt(
@@ -352,22 +352,22 @@ export function getRecentlyViewedSnippetsPrompt(
         return ps``
     }
     const recentViewedSnippetPrompts = recentViewedSnippets.map(item =>
-        joinPromptsWithNewlineSeparator(
+        joinPromptsWithNewlineSeparator([
             constants.SNIPPET_TAG_OPEN,
             getContextPromptWithPath(
                 PromptString.fromDisplayPath(item.uri),
                 PromptString.fromAutocompleteContextSnippet(item).content
             ),
-            constants.SNIPPET_TAG_CLOSE
-        )
+            constants.SNIPPET_TAG_CLOSE,
+        ])
     )
 
-    const snippetsPrompt = PromptString.join(recentViewedSnippetPrompts, ps`\n`)
-    return joinPromptsWithNewlineSeparator(
+    const snippetsPrompt = joinPromptsWithNewlineSeparator(recentViewedSnippetPrompts)
+    return joinPromptsWithNewlineSeparator([
         constants.RECENT_SNIPPET_VIEWS_TAG_OPEN,
         snippetsPrompt,
-        constants.RECENT_SNIPPET_VIEWS_TAG_CLOSE
-    )
+        constants.RECENT_SNIPPET_VIEWS_TAG_CLOSE,
+    ])
 }
 
 export function getJaccardSimilarityPrompt(contextItems: AutocompleteContextSnippet[]): PromptString {
@@ -379,23 +379,22 @@ export function getJaccardSimilarityPrompt(contextItems: AutocompleteContextSnip
         return ps``
     }
     const jaccardSimilarityPrompts = jaccardSimilarity.map(item =>
-        joinPromptsWithNewlineSeparator(
+        joinPromptsWithNewlineSeparator([
             constants.SNIPPET_TAG_OPEN,
             getContextPromptWithPath(
                 PromptString.fromDisplayPath(item.uri),
                 PromptString.fromAutocompleteContextSnippet(item).content
             ),
-            constants.SNIPPET_TAG_CLOSE
-        )
+            constants.SNIPPET_TAG_CLOSE,
+        ])
     )
 
-    const snippetsPrompt = PromptString.join(jaccardSimilarityPrompts, ps`\n`)
-
-    return joinPromptsWithNewlineSeparator(
+    const snippetsPrompt = joinPromptsWithNewlineSeparator(jaccardSimilarityPrompts)
+    return joinPromptsWithNewlineSeparator([
         constants.EXTRACTED_CODE_SNIPPETS_TAG_OPEN,
         snippetsPrompt,
-        constants.EXTRACTED_CODE_SNIPPETS_TAG_CLOSE
-    )
+        constants.EXTRACTED_CODE_SNIPPETS_TAG_CLOSE,
+    ])
 }
 
 //  Helper functions
@@ -473,6 +472,10 @@ export function getRecentEditsContextPromptWithPath(
     return ps`${filePath}\n${content}`
 }
 
-export function joinPromptsWithNewlineSeparator(...args: PromptString[]): PromptString {
-    return PromptString.join(args, ps`\n`)
+export function joinPromptsWithNewlineSeparator(
+    prompts: PromptString[],
+    separator = ps`\n`
+): PromptString {
+    const validPrompts = prompts.filter(args => args.length > 0)
+    return PromptString.join(validPrompts, separator)
 }

--- a/vscode/src/autoedits/prompt/short-term-diff-prompt-strategy.test.ts
+++ b/vscode/src/autoedits/prompt/short-term-diff-prompt-strategy.test.ts
@@ -197,9 +197,7 @@ describe('ShortTermPromptStrategy', () => {
               "Help me finish a coding change. You will see snippets from current open files in my editor, files I have recently viewed, the file I am editing, then a history of my recent codebase changes, then current compiler and linter errors, content I copied from my codebase. You will then rewrite the <code_to_rewrite>, to match what you think I would do next in the codebase. Note: I might have stopped in the middle of typing.
               The file currently open:(\`test.ts\`)
               <file>
-
               <<<AREA_AROUND_CODE_TO_REWRITE_WILL_BE_INSERTED_HERE>>>
-
               </file>
               <area_around_code_to_rewrite>
               line 37
@@ -273,9 +271,7 @@ describe('ShortTermPromptStrategy', () => {
               </recently_viewed_snippets>
               The file currently open:(\`test.ts\`)
               <file>
-
               <<<AREA_AROUND_CODE_TO_REWRITE_WILL_BE_INSERTED_HERE>>>
-
               </file>
               Code snippets just I viewed:
               <recently_viewed_snippets>

--- a/vscode/src/autoedits/prompt/short-term-diff-prompt-strategy.ts
+++ b/vscode/src/autoedits/prompt/short-term-diff-prompt-strategy.ts
@@ -162,18 +162,18 @@ export class ShortTermPromptStrategy extends AutoeditsUserPromptStrategy {
 
         const shortTermViewPrompt =
             shortTermViewedSnippets.length > 0
-                ? joinPromptsWithNewlineSeparator(
+                ? joinPromptsWithNewlineSeparator([
                       constants.SHORT_TERM_SNIPPET_VIEWS_INSTRUCTION,
-                      getRecentlyViewedSnippetsPrompt(shortTermViewedSnippets)
-                  )
+                      getRecentlyViewedSnippetsPrompt(shortTermViewedSnippets),
+                  ])
                 : ps``
 
         const longTermViewPrompt =
             longTermViewedSnippets.length > 0
-                ? joinPromptsWithNewlineSeparator(
+                ? joinPromptsWithNewlineSeparator([
                       constants.LONG_TERM_SNIPPET_VIEWS_INSTRUCTION,
-                      getRecentlyViewedSnippetsPrompt(longTermViewedSnippets)
-                  )
+                      getRecentlyViewedSnippetsPrompt(longTermViewedSnippets),
+                  ])
                 : ps``
 
         return {
@@ -228,9 +228,9 @@ export class ShortTermPromptStrategy extends AutoeditsUserPromptStrategy {
             combinedContextItems.push(combinedItem)
         }
 
-        return joinPromptsWithNewlineSeparator(
+        return joinPromptsWithNewlineSeparator([
             constants.RECENT_EDITS_INSTRUCTION,
-            getRecentEditsPrompt(combinedContextItems)
-        )
+            getRecentEditsPrompt(combinedContextItems),
+        ])
     }
 }


### PR DESCRIPTION
## Description

Our prompt strategy usually consists of bulding `PromptStrings` together. When we don't have valid information to prompt we return an empty string. I think this is OK and a good way to build the prompts, but we had some cases where we were unnecessarily padding empty strings with new lines. This fixes that.

## Test plan

Tested with unit tests, see the updated snapshots

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
