### PR TITLE
fix(agentic-chat): Fix tool result rendering for first message (#7491)

### DIFF
--- a/vscode/src/chat/chat-view/tools/diagnostic.ts
+++ b/vscode/src/chat/chat-view/tools/diagnostic.ts
@@ -23,28 +23,20 @@ export const diagnosticTool: AgentTool = {
         try {
             const fileInfo = await fileOps.getWorkspaceFile(name)
             if (!fileInfo) {
-                return createDiagnosticToolState(name, `Cannot find file ${name}.`, UIToolStatus.Error)
+                throw new Error(`File not found: ${name}`)
             }
 
             const diagnostics = vscode.languages
                 .getDiagnostics(fileInfo.uri)
                 .filter(d => d.severity === vscode.DiagnosticSeverity.Error)
 
-            const content = diagnostics?.length
-                ? `Diagnostics for ${name}:\n${diagnostics.map(d => d.message).join('\n')}`
-                : `No errors found in ${name}`
-
-            return createDiagnosticToolState(
-                name,
-                content,
-                diagnostics.length ? UIToolStatus.Error : UIToolStatus.Done,
-                fileInfo.uri
-            )
+            return createDiagnosticToolState(name, diagnostics, fileInfo.uri)
         } catch (error) {
             return createDiagnosticToolState(
                 name,
-                `Failed to get diagnostics for ${name}: ${error}`,
-                UIToolStatus.Error
+                [],
+                undefined,
+                `Failed to get diagnostics for ${name}: ${error}`
             )
         }
     },
@@ -89,28 +81,37 @@ export function getErrorDiagnostics(file: vscode.Uri): vscode.Diagnostic[] {
  */
 function createDiagnosticToolState(
     fileName: string,
-    content: string,
-    status: UIToolStatus,
-    uri?: vscode.Uri
+    diagnostics: vscode.Diagnostic[],
+    uri?: vscode.Uri,
+    error?: string
 ): ContextItemToolState {
     const toolId = `diagnostic-${Date.now()}`
+    const hasProblems = diagnostics?.length > 0 || error !== undefined
+    const content = hasProblems
+        ? `Diagnostics for ${name}:\n${diagnostics.map(d => d.message).join('\n')}`
+        : error ?? 'EMPTY'
+    const icon = hasProblems ? 'alarm-clock-check' : 'alarm-clock-minus'
+    const status = error ? UIToolStatus.Error : hasProblems ? UIToolStatus.Info : UIToolStatus.Done
 
     return {
         type: 'tool-state',
         toolId,
         toolName: 'get_diagnostic',
         status,
-        outputType: 'file-view',
-
-        // ContextItemCommon properties
-        uri: uri || vscode.Uri.parse(`cody:/tools/diagnostic/${toolId}`),
         content,
-        title: 'File Diagnostics',
-        description: `Diagnostics for ${fileName}`,
+        title: fileName ?? 'Diagnostics',
+        description: 'Diagnostics',
+        icon,
+        outputType,
+        metadata: [
+            'diagnostics',
+            `File: ${fileName}`,
+            `Status: ${status}`,
+            uri ? `Path: ${uri.fsPath}` : null,
+        ].filter(Boolean) as string[],
         source: ContextItemSource.Agentic,
-        icon: 'warning',
-        metadata: [`File: ${fileName}`, `Status: ${status}`, uri ? `Path: ${uri.fsPath}` : null].filter(
-            Boolean
-        ) as string[],
+        uri: uri || vscode.Uri.parse(`cody-tool://diagnostic?id=${toolId}`),
     }
 }
+
+const outputType = 'terminal-output'

--- a/vscode/src/chat/chat-view/tools/shell.ts
+++ b/vscode/src/chat/chat-view/tools/shell.ts
@@ -52,11 +52,13 @@ export const shellTool: AgentTool = {
                 cwd: workspaceFolder.uri.path,
             })
 
-            const content = `${validInput.command}<|OUTPUT|>${commandResult.stdout}${
+            const content = `${commandResult.stdout}${
                 commandResult.stderr ? '<|ERRORS|>' + commandResult.stderr : ''
             }`
 
-            return createShellToolState(validInput.command, content, UIToolStatus.Done)
+            const error = commandResult.stderr ? `Exited with code ${commandResult.stderr}` : undefined
+
+            return createShellToolState(validInput.command, content, UIToolStatus.Done, error)
         } catch (error) {
             if (error instanceof CommandError) {
                 if (error instanceof CommandError) {
@@ -185,26 +187,30 @@ export async function runShellCommand(
  */
 function createShellToolState(
     command: string,
-    content: string,
-    status: UIToolStatus,
-    outputType: 'terminal-output' = 'terminal-output'
+    stdout: string,
+    sterr?: string,
+    error?: string
 ): ContextItemToolState {
     const toolId = `shell-${Date.now()}`
+    const status = error ? UIToolStatus.Error : sterr ? UIToolStatus.Info : UIToolStatus.Done
+    let content = error ?? stdout
+    if (sterr) {
+        content += `<sterr>${sterr}</sterr>`
+    }
 
     return {
         type: 'tool-state',
         toolId,
         toolName: 'run_terminal_command',
-        status,
         outputType,
-
-        // ContextItemCommon properties
-        uri: vscode.Uri.parse(`cody:/tools/shell/${toolId}`),
-        content,
-        description: 'Terminal Command',
         title: command,
-        source: ContextItemSource.Agentic,
+        content,
+        description: 'Bash',
         icon: 'terminal',
-        metadata: [`Command: ${command}`, `Status: ${status}`],
+        status,
+        source: ContextItemSource.Agentic,
+        uri: vscode.Uri.parse(`cody-tool://shell?id=${toolId}`),
     }
 }
