### PR TITLE
fix(agentic-chat): Improve error handling and tool execution robustness

### DIFF
--- a/vscode/src/chat/chat-view/tools/diagnostic.ts
+++ b/vscode/src/chat/chat-view/tools/diagnostic.ts
@@ -99,7 +99,7 @@ function createDiagnosticToolState(
         toolName: 'get_diagnostic',
         status,
         content,
-        title: fileName ?? 'Diagnostics',
+        title: 'diagnostics:' + fileName,
         description: 'Diagnostics',
         icon,
         outputType,

--- a/vscode/src/chat/chat-view/tools/edit.ts
+++ b/vscode/src/chat/chat-view/tools/edit.ts
@@ -110,8 +110,7 @@ async function createFile(uri: vscode.Uri, fileText: string | undefined): Promis
         await fileOps.createFile(uri, fileText)
 
         // Open the file
-        const doc = await vscode.workspace.openTextDocument(uri)
-        await vscode.window.showTextDocument(doc)
+        await vscode.workspace.openTextDocument(uri)
 
         // Check for problems
         const problems = vscode.languages.getDiagnostics(uri)
@@ -286,8 +285,7 @@ async function insertInFile(
         await fileOps.write(uri, lines.join('\n'))
 
         // Open document
-        const document = await vscode.workspace.openTextDocument(uri)
-        await vscode.window.showTextDocument(document)
+        await vscode.workspace.openTextDocument(uri)
 
         return createEditToolState(
             toolId,

--- a/vscode/webviews/chat/cells/toolCell/DiffCell.tsx
+++ b/vscode/webviews/chat/cells/toolCell/DiffCell.tsx
@@ -1,6 +1,6 @@
 import { displayPath } from '@sourcegraph/cody-shared'
 import type { ContextItemToolState } from '@sourcegraph/cody-shared/src/codebase-context/messages'
-import { FileDiffIcon, Minus, Plus } from 'lucide-react'
+import { GitCompare, Minus, Plus } from 'lucide-react'
 import { type FC, useMemo } from 'react'
 import type { URI } from 'vscode-uri'
 import { getFileDiff } from '../../../../src/chat/chat-view/utils/diff'
@@ -50,10 +50,10 @@ export const DiffCell: FC<DiffCellProps> = ({
             </Button>
             <div className="tw-ml-2 tw-flex tw-flex-shrink-0 tw-items-center tw-gap-2">
                 <span className="tw-flex tw-items-center tw-text-emerald-500">
-                    <Plus size={14} className="tw-mr-0.5" /> {result.total.added}
+                    <Plus size={14} className="tw-mr-0.5" /> {result.total.added + 1}
                 </span>
                 <span className="tw-flex tw-items-center tw-text-rose-500">
-                    <Minus size={14} className="tw-mr-0.5" /> {result.total.removed}
+                    <Minus size={14} className="tw-mr-0.5" /> {result.total.removed + 1}
                 </span>
             </div>
         </div>
@@ -97,7 +97,7 @@ export const DiffCell: FC<DiffCellProps> = ({
 
     return (
         <BaseCell
-            icon={FileDiffIcon}
+            icon={GitCompare}
             headerContent={renderHeaderContent()}
             bodyContent={renderBodyContent()}
             className={className}

--- a/vscode/webviews/chat/cells/toolCell/TerminalOutputCell.tsx
+++ b/vscode/webviews/chat/cells/toolCell/TerminalOutputCell.tsx
@@ -1,6 +1,6 @@
-import { type UITerminalLine, UITerminalOutputType } from '@sourcegraph/cody-shared'
+import { type UITerminalLine, UITerminalOutputType, UIToolStatus } from '@sourcegraph/cody-shared'
 import type { ContextItemToolState } from '@sourcegraph/cody-shared/src/codebase-context/messages'
-import { AlarmCheck, Terminal } from 'lucide-react'
+import { Bug, BugOff, Terminal } from 'lucide-react'
 import { type FC, useMemo } from 'react'
 import { Skeleton } from '../../../components/shadcn/ui/skeleton'
 import { cn } from '../../../components/shadcn/utils'
@@ -73,7 +73,12 @@ export const TerminalOutputCell: FC<TerminalOutputCellProps> = ({
     isLoading = false,
     defaultOpen = false,
 }) => {
-    const icon = item.toolName === 'get_diagnostic' ? AlarmCheck : Terminal
+    const icon =
+        item.toolName === 'get_diagnostic'
+            ? item.status === UIToolStatus.Info
+                ? Bug
+                : BugOff
+            : Terminal
     // Process content into lines if provided, otherwise use lines prop
     const lines = useMemo(() => {
         if (item?.content && item.content.trim() !== '') {


### PR DESCRIPTION
This commit improves the robustness of agentic chat by enhancing error handling during tool execution and file creation/insertion.

- **AgenticHandler:**
  - Adds a catch block to `executeTools` to handle errors during tool execution, preventing the chat from crashing.
  - Uses `Promise.allSettled` to execute tools concurrently, allowing the process to continue even if some tools fail.
  - Filters out rejected promises and null/undefined results from `Promise.allSettled` to ensure only successful tool results are processed.
  - Adds a catch block to `executeSingleTool` to handle errors during individual tool invocations.
  - Throws an error if a tool returns null to signal failure.

- **Edit Tool:**
  - Removes `await vscode.window.showTextDocument(doc)` after creating or inserting into a file. This prevents the editor from automatically focusing on the newly created/modified file, improving user experience.

These changes ensure that the agentic chat functionality remains robust even if some tools fail or encounter errors, and improves the user experience by preventing unnecessary focus changes in the editor.

## Test plan

- Manually tested the agentic chat with tools that are known to fail.
- Verified that the chat does not crash when a tool fails.
- Verified that the chat continues to function even if some tools fail.
- Verified that the editor does not automatically focus on newly created/modified files.

Before

<img width="889" alt="image" src="https://github.com/user-attachments/assets/f3e00815-4aa1-470a-bf7a-4e242a06104d" />


After

<img width="1134" alt="image" src="https://github.com/user-attachments/assets/430a406d-04f9-480d-b5d3-1922a5ff2c0a" />

