### PR TITLE
fix(chat): update openctx error handling

### DIFF
--- a/lib/shared/src/context/openctx/context.ts
+++ b/lib/shared/src/context/openctx/context.ts
@@ -1,12 +1,19 @@
 import { URI } from 'vscode-uri'
 import { type ContextItemOpenCtx, ContextItemSource } from '../../codebase-context/messages'
+import { logDebug } from '../../logger'
 import { currentOpenCtxController } from './api'
 
 // getContextForChatMessage returns context items for a given chat message from the OpenCtx providers.
 export const getContextForChatMessage = async (
     message: string,
-    signal?: AbortSignal
+    parentSignal?: AbortSignal
 ): Promise<ContextItemOpenCtx[]> => {
+    // Create a dependent abort controller that aborts if the parent aborts
+    // but doesn't propagate its own aborts back to the parent
+    const controller = new AbortController()
+    if (parentSignal) {
+        parentSignal.addEventListener('abort', () => controller.abort())
+    }
     try {
         const openCtxClient = currentOpenCtxController()
         if (!openCtxClient) {
@@ -14,8 +21,10 @@ export const getContextForChatMessage = async (
         }
 
         // get list of all configured OpenCtx providers.
-        const providers = await openCtxClient.meta({})
-        signal?.throwIfAborted()
+        // All operations below use the parentSignal but we catch and handle all errors
+        // to prevent them from propagating up the chain
+        const providers = await openCtxClient.meta({}).catch(() => [])
+        if (parentSignal?.aborted) return []
 
         // filter providers that have message selectors configured and match the message text.
         const matchingProviders = providers.filter(
@@ -24,6 +33,11 @@ export const getContextForChatMessage = async (
                     try {
                         return message.match(new RegExp(pattern))?.length
                     } catch {
+                        // Log the error but don't propagate it
+                        logDebug(
+                            'OpenCtx',
+                            `getContextForChatMessage Error: matching regex ${pattern} for provider ${p.providerUri}`
+                        )
                         return []
                     }
                 })?.length
@@ -38,7 +52,7 @@ export const getContextForChatMessage = async (
             )
         ).flat()
         // TODO(sqs): add abort signal to openCtxClient.items API
-        signal?.throwIfAborted()
+        if (parentSignal?.aborted) return []
 
         return items
             .filter(item => item.ai?.content)

--- a/vscode/src/chat/chat-view/tools/search.ts
+++ b/vscode/src/chat/chat-view/tools/search.ts
@@ -28,28 +28,46 @@ export async function getCodebaseSearchTool(
             input_schema: zodToolSchema(CodeSearchSchema),
         },
         invoke: async (input: CodeSearchInput) => {
-            const validInput = validateWithZod(CodeSearchSchema, input, 'code_search')
-            const corpusItems = await firstValueFrom(getCorpusContextItemsForEditorState())
-            if (!corpusItems || corpusItems === pendingOperation)
+            const startTime = Date.now()
+            try {
+                const validInput = validateWithZod(CodeSearchSchema, input, 'code_search')
+                const corpusItems = await firstValueFrom(getCorpusContextItemsForEditorState())
+                if (!corpusItems || corpusItems === pendingOperation) {
+                    throw new Error('No corpus items available')
+                }
+
+                const repo = corpusItems.find(i => i.type === 'tree' || i.type === 'repository')
+                const mentions = repo ? [repo] : []
+
+                try {
+                    const searches = await contextRetriever.retrieveContext(
+                        toStructuredMentions(mentions),
+                        PromptString.unsafe_fromLLMResponse(validInput.query),
+                        span,
+                        // Create a new abort controller that doesn't propagate back
+                        new AbortController().signal,
+                        true
+                    )
+                    return createSearchToolStateItem(
+                        validInput.query,
+                        searches,
+                        UIToolStatus.Done,
+                        startTime
+                    )
+                } catch (error) {
+                    // Handle error from context retrieval
+                    throw new Error(`Context retrieval failed: ${error}`)
+                }
+            } catch (error) {
+                // Handle any other errors
                 return createSearchToolStateItem(
-                    validInput.query,
+                    input.query || 'unknown query',
                     [],
                     UIToolStatus.Error,
-                    'Codebase search failed.'
+                    startTime,
+                    `Tool error: ${error}`
                 )
-
-            const repo = corpusItems.find(i => i.type === 'tree' || i.type === 'repository')
-            const mentions = repo ? [repo] : []
-
-            const searches = await contextRetriever.retrieveContext(
-                toStructuredMentions(mentions),
-                PromptString.unsafe_fromLLMResponse(validInput.query),
-                span,
-                undefined,
-                true
-            )
-
-            return createSearchToolStateItem(validInput.query, searches)
+            }
         },
     }
 
@@ -60,8 +78,8 @@ export function createSearchToolStateItem(
     query: string,
     searchResults: ContextItem[],
     status: UIToolStatus = UIToolStatus.Done,
-    error?: string,
-    startTime?: number
+    startTime?: number,
+    error?: string
 ): ContextItemToolState {
     // Calculate duration if we have a start time
     const duration = startTime ? Date.now() - startTime : undefined
@@ -94,7 +112,7 @@ export function createSearchToolStateItem(
         // ContextItemCommon properties
         uri,
         content: description + groupedResults + error,
-        title: 'Search Results',
+        title: query,
         description,
         source: ContextItemSource.Agentic,
         icon: 'search',


### PR DESCRIPTION
This commit enhances error handling in the codebase search tool and OpenCtx context retrieval.

For the codebase search tool, it adds a try-catch block to handle potential errors during the validation of input, retrieval of corpus items, and context retrieval. This prevents the chat view from crashing and provides more informative error messages to the user.

For OpenCtx, it adds a dependent abort controller to handle abort signals from the parent operation. It also adds error handling to prevent errors from OpenCtx providers from propagating up the chain. This ensures that the chat functionality remains robust even if some OpenCtx providers fail. Additionally, it logs errors when matching regex patterns for OpenCtx providers.

The title of the search result is changed to the query to provide more context.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

context: https://sourcegraph.slack.com/archives/C05AGQYD528/p1742543511477939

<img width="2054" alt="image" src="https://github.com/user-attachments/assets/a7a9f9c5-d89b-4080-b7a1-2351300db0f8" />



1. Observe the console to see openCtx spawning error about aborted request
2. If it happens, verify the aborted request did not affect the agentic chat experience
3. You can easily trigger the error by "Cmd+N" to open a new file. the error will continue to show up in the log, but the chat requests will not get aborted

![image](https://github.com/user-attachments/assets/5f16d96a-6486-4e09-a82e-eb0516b5becc)
