### PR TITLE
fix(vscode): Improve placeholder text in chat input (#7490)

### DIFF
--- a/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
@@ -95,8 +95,8 @@ const HumanMessageCellContent = memo<HumanMessageCellContent>(props => {
                     initialEditorState={initialEditorState}
                     placeholder={
                         isFirstMessage
-                            ? 'Ask anything. Use @ to specify context...'
-                            : 'Ask a followup...'
+                            ? 'Enter your question use @ to add files and context...'
+                            : 'Use @ to add more context...'
                     }
                     isFirstMessage={isFirstMessage}
                     isSent={isSent}

--- a/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
@@ -95,7 +95,7 @@ const HumanMessageCellContent = memo<HumanMessageCellContent>(props => {
                     initialEditorState={initialEditorState}
                     placeholder={
                         isFirstMessage
-                            ? 'Enter your question use @ to add files and context...'
+                            ? 'Ask anything. Use @ to specify context...'
                             : 'Use @ to add more context...'
                     }
                     isFirstMessage={isFirstMessage}


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-5451/update-ghost-text-for-follow-up-message-in-chat

The commit updates the placeholder text in the chat input field to provide clearer guidance to the user on how to add context to their questions.

## Test plan

Manually verified the placeholder text in the chat input field.

