### PR TITLE
feat(chat): Refactor focus management for human message editors

### DIFF
--- a/vscode/webviews/chat/context.ts
+++ b/vscode/webviews/chat/context.ts
@@ -1,6 +1,17 @@
 import type { PromptEditorRefAPI } from '@sourcegraph/prompt-editor'
-import { type MutableRefObject, createContext } from 'react'
+import { type MutableRefObject, createContext, useRef } from 'react'
 
 export const LastEditorContext = createContext<MutableRefObject<PromptEditorRefAPI | null>>({
     current: null,
 })
+
+export function useLastHumanEditor() {
+    const lastHumanEditorRef = useRef<PromptEditorRefAPI | null>(null)
+
+    const focusLastHumanMessageEditor = () => {
+        if (!lastHumanEditorRef.current) return
+        lastHumanEditorRef.current?.setFocus(true)
+    }
+
+    return { lastHumanEditorRef, focusLastHumanMessageEditor }
+}


### PR DESCRIPTION
This commit refactors the focus management for human message editors in the chat interface. It introduces a global context (`LastEditorContext`) to track the most recent editor and provides a hook (`useLastHumanEditor`) to simplify access and management of the last active editor.

Key changes:

-   Introduced `LastEditorContext` to share the last human editor ref across components.
-   Created `useLastHumanEditor` hook to manage the last editor ref and provide a `focusLastHumanMessageEditor` function.
-   Removed the `focusLastHumanMessageEditor` function from `Transcript.tsx` and moved the logic to the `useLastHumanEditor` hook.
-   Updated `Chat.tsx` to use the `useLastHumanEditor` hook to manage focus on webview focus.
-   Updated `TranscriptInteraction` to pass the editor ref to the `LastEditorContext`.
-   Updated `editHumanMessage` and `submitHumanMessage` to use the `lastHumanEditorRef` to set focus.
-   Removed `onAddToFollowupChat` from `Transcript.tsx` as it was not used.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

green ci