+
+const outputType = 'terminal-output'

--- a/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
@@ -50,6 +50,17 @@ interface HumanMessageCellProps {
  * A component that displays a chat message from the human.
  */
 export const HumanMessageCell: FC<HumanMessageCellProps> = ({ message, ...otherProps }) => {
+    // Don't render the editor if the message text is explicitly undefined or empty,
+    // and it's been sent already and it's not the last interaction (i.e. there is a tool result response).
+    if (
+        (message.text === undefined || (message.text && message.text.length === 0)) &&
+        otherProps.isSent &&
+        !otherProps.isLastInteraction &&
+        message.intent === 'agentic'
+    ) {
+        return null
+    }
+
     const messageJSON = JSON.stringify(message)
 
     const initialEditorState = useMemo(

--- a/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/SubmitButton.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/SubmitButton.tsx
@@ -16,7 +16,10 @@ export const SubmitButton: FC<{
                 type="submit"
                 onClick={e => {
                     e.preventDefault()
-                    onClick()
+                    // Do not submit if the editor is empty.
+                    if (state !== 'emptyEditorValue') {
+                        onClick()
+                    }
                 }}
                 className={clsx(
                     'tw-px-6 tw-py-1',

--- a/vscode/webviews/chat/cells/toolCell/TerminalOutputCell.story.tsx
+++ b/vscode/webviews/chat/cells/toolCell/TerminalOutputCell.story.tsx
@@ -1,5 +1,7 @@
-import { UITerminalOutputType } from '@sourcegraph/cody-shared'
+import { UIToolStatus } from '@sourcegraph/cody-shared'
+import type { ContextItemToolState } from '@sourcegraph/cody-shared/src/codebase-context/messages'
 import type { Meta, StoryObj } from '@storybook/react'
+import { URI } from 'vscode-uri'
 import { VSCodeWebview } from '../../../storybook/VSCodeStoryDecorator'
 import { TerminalOutputCell } from './TerminalOutputCell'
 
@@ -13,72 +15,75 @@ export default meta
 
 type Story = StoryObj<typeof TerminalOutputCell>
 
+// Helper function to create a mock ContextItemToolState with terminal output
+const createTerminalItem = (title: string, content: string): ContextItemToolState => ({
+    type: 'tool-state',
+    toolId: `terminal-${title}-${Date.now()}`,
+    toolName: 'run_terminal_command',
+    status: UIToolStatus.Done,
+    outputType: 'terminal-output',
+    title,
+    content,
+    uri: URI.parse(`cody:/tools/shell/terminal-${title}`),
+})
+
 export const Default: Story = {
     args: {
-        lines: [
-            { content: 'ls -la', type: UITerminalOutputType.Input },
-            { content: 'total 32' },
-            { content: 'drwxr-xr-x  10 user  staff   320 Mar 17 12:34 .' },
-            { content: 'drwxr-xr-x   5 user  staff   160 Mar 17 12:30 ..' },
-            { content: '-rw-r--r--   1 user  staff  1420 Mar 17 12:34 TerminalOutputCell.tsx' },
-        ],
+        item: createTerminalItem(
+            'ls -la',
+            `total 32
+drwxr-xr-x  10 user  staff   320 Mar 17 12:34 .
+drwxr-xr-x   5 user  staff   160 Mar 17 12:30 ..
+-rw-r--r--   1 user  staff  1420 Mar 17 12:34 TerminalOutputCell.tsx`
+        ),
+        defaultOpen: false,
     },
 }
 
 export const WithErrors: Story = {
     args: {
-        lines: [
-            { content: 'npm run build', type: UITerminalOutputType.Input },
-            { content: '> cody-vscode@1.0.0 build' },
-            { content: '> vite build' },
-            { content: 'Error: Cannot find module', type: UITerminalOutputType.Error },
-            {
-                content: 'File not found: /src/components/ui/button.tsx',
-                type: UITerminalOutputType.Error,
-            },
-            { content: 'Build failed with 2 errors', type: UITerminalOutputType.Error },
-        ],
-
+        item: createTerminalItem(
+            'npm run build',
+            `> cody-vscode@1.0.0 build
+> vite build
+<sterr>Error: Cannot find module
+File not found: /src/components/ui/button.tsx
+Build failed with 2 errors</sterr>`
+        ),
         defaultOpen: true,
     },
 }
 
 export const WithWarnings: Story = {
     args: {
-        lines: [
-            { content: 'npm run lint', type: UITerminalOutputType.Input },
-            { content: '> cody-vscode@1.0.0 lint' },
-            { content: '> eslint . --ext ts,tsx' },
-            { content: 'Warning: Unexpected any in types', type: UITerminalOutputType.Warning },
-            {
-                content: 'Consider adding explicit type annotation',
-                type: UITerminalOutputType.Warning,
-            },
-            { content: 'Lint complete with 2 warnings', type: UITerminalOutputType.Warning },
-        ],
+        item: createTerminalItem(
+            'npm run lint',
+            `> cody-vscode@1.0.0 lint
+> eslint . --ext ts,tsx
+<sterr>Warning: Unexpected any in types
+Consider adding explicit type annotation
+Lint complete with 2 warnings</sterr>`
+        ),
         defaultOpen: true,
     },
 }
 
 export const WithSuccess: Story = {
     args: {
-        lines: [
-            { content: 'npm run test', type: UITerminalOutputType.Input },
-            { content: '> cody-vscode@1.0.0 test' },
-            { content: '> vitest run' },
-            { content: 'Running 24 tests...' },
-            {
-                content: 'Test suite completed: 24 passed, 0 failed',
-                type: UITerminalOutputType.Success,
-            },
-        ],
+        item: createTerminalItem(
+            'npm run test',
+            `> cody-vscode@1.0.0 test
+> vitest run
+Running 24 tests...
+Test suite completed: 24 passed, 0 failed`
+        ),
         defaultOpen: true,
     },
 }
 
 export const Loading: Story = {
     args: {
-        lines: [],
+        item: createTerminalItem('Loading...', ''),
         isLoading: true,
         defaultOpen: true,
     },
@@ -86,9 +91,13 @@ export const Loading: Story = {
 
 export const LongOutput: Story = {
     args: {
-        lines: Array.from({ length: 30 }, (_, i) => ({
-            content: `Line ${i + 1}: ${JSON.stringify({ key: `value-${i}` })}`,
-        })),
+        item: createTerminalItem(
+            'Long Output',
+            Array.from(
+                { length: 30 },
+                (_, i) => `Line ${i + 1}: ${JSON.stringify({ key: `value-${i}` })}`
+            ).join('\n')
+        ),
         defaultOpen: true,
     },
 }

--- a/vscode/webviews/chat/cells/toolCell/TerminalOutputCell.tsx
+++ b/vscode/webviews/chat/cells/toolCell/TerminalOutputCell.tsx
@@ -1,15 +1,17 @@
 import { type UITerminalLine, UITerminalOutputType } from '@sourcegraph/cody-shared'
-import { Terminal } from 'lucide-react'
-import type { FC } from 'react'
+import type { ContextItemToolState } from '@sourcegraph/cody-shared/src/codebase-context/messages'
+import { AlarmCheck, Terminal } from 'lucide-react'
+import { type FC, useMemo } from 'react'
 import { Skeleton } from '../../../components/shadcn/ui/skeleton'
 import { cn } from '../../../components/shadcn/utils'
 import { BaseCell } from './BaseCell'
 
 interface TerminalOutputCellProps {
-    lines: UITerminalLine[]
+    command: string
     className?: string
     isLoading?: boolean
     defaultOpen?: boolean
+    item: ContextItemToolState
 }
 
 /**
@@ -42,25 +44,46 @@ const getLineClass = (type?: string) => {
 }
 
 // Format the output as an array of TerminalLine objects
-export function convertToTerminalLines(content: string): UITerminalLine[] {
-    const [command, output] = content.split('<|OUTPUT|>')
-    const [stdout, stderr] = output.split('<|ERRORS|>')
+export function convertToTerminalLines(command: string, content?: string): UITerminalLine[] {
+    if (!content) return []
+    // Split content into strout and sterr parts
+    // We will get the errors from between the <sterr> tags
+    const sterrRegex = /<sterr>([\s\S]*)<\/sterr>/g
+    const parts = content.split(sterrRegex)
+    const stdout = parts[0] || ''
+    const stderr = parts.length > 1 ? parts[1] : ''
+    // If there's no output parts, return just the command
+    if (parts.length < 2) {
+        return [{ content: command, type: UITerminalOutputType.Input }].filter(
+            line => line.content.trim() !== ''
+        )
+    }
     const lines: UITerminalLine[] = [
         { content: command, type: UITerminalOutputType.Input },
         ...formatOutputToTerminalLines(stdout, UITerminalOutputType.Output),
         ...formatOutputToTerminalLines(stderr, UITerminalOutputType.Error),
     ].filter(line => line.content.trim() !== '')
+
     return lines
 }
 
 export const TerminalOutputCell: FC<TerminalOutputCellProps> = ({
-    lines,
+    item,
     className,
     isLoading = false,
     defaultOpen = false,
 }) => {
+    const icon = item.toolName === 'get_diagnostic' ? AlarmCheck : Terminal
+    // Process content into lines if provided, otherwise use lines prop
+    const lines = useMemo(() => {
+        if (item?.content && item.content.trim() !== '') {
+            return convertToTerminalLines(item.title ?? 'Terminal', item.content)
+        }
+        return []
+    }, [item.title, item?.content])
+
     const renderHeaderContent = () => {
-        if (isLoading) {
+        if (isLoading && item?.title) {
             return (
                 <div className="tw-flex tw-items-center tw-gap-2 tw-overflow-hidden tw-flex-1">
                     <Skeleton className="tw-h-4 tw-w-40 tw-bg-zinc-800 tw-animate-pulse" />
@@ -78,7 +101,7 @@ export const TerminalOutputCell: FC<TerminalOutputCellProps> = ({
     }
 
     const renderBodyContent = () => {
-        if (isLoading) {
+        if (isLoading || !lines?.length) {
             return (
                 <div className="tw-font-mono tw-text-xs tw-p-4 tw-bg-black tw-rounded-b-md tw-space-y-1">
                     {Array.from({ length: 6 }).map((_, i) => (
@@ -116,7 +139,7 @@ export const TerminalOutputCell: FC<TerminalOutputCellProps> = ({
 
     return (
         <BaseCell
-            icon={Terminal}
+            icon={icon}
             headerContent={renderHeaderContent()}
             bodyContent={renderBodyContent()}
             className={className}

--- a/vscode/webviews/chat/cells/toolCell/ToolStatusCell.tsx
+++ b/vscode/webviews/chat/cells/toolCell/ToolStatusCell.tsx
@@ -1,5 +1,5 @@
 import type { ContextItemToolState } from '@sourcegraph/cody-shared/src/codebase-context/messages'
-import { type FC, useCallback, useMemo } from 'react'
+import { type FC, useCallback } from 'react'
 import type { URI } from 'vscode-uri'
 import { Skeleton } from '../../../components/shadcn/ui/skeleton'
 import { type VSCodeWrapper, getVSCodeAPI } from '../../../utils/VSCodeApi'
@@ -7,7 +7,7 @@ import { DiffCell } from './DiffCell'
 import { FileCell } from './FileCell'
 import { OutputStatusCell } from './OutputStatusCell'
 import { SearchResultsCell } from './SearchResultsCell'
-import { TerminalOutputCell, convertToTerminalLines } from './TerminalOutputCell'
+import { TerminalOutputCell } from './TerminalOutputCell'
 
 export interface ToolStatusProps {
     title: string
@@ -24,15 +24,6 @@ export const ToolStatusCell: FC<ToolStatusProps> = ({ title, output }) => {
         // when the api is not available on the first render
         getVSCodeAPI()?.postMessage({ command: 'openFileLink', uri })
     }, [])
-
-    // Extract terminal lines outside of the conditional render
-    const terminalLines = useMemo(
-        () =>
-            output?.outputType === 'terminal-output' && output.content
-                ? convertToTerminalLines(output.content)
-                : [],
-        [output?.outputType, output?.content]
-    )
 
     if (!title || !output) {
         return (
@@ -61,7 +52,7 @@ export const ToolStatusCell: FC<ToolStatusProps> = ({ title, output }) => {
     }
 
     if (output?.outputType === 'terminal-output') {
-        return <TerminalOutputCell lines={terminalLines} />
+        return <TerminalOutputCell command={title} item={output} />
     }
 
     return <OutputStatusCell item={output} />


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-5442 CLOSE https://linear.app/sourcegraph/issue/CODY-5445

The tool result was not rendering for the first message in agentic chat due to incorrect logic in `Transcript.tsx`. The `isAgenticMode` check was incorrectly using `humanMessage?.index` which was undefined for the first message. This has been fixed by checking
`!humanMessage.isUnsentFollowup && humanMessage?.intent === 'agentic'` instead. Also, the `toolResultContent` and `toolCallContent` were refactored to use `agentToolCalls` to simplify the logic. The test cases in `Transcript.test.tsx` were updated to reflect the changes.

This also fixed the issue where indicator is showing because a bot message that is not in progress was marked as
`assistantMessage.isLoading`

Prevent rendering empty human message cells and submitting empty messages

This commit addresses two issues related to human message cells in the chat interface:

- **Prevent rendering empty cells:** The `HumanMessageCell` component now checks if a message is empty, has been sent, and is not the last interaction (implying a tool result is expected). If all conditions are met, the cell is not rendered, preventing an empty editor from appearing.
- **Prevent submitting empty messages:** The `SubmitButton` component now checks if the editor content is empty before submitting. This prevents accidental submissions of empty messages.

## Test plan

<!-- Required. See
https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Tool use for first message is now being rendered. Example question:

> add a new claude 3.8 sonnet to dotcom models

### After

<img width="771" alt="image"
src="https://github.com/user-attachments/assets/d675fe41-087a-466c-b387-f422e3a6a768" />

### Before

<img width="917" alt="image"
src="https://github.com/user-attachments/assets/d230f6b6-ad59-408a-b899-3635a4ca0e7c" />

(cherry picked from commit 6127da1c58c97b1d60613af6678f4715873ba1f3)


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
