### PR TITLE
Make com.intellij.modules.json an optional dependency

### DIFF
--- a/jetbrains/src/main/resources/META-INF/plugin-json.xml
+++ b/jetbrains/src/main/resources/META-INF/plugin-json.xml
@@ -1,0 +1,2 @@
+<idea-plugin>
+</idea-plugin>

--- a/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -9,7 +9,7 @@
     <change-notes>
         <![CDATA[<a href="https://github.com/sourcegraph/cody/releases?q=JetBrains&expanded=true">Update notes are available on GitHub.</a>]]></change-notes>
 
-    <depends>com.intellij.modules.json</depends>
+    <depends optional="true" config-file="plugin-json.xml">com.intellij.modules.json</depends>
     <depends>com.intellij.modules.platform</depends>
     <depends optional="true" config-file="plugin-git.xml">Git4Idea</depends>
     <depends optional="true" config-file="plugin-perforce.xml">


### PR DESCRIPTION
close https://github.com/sourcegraph/jetbrains/issues/3197

This PR makes the `com.intellij.modules.json` module an optional dependency. This is necessary if you use a remote WSL. JetBrains client can only use trimmed module (`com.intellij.json.frontend`). The full version is not available on client-side which leads to an error. More info: https://intellij-support.jetbrains.com/hc/en-us/community/posts/21479962703890-JSON-plugin-dependency-cannot-be-resolved

## Test plan
1. Run IJ instance on WSL
2. Install Cody extension (use 'Plugins Client' settings page then click gear icon and select 'Install plugin from Disk')
3. After restarting Cody should load without any errors
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
