### PR TITLE
feat: Add Dockerfile that installs cody from source

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+# Dependencies - will be installed during build
+**/node_modules/
+node_modules/
+
+# Git directories
+.git/
+**/.git/

--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -51,3 +51,25 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: pnpm publish --no-git-checks agent
+
+      # Build and push Docker image
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Login to Docker Hub
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      # Build and push
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            sourcegraph/cody-cli:latest
+            sourcegraph/cody-cli:${{ env.EXT_VERSION }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+# Cody Agent Docker Image
+#
+# This Dockerfile builds the Cody Agent CLI tool in a multi-stage process:
+# 1. First stage: Build the agent from source using the pnpm workspace
+# 2. Second stage: Create a minimal runtime image with just the agent installed
+#
+# Usage:
+#   docker build -t cody-agent .
+#   docker run -it --rm cody-agent cody --version
+#   docker run -it --rm cody-agent
+
+# ===== Build Stage =====
+FROM node:23 AS builder
+
+# Install pnpm with specific version from package.json
+RUN npm install -g pnpm
+
+# Copy the entire repository to build with workspace dependencies
+WORKDIR /cody
+COPY . .
+RUN pnpm install
+RUN pnpm build
+
+FROM ubuntu:24.04
+
+# Install Node.js and dependencies
+RUN apt-get update && apt-get install -y nodejs npm libsecret-tools gnome-keyring
+RUN npm install -g pnpm
+
+# Copy the built agent package from the builder stage
+WORKDIR /app
+COPY --from=builder /cody/agent/dist /app/dist
+COPY --from=builder /cody/agent/package.json /app/
+# Create an executable wrapper script for cody
+RUN echo '#!/bin/bash\nnode /app/dist/index.js "$@"' > /usr/local/bin/cody && \
+    chmod +x /usr/local/bin/cody
+
+
+# Test that the agent is installed correctly
+RUN which cody || echo "Cody not found in PATH"
+RUN cody --version || echo "Cody installation failed"
+
+CMD ["/bin/bash"]

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,7 +1,0 @@
-FROM ubuntu:24.04
-
-
-RUN apt-get update && apt-get install -y nodejs npm libsecret-tools gnome-keyring
-RUN npm install -g @sourcegraph/cody
-
-CMD ["/bin/bash"]

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:24.04
+
+
+RUN apt-get update && apt-get install -y nodejs npm libsecret-tools gnome-keyring
+RUN npm install -g @sourcegraph/cody
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
[Slack context](https://sourcegraph.slack.com/archives/C04MSD3DP5L/p1742314663276049)
[Linear ticket](https://linear.app/sourcegraph/issue/REL-806/release-cody-cli-as-docker-image-for-version-5517)

~~This is just so that we have a reference here for now. We're unblocking
a customer while we integrate a CI  pipeline that will publish this
whenever an agent release goes out. That means coping the _built_ files
into this container, rather than using npm. We'll also need to give the
GHA the creds to publish this to Dockerhub.~~

This handles creation of a docker container, pushed to docker hub, which comes pre-installed with the cody npm package, built from source. Previously a single image was published for a customer under the `ccsourcegraph` account, but this PR makes the process production ready, and hooks into existing CI actions, under the `sourcegraph` dockerhub account. 

~~I have chosen not to publish this image given it doesn't currently exist
in the Sourcegraph Dockerhub registry. If the customer demands it, I
could.~~

Once approved and merged, I'll publish the specific image for `5.5.17` to dockerhub since that CI run has already passed. 

Running `docker build . -t sourcegraph/cody-cli:5.5.17` from the `cody/cli` directory will give you a container that has `cody` installed. 

## Test plan
```
> docker run --rm sourcegraph/cody-cli cody --help

Usage: cody [options] [command]

The Cody cli supports running Cody in headless mode and interacting with it via
JSON-RPC. Run `cody chat -m "Hello" to get started.

Options:
  -v, --version   output the version number
  -h, --help      display help for command

Commands:
  auth            Authenticate Cody with Sourcegraph
  chat [options]  Chat with codebase context.
  
  Examples:
    cody chat -m 'Tell me about React hooks'
    cody chat --context-file README.md --message 'Summarize this readme'
    git diff | cody chat --stdin -m 'Explain this diff'
  
  Enterprise Only:
    cody chat --context-repo github.com/sourcegraph/cody --message 'What is the agent?'
  models          Manage models
  api
  internal
  help [command]  display help for command


```

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
