### PR TITLE
fix(vscode): Ensure file link clicks work in ToolStatusCell

### DIFF
--- a/vscode/webviews/chat/cells/toolCell/ToolStatusCell.tsx
+++ b/vscode/webviews/chat/cells/toolCell/ToolStatusCell.tsx
@@ -2,7 +2,7 @@ import type { ContextItemToolState } from '@sourcegraph/cody-shared/src/codebase
 import { type FC, useCallback, useMemo } from 'react'
 import type { URI } from 'vscode-uri'
 import { Skeleton } from '../../../components/shadcn/ui/skeleton'
-import type { VSCodeWrapper } from '../../../utils/VSCodeApi'
+import { type VSCodeWrapper, getVSCodeAPI } from '../../../utils/VSCodeApi'
 import { DiffCell } from './DiffCell'
 import { FileCell } from './FileCell'
 import { OutputStatusCell } from './OutputStatusCell'
@@ -18,13 +18,12 @@ export interface ToolStatusProps {
     vscodeAPI?: VSCodeWrapper
 }
 
-export const ToolStatusCell: FC<ToolStatusProps> = ({ title, output, vscodeAPI }) => {
-    const onFileLinkClicked = useCallback(
-        (uri: URI) => {
-            vscodeAPI?.postMessage({ command: 'openFileLink', uri })
-        },
-        [vscodeAPI]
-    )
+export const ToolStatusCell: FC<ToolStatusProps> = ({ title, output }) => {
+    const onFileLinkClicked = useCallback((uri: URI) => {
+        // Fixes an issue where the link is not getting sent to the extension host
+        // when the api is not available on the first render
+        getVSCodeAPI()?.postMessage({ command: 'openFileLink', uri })
+    }, [])
 
     // Extract terminal lines outside of the conditional render
     const terminalLines = useMemo(


### PR DESCRIPTION
Close https://linear.app/sourcegraph/issue/CODY-5444/bug-search-results-and-file-tool-results-are-not-clickable

The Issue: In the original implementation, if the vscodeAPI prop was undefined during initial component render (because the VSCode API wasn't fully initialized yet), the onFileLinkClicked function would be created with a reference to that undefined value. Even if the API became available later, the callback would still reference the initial undefined value due to how closures work.

The Fix: By calling getVSCodeAPI() at the time the link is clicked (rather than capturing the value during render), the code now gets the most current API reference at the exact moment it's needed. This guarantees that even if the API wasn't available during the component's first render, the link functionality will still work when clicked as long as the API is available by then.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Clicking on agent search result should open the file link in editor for you

<img width="593" alt="image" src="https://github.com/user-attachments/assets/468e39d3-0a9a-4050-bd2b-a8c9bf7285f8" />


