### PR TITLE
fix(vscode): Extract terminal lines outside of conditional render in ToolStatusCell

### DIFF
--- a/vscode/webviews/chat/cells/toolCell/ToolStatusCell.tsx
+++ b/vscode/webviews/chat/cells/toolCell/ToolStatusCell.tsx
@@ -26,6 +26,15 @@ export const ToolStatusCell: FC<ToolStatusProps> = ({ title, output, vscodeAPI }
         [vscodeAPI]
     )
 
+    // Extract terminal lines outside of the conditional render
+    const terminalLines = useMemo(
+        () =>
+            output?.outputType === 'terminal-output' && output.content
+                ? convertToTerminalLines(output.content)
+                : [],
+        [output?.outputType, output?.content]
+    )
+
     if (!title || !output) {
         return (
             <div className="tw-flex tw-items-center tw-gap-2 tw-overflow-hidden tw-h-7">
@@ -53,12 +62,7 @@ export const ToolStatusCell: FC<ToolStatusProps> = ({ title, output, vscodeAPI }
     }
 
     if (output?.outputType === 'terminal-output') {
-        const lines = useMemo(
-            () => (output.content ? convertToTerminalLines(output.content) : []),
-            [output.content]
-        )
-
-        return <TerminalOutputCell lines={lines} />
+        return <TerminalOutputCell lines={terminalLines} />
     }
 
     return <OutputStatusCell item={output} />


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-5441/bug-fix-view-goes-blank-when-display-terminal-output

Memorize the terminal lines to resolve an error
![Screenshot 2025-03-20 at 1 57 34 PM](https://github.com/user-attachments/assets/41b0fead-ad1a-4899-8f4a-56cdbec6e02e)

Cause: The useMemo dependency array only includes output.content, but the function is using convertToTerminalLines(output.content). If convertToTerminalLines is not stable (i.e., it creates a new reference each time), this could cause issues.

The key changes are:

1. Moved the useMemo for terminal lines outside of the conditional rendering
2. Added proper dependency on output?.outputType as well as output?.content
3. Added null/undefined checks with optional chaining

This should resolve the React error by ensuring the useMemo hook has all the dependencies it needs and is used consistently.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Verified with Alex that the fixed worked. To test this manually. ask agentic chat to run a terminal command two times and try opening the component. Before the fix the webview will die and goes blank