### PR TITLE
chore(chat): Remove the expanded content for the files

### DIFF
--- a/vscode/webviews/chat/cells/toolCell/BaseCell.tsx
+++ b/vscode/webviews/chat/cells/toolCell/BaseCell.tsx
@@ -65,11 +65,11 @@ const BaseCellComponent: FC<BaseCellProps> = ({
                         {headerContent}
                     </div>
                     {/* Only show chevron icons when there's expandable content */}
-                    {bodyContent && (isOpen ? (
+                    {bodyContent && isOpen ? (
                         <ChevronDown size={16} className="tw-flex-shrink-0 tw-text-zinc-400" />
                     ) : (
                         <ChevronRight size={16} className="tw-flex-shrink-0 tw-text-zinc-400" />
-                    ))}
+                    )}
                 </CollapsibleTrigger>
                 <CollapsibleContent>
                     <div className="tw-overflow-auto tw-bg-zinc-950 tw-p-0 tw-h-auto tw-max-h-[300px]">

--- a/vscode/webviews/chat/cells/toolCell/BaseCell.tsx
+++ b/vscode/webviews/chat/cells/toolCell/BaseCell.tsx
@@ -64,11 +64,12 @@ const BaseCellComponent: FC<BaseCellProps> = ({
                         {Icon && <Icon size={16} className="tw-flex-shrink-0 tw-text-zinc-400" />}
                         {headerContent}
                     </div>
-                    {isOpen ? (
+                    {/* Only show chevron icons when there's expandable content */}
+                    {bodyContent && (isOpen ? (
                         <ChevronDown size={16} className="tw-flex-shrink-0 tw-text-zinc-400" />
                     ) : (
                         <ChevronRight size={16} className="tw-flex-shrink-0 tw-text-zinc-400" />
-                    )}
+                    ))}
                 </CollapsibleTrigger>
                 <CollapsibleContent>
                     <div className="tw-overflow-auto tw-bg-zinc-950 tw-p-0 tw-h-auto tw-max-h-[300px]">

--- a/vscode/webviews/chat/cells/toolCell/FileCell.tsx
+++ b/vscode/webviews/chat/cells/toolCell/FileCell.tsx
@@ -34,34 +34,13 @@ export const FileCell: FC<FileCellProps> = ({
         </div>
     )
 
-    const renderBodyContent = () => (
-        <div className="tw-overflow-x-auto tw-bg-zinc-950 tw-p-0">
-            <pre className="tw-font-mono tw-text-xs tw-leading-relaxed">
-                <table className="tw-w-full tw-border-collapse">
-                    <tbody>
-                        {result?.content?.split('\n').map((line, index) => (
-                            <tr key={`${index}-${line.substring(0, 10)}`}>
-                                <td className="tw-select-none tw-border-r tw-border-r-zinc-700 tw-px-2 tw-text-right tw-text-zinc-500 tw-w-12">
-                                    {index + 1}
-                                </td>
-                                <td className="tw-px-4 tw-py-0.5 tw-text-zinc-200 tw-whitespace-pre">
-                                    <div className="tw-flex tw-items-center">{line}</div>
-                                </td>
-                            </tr>
-                        ))}
-                    </tbody>
-                </table>
-            </pre>
-        </div>
-    )
-
     return (
         <BaseCell
             icon={FileCode}
             headerContent={renderHeaderContent()}
-            bodyContent={result?.content ? renderBodyContent() : undefined}
+            bodyContent={undefined}
             className={className}
-            defaultOpen={defaultOpen}
+            defaultOpen={false} // Always closed since there's no content to show
         />
     )
 }


### PR DESCRIPTION
Remove the expanded content for the files since the user can click on the filename to see the content in the editor.

## Test plan
CI
<img width="395" alt="Screenshot 2025-03-21 at 12 35 05 PM" src="https://github.com/user-attachments/assets/4607e554-56ff-4e2b-a4e1-7417c9963882" />
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
