### PR TITLE
fix(auto-edit): Do not swtich user to if already enrolled to beta

### DIFF
--- a/vscode/src/autoedits/autoedit-onboarding.ts
+++ b/vscode/src/autoedits/autoedit-onboarding.ts
@@ -35,7 +35,7 @@ export class AutoEditBetaOnboarding implements vscode.Disposable {
                 vscode.ConfigurationTarget.Global
             )
         // Set Enroll to true in local storage so that we don't override the setting if the user changes it
-        await localStorage.setAutoeditBetaEnrollment()
+        this.markUserAsAutoEditBetaEnrolled()
         this.writeAutoeditNotificationEvent()
 
         const selection = await vscode.window.showInformationMessage(
@@ -52,12 +52,6 @@ export class AutoEditBetaOnboarding implements vscode.Disposable {
                     CodyAutoSuggestionMode.Autocomplete,
                     vscode.ConfigurationTarget.Global
                 )
-
-            // Open VS Code settings UI and focus on the Cody AutoEdit setting
-            await vscode.commands.executeCommand(
-                'workbench.action.openSettings',
-                'cody.suggestions.mode'
-            )
         }
     }
 
@@ -71,6 +65,9 @@ export class AutoEditBetaOnboarding implements vscode.Disposable {
     private async isUserEligibleForAutoeditBetaOverride(): Promise<boolean> {
         const isAutoEditEnabled = await this.isAutoEditEnabled()
         if (isAutoEditEnabled) {
+            // If auto-edit has been enabled, we don't need to show the onboarding and mark
+            // the user as enrolled
+            this.markUserAsAutoEditBetaEnrolled()
             return false
         }
         const isUserEligible = await this.isUserEligibleForAutoEditFeature()
@@ -88,6 +85,10 @@ export class AutoEditBetaOnboarding implements vscode.Disposable {
     private async isAutoEditEnabled(): Promise<boolean> {
         const config = await currentResolvedConfig()
         return config.configuration.experimentalAutoEditEnabled
+    }
+
+    public markUserAsAutoEditBetaEnrolled(): Promise<void> {
+        return localStorage.setAutoeditBetaEnrollment()
     }
 
     private async isUserEligibleForAutoEditFeature(): Promise<boolean> {
@@ -113,3 +114,5 @@ export class AutoEditBetaOnboarding implements vscode.Disposable {
         this.featureFlagAutoEditExperimental.subscription.unsubscribe()
     }
 }
+
+export const autoeditsOnboarding = new AutoEditBetaOnboarding()

--- a/vscode/src/autoedits/autoedits-provider.ts
+++ b/vscode/src/autoedits/autoedits-provider.ts
@@ -17,7 +17,6 @@ import { getCurrentDocContext } from '../completions/get-current-doc-context'
 import { isRunningInsideAgent } from '../jsonrpc/isRunningInsideAgent'
 import type { FixupController } from '../non-stop/FixupController'
 import type { CodyStatusBar } from '../services/StatusBar'
-
 import type { CompletionBookkeepingEvent } from '../completions/analytics-logger'
 import type { AutocompleteEditItem, AutoeditChanges } from '../jsonrpc/agent-protocol'
 import type { AutoeditsModelAdapter, AutoeditsPrompt, ModelResponse } from './adapters/base'
@@ -32,6 +31,7 @@ import {
     getTimeNowInMillis,
 } from './analytics-logger'
 import { AutoeditCompletionItem } from './autoedit-completion-item'
+import { autoeditsOnboarding } from './autoedit-onboarding'
 import { autoeditsProviderConfig } from './autoedits-config'
 import { FilterPredictionBasedOnRecentEdits } from './filter-prediction-edits'
 import { autoeditsOutputChannelLogger } from './output-channel-logger'
@@ -110,6 +110,8 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
 
         // Initialise the canvas renderer for image generation.
         initImageSuggestionService()
+        // If the user is using auto-edit, mark the user as enrolled
+        autoeditsOnboarding.markUserAsAutoEditBetaEnrolled()
 
         autoeditsOutputChannelLogger.logDebug('Constructor', 'Constructing AutoEditsProvider')
         this.modelAdapter = createAutoeditsModelAdapter({

--- a/vscode/src/autoedits/autoedits-provider.ts
+++ b/vscode/src/autoedits/autoedits-provider.ts
@@ -10,15 +10,15 @@ import {
     tokensToChars,
 } from '@sourcegraph/cody-shared'
 
+import type { CompletionBookkeepingEvent } from '../completions/analytics-logger'
 import { ContextRankingStrategy } from '../completions/context/completions-context-ranker'
 import { ContextMixer } from '../completions/context/context-mixer'
 import { DefaultContextStrategyFactory } from '../completions/context/context-strategy'
 import { getCurrentDocContext } from '../completions/get-current-doc-context'
+import type { AutocompleteEditItem, AutoeditChanges } from '../jsonrpc/agent-protocol'
 import { isRunningInsideAgent } from '../jsonrpc/isRunningInsideAgent'
 import type { FixupController } from '../non-stop/FixupController'
 import type { CodyStatusBar } from '../services/StatusBar'
-import type { CompletionBookkeepingEvent } from '../completions/analytics-logger'
-import type { AutocompleteEditItem, AutoeditChanges } from '../jsonrpc/agent-protocol'
 import type { AutoeditsModelAdapter, AutoeditsPrompt, ModelResponse } from './adapters/base'
 import { createAutoeditsModelAdapter } from './adapters/create-adapter'
 import {

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -23,7 +23,7 @@ import { autocompleteStageCounterLogger } from '../services/autocomplete-stage-c
 import { recordExposedExperimentsToSpan } from '../services/open-telemetry/utils'
 
 import { AuthError } from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
-import { AutoEditBetaOnboarding } from '../autoedits/autoedit-onboarding'
+import { autoeditsOnboarding } from '../autoedits/autoedit-onboarding'
 import { ContextRankingStrategy } from '../completions/context/completions-context-ranker'
 import type { CompletionBookkeepingEvent, CompletionItemID, CompletionLogID } from './analytics-logger'
 import * as CompletionAnalyticsLogger from './analytics-logger'
@@ -143,9 +143,7 @@ export class InlineCompletionItemProvider
     }: CodyCompletionItemProviderConfig) {
         // Show the autoedit onboarding message if the user hasn't enabled autoedits
         // but is eligible to use them as an alternative to autocomplete
-        const autoeditsOnboarding = new AutoEditBetaOnboarding()
         autoeditsOnboarding.enrollUserToAutoEditBetaIfEligible()
-        this.disposables.push(autoeditsOnboarding)
 
         // This is a static field to allow for easy access in the static `configuration` getter.
         // There must only be one instance of this class at a time.


### PR DESCRIPTION
PR marks the user as auto-edit enrolled if they are already using auto-edits. This prevents switching them to `auto-edits` if user switched to `autocomplete`.

## Test plan
- Start the debug mode with `auto-edits` enabled and switch to `autocomplete`, this should prevent automatically enrolling user to `auto-edit` feature.
