### PR TITLE
feat(auto-edit): Handle accept events correctly when document changes match the active request

### DIFF
--- a/vscode/src/autoedits/analytics-logger/analytics-logger.test.ts
+++ b/vscode/src/autoedits/analytics-logger/analytics-logger.test.ts
@@ -20,6 +20,7 @@ import { getDecorationInfo } from '../renderer/diff-utils'
 import { AutoeditAnalyticsLogger } from './analytics-logger'
 import {
     type AutoeditRequestID,
+    autoeditAcceptReason,
     autoeditDiscardReason,
     autoeditRejectReason,
     autoeditSource,
@@ -135,7 +136,10 @@ describe('AutoeditAnalyticsLogger', () => {
         autoeditLogger.markAsSuggested(requestId)
 
         if (finalPhase === 'accepted') {
-            autoeditLogger.markAsAccepted(requestId)
+            autoeditLogger.markAsAccepted({
+                requestId,
+                acceptReason: autoeditAcceptReason.acceptCommand,
+            })
         }
 
         if (finalPhase === 'rejected') {
@@ -174,7 +178,10 @@ describe('AutoeditAnalyticsLogger', () => {
         })
 
         // Invalid transition attempt
-        autoeditLogger.markAsAccepted(requestId)
+        autoeditLogger.markAsAccepted({
+            requestId,
+            acceptReason: autoeditAcceptReason.acceptCommand,
+        })
 
         expect(recordSpy).toHaveBeenCalledTimes(3)
         expect(recordSpy).toHaveBeenNthCalledWith(1, 'cody.autoedit', 'suggested', expect.any(Object))
@@ -192,6 +199,7 @@ describe('AutoeditAnalyticsLogger', () => {
             },
             "interactionID": "stable-id-for-tests-2",
             "metadata": {
+              "acceptReason": 1,
               "contextSummary.duration": 1.234,
               "contextSummary.prefixChars": 5,
               "contextSummary.suffixChars": 5,

--- a/vscode/src/autoedits/analytics-logger/analytics-logger.ts
+++ b/vscode/src/autoedits/analytics-logger/analytics-logger.ts
@@ -30,6 +30,7 @@ import type { AutoEditRenderOutput } from '../renderer/render-output'
 import { autoeditIdRegistry } from './suggestion-id-registry'
 import {
     type AcceptedState,
+    type AutoeditAcceptReasonMetadata,
     type AutoeditDiscardReasonMetadata,
     type AutoeditRejectReasonMetadata,
     type AutoeditRequestID,
@@ -248,7 +249,13 @@ export class AutoeditAnalyticsLogger {
         }))
     }
 
-    public markAsAccepted(requestId: AutoeditRequestID): void {
+    public markAsAccepted({
+        requestId,
+        acceptReason,
+    }: {
+        requestId: AutoeditRequestID
+        acceptReason: AutoeditAcceptReasonMetadata
+    }): void {
         const acceptedAt = getTimeNowInMillis()
 
         const result = this.tryTransitionTo(requestId, 'accepted', request => {
@@ -283,6 +290,7 @@ export class AutoeditAnalyticsLogger {
                     isRead: true,
                     timeFromSuggestedAt: acceptedAt - request.suggestedAt,
                     suggestionsStartedSinceLastSuggestion: this.autoeditsStartedSinceLastSuggestion,
+                    acceptReason,
                 },
             }
         })

--- a/vscode/src/autoedits/analytics-logger/types.ts
+++ b/vscode/src/autoedits/analytics-logger/types.ts
@@ -132,6 +132,15 @@ export const autoeditRejectReason = {
 export type AutoeditRejectReasonMetadata =
     (typeof autoeditRejectReason)[keyof typeof autoeditRejectReason]
 
+export const autoeditAcceptReason = {
+    acceptCommand: 1,
+    onDidChangeTextDocument: 2,
+    unknown: 3,
+} as const
+
+export type AutoeditAcceptReasonMetadata =
+    (typeof autoeditRejectReason)[keyof typeof autoeditRejectReason]
+
 /**
  * A stable ID that identifies a particular autoedit suggestion. If the same text
  * and context recurs, we reuse this ID to avoid double-counting.
@@ -310,7 +319,11 @@ export interface AcceptedState extends Omit<SuggestedState, 'phase' | 'payload'>
     suggestionLoggedAt?: number
     /** Optional because it might be accepted before the read timeout */
     readAt?: number
-    payload: FinalPayload & Omit<CodeGenEventMetadata, 'charsInserted' | 'charsDeleted'>
+    payload: FinalPayload &
+        Omit<CodeGenEventMetadata, 'charsInserted' | 'charsDeleted'> & {
+            /** Reason why the suggestion was accepted. */
+            acceptReason: AutoeditAcceptReasonMetadata
+        }
 }
 
 export interface RejectedState extends Omit<SuggestedState, 'phase' | 'payload'> {

--- a/vscode/src/autoedits/analytics-logger/types.ts
+++ b/vscode/src/autoedits/analytics-logger/types.ts
@@ -139,7 +139,7 @@ export const autoeditAcceptReason = {
 } as const
 
 export type AutoeditAcceptReasonMetadata =
-    (typeof autoeditRejectReason)[keyof typeof autoeditRejectReason]
+    (typeof autoeditAcceptReason)[keyof typeof autoeditAcceptReason]
 
 /**
  * A stable ID that identifies a particular autoedit suggestion. If the same text

--- a/vscode/src/autoedits/autoedits-provider.test.ts
+++ b/vscode/src/autoedits/autoedits-provider.test.ts
@@ -125,6 +125,7 @@ describe('AutoeditsProvider', () => {
             },
             "interactionID": "stable-id-for-tests-2",
             "metadata": {
+              "acceptReason": 1,
               "contextSummary.duration": 0,
               "contextSummary.prefixChars": 10,
               "contextSummary.suffixChars": 0,
@@ -187,6 +188,7 @@ describe('AutoeditsProvider', () => {
             },
             "interactionID": "stable-id-for-tests-2",
             "metadata": {
+              "acceptReason": 1,
               "contextSummary.duration": 0,
               "contextSummary.prefixChars": 10,
               "contextSummary.suffixChars": 0,

--- a/vscode/src/autoedits/renderer/inline-manager.ts
+++ b/vscode/src/autoedits/renderer/inline-manager.ts
@@ -1,6 +1,6 @@
 import type * as vscode from 'vscode'
 
-import { autoeditRejectReason } from '../analytics-logger'
+import { autoeditAcceptReason, autoeditRejectReason } from '../analytics-logger'
 import { areSameUriDocs } from '../utils'
 
 import { AutoEditsDefaultRendererManager, type AutoEditsRendererManager } from './manager'
@@ -71,15 +71,95 @@ export class AutoEditsInlineRendererManager
         )
     }
 
+    /**
+     * Given a document change event, determines if the change matches the active request.
+     * If it does, we should treat this as a user acceptance of the suggestion.
+     *
+     * IMPORTANT:
+     * This logic also helps with a race condition where VS Code makes the insertion before notifying us
+     * that the completion was accepted. For example, VS Code calls `onDidChangeTextDocument` before
+     * `cody.supersuggest.accept`.
+     * By checking if the inserted changes match the active request, we ensure that we always reliably accept
+     * completions despite this race condition.
+     */
+    private documentChangesMatchesActiveRequest(event: vscode.TextDocumentChangeEvent): boolean {
+        const { activeRequest } = this
+        if (!activeRequest) {
+            return false
+        }
+
+        if (event.contentChanges.length === 0) {
+            // No changes to match
+            return false
+        }
+
+        if (activeRequest.renderOutput.type === 'completion') {
+            // Completions are inserted to the document differently, so handle their specific ranges
+            // so we can intercept them.
+            return activeRequest.renderOutput.inlineCompletionItems.every(completion => {
+                if (!completion.range || !completion.insertText) {
+                    return false
+                }
+                const { range, insertText } = completion
+                return event.contentChanges.some(
+                    change => change.range.isEqual(range) && change.text === insertText
+                )
+            })
+        }
+
+        return event.contentChanges.some(
+            change =>
+                change.range.isEqual(activeRequest.codeToReplaceData.range) &&
+                change.text === activeRequest.prediction
+        )
+    }
+
+    protected onDidChangeTextDocument(event: vscode.TextDocumentChangeEvent): void {
+        if (!this.activeRequest) {
+            return
+        }
+
+        if (!areSameUriDocs(event.document, this.activeRequest.document)) {
+            return
+        }
+
+        if (this.documentChangesMatchesActiveRequest(event)) {
+            // For completions, onDidChangeTextDocument is called BEFORE `cody.supersuggest.accept`
+            // For edits, onDidChangeTextDocument is called AFTER `cody.supersuggest.accept`
+            // Due to this difference, we rely on `documentChangesMatchesActiveRequest` to determine if a completion
+            // was accepted, otherwise we will reject it on the assunption that the user made other changes.
+            // We cannot reliably tell if, at this point, the reason the completion was accepted.
+            const reason =
+                this.activeRequest.renderOutput.type === 'completion'
+                    ? autoeditAcceptReason.unknown
+                    : autoeditAcceptReason.onDidChangeTextDocument
+            // We have intercepted a document change that matches the active request.
+            // Accept the edit and dismiss the suggestion.
+            this.acceptActiveEdit(reason)
+            return
+        }
+
+        if (this.hasInlineDecorations()) {
+            // We are showing inline decorations, we should dismiss the suggestion.
+            this.rejectActiveEdit(autoeditRejectReason.onDidChangeTextDocument)
+            return
+        }
+    }
+
     protected async onDidChangeTextEditorSelection(
         event: vscode.TextEditorSelectionChangeEvent
     ): Promise<void> {
-        if (
-            this.activeRequest?.renderOutput.type === 'completion-with-decorations' &&
-            areSameUriDocs(event.textEditor.document, this.activeRequest?.document)
-        ) {
-            // We are showing a completion alongisde decorations. The dismissal of the completion will
-            // automatically be handled by VS Code. We must match that behaviour for the decorations,
+        if (!this.activeRequest) {
+            return
+        }
+
+        if (!areSameUriDocs(event.textEditor.document, this.activeRequest.document)) {
+            return
+        }
+
+        if (this.hasInlineCompletionItems()) {
+            // We are showing a completion. The dismissal of the completion will
+            // automatically be handled by VS Code. We must match that behaviour for any decorations,
             // otherwise we will end up with a scenario where the decorations of a suggestion are preserved,
             // whilst the completion has already been dismissed.
             // If the cursor moved in any file, we assume it's a user action and
@@ -87,11 +167,7 @@ export class AutoEditsInlineRendererManager
             this.rejectActiveEdit(autoeditRejectReason.onDidChangeTextEditorSelection)
         }
 
-        if (
-            this.hasInlineDecorationOnly() &&
-            this.activeRequest &&
-            areSameUriDocs(event.textEditor.document, this.activeRequest?.document)
-        ) {
+        if (this.hasInlineDecorationOnly()) {
             // We are only showing decorations. We can handle this entirely ourselves.
             // We will only dismiss the suggestion if the user moves the cursor outside of the target range.
             const currentSelectionRange = event.selections.at(-1)


### PR DESCRIPTION
## Description

Notable changes in this PR:
1. We now mark auto-edits as accepted when the document changes match the suggestion. I think this is logically correct for our telemetry - if a user pastes some code in that matches our suggestion we can say that our suggestion was accepted and pat ourselves on the back
2. We handle a nasty bug where VS Code makes an insertion for native completions _before_ calling the command we provide `cody.supersuggest.accept`. This ordering means that, due to how we try to intercept cursor changes as a way to reject suggestions, we would incorrectly reject an accepted completion. See the flow below:

### Completion acceptance bug
Before:
1. Suggest native completion
2. User accepts it
3. VS Code inserts the text, and calls `onDidChangeTextDocument` and `onDidChangeTextEditorSelection` due to the inserted text and cursor position change.
4. Our logic intercepts `onDidChangeTextEditorSelection` and sees that the user moves their cursor, we reject the suggestion
5. VS Code calls `cody.supersuggest.accept`, we cannot accept the change in our telemetry as we have already rejected it.

After:
1. Suggest native completion
2. User accepts it
3. VS Code inserts the text, and calls `onDidChangeTextDocument` and `onDidChangeTextEditorSelection` due to the inserted text and cursor position change.
4. Our new logic intercepts `onDidChangeTextDocument`, sees that the insertion matches our active request and marks the suggestion as accepted

## Test plan
- [x] Verify auto-edits work correctly when accepting via different methods
- [x] Check that analytics capture the correct acceptance reasons
