### PR TITLE
fix(agentic-chat): Improve error handling and tool execution robustne…

### DIFF
--- a/vscode/src/chat/chat-view/tools/diagnostic.ts
+++ b/vscode/src/chat/chat-view/tools/diagnostic.ts
@@ -23,28 +23,20 @@ export const diagnosticTool: AgentTool = {
         try {
             const fileInfo = await fileOps.getWorkspaceFile(name)
             if (!fileInfo) {
-                return createDiagnosticToolState(name, `Cannot find file ${name}.`, UIToolStatus.Error)
+                throw new Error(`File not found: ${name}`)
             }
 
             const diagnostics = vscode.languages
                 .getDiagnostics(fileInfo.uri)
                 .filter(d => d.severity === vscode.DiagnosticSeverity.Error)
 
-            const content = diagnostics?.length
-                ? `Diagnostics for ${name}:\n${diagnostics.map(d => d.message).join('\n')}`
-                : `No errors found in ${name}`
-
-            return createDiagnosticToolState(
-                name,
-                content,
-                diagnostics.length ? UIToolStatus.Error : UIToolStatus.Done,
-                fileInfo.uri
-            )
+            return createDiagnosticToolState(name, diagnostics, fileInfo.uri)
         } catch (error) {
             return createDiagnosticToolState(
                 name,
-                `Failed to get diagnostics for ${name}: ${error}`,
-                UIToolStatus.Error
+                [],
+                undefined,
+                `Failed to get diagnostics for ${name}: ${error}`
             )
         }
     },
@@ -89,28 +81,37 @@ export function getErrorDiagnostics(file: vscode.Uri): vscode.Diagnostic[] {
  */
 function createDiagnosticToolState(
     fileName: string,
-    content: string,
-    status: UIToolStatus,
-    uri?: vscode.Uri
+    diagnostics: vscode.Diagnostic[],
+    uri?: vscode.Uri,
+    error?: string
 ): ContextItemToolState {
     const toolId = `diagnostic-${Date.now()}`
+    const hasProblems = diagnostics?.length > 0 || error !== undefined
+    const content = hasProblems
+        ? `Diagnostics for ${name}:\n${diagnostics.map(d => d.message).join('\n')}`
+        : error ?? 'EMPTY'
+    const icon = hasProblems ? 'alarm-clock-check' : 'alarm-clock-minus'
+    const status = error ? UIToolStatus.Error : hasProblems ? UIToolStatus.Info : UIToolStatus.Done
 
     return {
         type: 'tool-state',
         toolId,
         toolName: 'get_diagnostic',
         status,
-        outputType: 'file-view',
-
-        // ContextItemCommon properties
-        uri: uri || vscode.Uri.parse(`cody:/tools/diagnostic/${toolId}`),
         content,
-        title: 'File Diagnostics',
-        description: `Diagnostics for ${fileName}`,
+        title: 'diagnostics:' + fileName,
+        description: 'Diagnostics',
+        icon,
+        outputType,
+        metadata: [
+            'diagnostics',
+            `File: ${fileName}`,
+            `Status: ${status}`,
+            uri ? `Path: ${uri.fsPath}` : null,
+        ].filter(Boolean) as string[],
         source: ContextItemSource.Agentic,
-        icon: 'warning',
-        metadata: [`File: ${fileName}`, `Status: ${status}`, uri ? `Path: ${uri.fsPath}` : null].filter(
-            Boolean
-        ) as string[],
+        uri: uri || vscode.Uri.parse(`cody-tool://diagnostic?id=${toolId}`),
     }
 }
+
+const outputType = 'terminal-output'

--- a/vscode/src/chat/chat-view/tools/edit.ts
+++ b/vscode/src/chat/chat-view/tools/edit.ts
@@ -110,8 +110,7 @@ async function createFile(uri: vscode.Uri, fileText: string | undefined): Promis
         await fileOps.createFile(uri, fileText)
 
         // Open the file
-        const doc = await vscode.workspace.openTextDocument(uri)
-        await vscode.window.showTextDocument(doc)
+        await vscode.workspace.openTextDocument(uri)
 
         // Check for problems
         const problems = vscode.languages.getDiagnostics(uri)
@@ -286,8 +285,7 @@ async function insertInFile(
         await fileOps.write(uri, lines.join('\n'))
 
         // Open document
-        const document = await vscode.workspace.openTextDocument(uri)
-        await vscode.window.showTextDocument(document)
+        await vscode.workspace.openTextDocument(uri)
 
         return createEditToolState(
             toolId,

--- a/vscode/webviews/chat/cells/toolCell/DiffCell.tsx
+++ b/vscode/webviews/chat/cells/toolCell/DiffCell.tsx
@@ -1,6 +1,6 @@
 import { displayPath } from '@sourcegraph/cody-shared'
 import type { ContextItemToolState } from '@sourcegraph/cody-shared/src/codebase-context/messages'
-import { FileDiffIcon, Minus, Plus } from 'lucide-react'
+import { GitCompare, Minus, Plus } from 'lucide-react'
 import { type FC, useMemo } from 'react'
 import type { URI } from 'vscode-uri'
 import { getFileDiff } from '../../../../src/chat/chat-view/utils/diff'
@@ -50,10 +50,10 @@ export const DiffCell: FC<DiffCellProps> = ({
             </Button>
             <div className="tw-ml-2 tw-flex tw-flex-shrink-0 tw-items-center tw-gap-2">
                 <span className="tw-flex tw-items-center tw-text-emerald-500">
-                    <Plus size={14} className="tw-mr-0.5" /> {result.total.added}
+                    <Plus size={14} className="tw-mr-0.5" /> {result.total.added + 1}
                 </span>
                 <span className="tw-flex tw-items-center tw-text-rose-500">
-                    <Minus size={14} className="tw-mr-0.5" /> {result.total.removed}
+                    <Minus size={14} className="tw-mr-0.5" /> {result.total.removed + 1}
                 </span>
             </div>
         </div>
@@ -97,7 +97,7 @@ export const DiffCell: FC<DiffCellProps> = ({
 
     return (
         <BaseCell
-            icon={FileDiffIcon}
+            icon={GitCompare}
             headerContent={renderHeaderContent()}
             bodyContent={renderBodyContent()}
             className={className}

--- a/vscode/webviews/chat/cells/toolCell/TerminalOutputCell.tsx
+++ b/vscode/webviews/chat/cells/toolCell/TerminalOutputCell.tsx
@@ -1,15 +1,17 @@
-import { type UITerminalLine, UITerminalOutputType } from '@sourcegraph/cody-shared'
-import { Terminal } from 'lucide-react'
-import type { FC } from 'react'
+import { type UITerminalLine, UITerminalOutputType, UIToolStatus } from '@sourcegraph/cody-shared'
+import type { ContextItemToolState } from '@sourcegraph/cody-shared/src/codebase-context/messages'
+import { Bug, BugOff, Terminal } from 'lucide-react'
+import { type FC, useMemo } from 'react'
 import { Skeleton } from '../../../components/shadcn/ui/skeleton'
 import { cn } from '../../../components/shadcn/utils'
 import { BaseCell } from './BaseCell'
 
 interface TerminalOutputCellProps {
-    lines: UITerminalLine[]
+    command: string
     className?: string
     isLoading?: boolean
     defaultOpen?: boolean
+    item: ContextItemToolState
 }
 
 /**
@@ -42,25 +44,51 @@ const getLineClass = (type?: string) => {
 }
 
 // Format the output as an array of TerminalLine objects
-export function convertToTerminalLines(content: string): UITerminalLine[] {
-    const [command, output] = content.split('<|OUTPUT|>')
-    const [stdout, stderr] = output.split('<|ERRORS|>')
+export function convertToTerminalLines(command: string, content?: string): UITerminalLine[] {
+    if (!content) return []
+    // Split content into strout and sterr parts
+    // We will get the errors from between the <sterr> tags
+    const sterrRegex = /<sterr>([\s\S]*)<\/sterr>/g
+    const parts = content.split(sterrRegex)
+    const stdout = parts[0] || ''
+    const stderr = parts.length > 1 ? parts[1] : ''
+    // If there's no output parts, return just the command
+    if (parts.length < 2) {
+        return [{ content: command, type: UITerminalOutputType.Input }].filter(
+            line => line.content.trim() !== ''
+        )
+    }
     const lines: UITerminalLine[] = [
         { content: command, type: UITerminalOutputType.Input },
         ...formatOutputToTerminalLines(stdout, UITerminalOutputType.Output),
         ...formatOutputToTerminalLines(stderr, UITerminalOutputType.Error),
     ].filter(line => line.content.trim() !== '')
+
     return lines
 }
 
 export const TerminalOutputCell: FC<TerminalOutputCellProps> = ({
-    lines,
+    item,
     className,
     isLoading = false,
     defaultOpen = false,
 }) => {
+    const icon =
+        item.toolName === 'get_diagnostic'
+            ? item.status === UIToolStatus.Info
+                ? Bug
+                : BugOff
+            : Terminal
+    // Process content into lines if provided, otherwise use lines prop
+    const lines = useMemo(() => {
+        if (item?.content && item.content.trim() !== '') {
+            return convertToTerminalLines(item.title ?? 'Terminal', item.content)
+        }
+        return []
+    }, [item.title, item?.content])
+
     const renderHeaderContent = () => {
-        if (isLoading) {
+        if (isLoading && item?.title) {
             return (
                 <div className="tw-flex tw-items-center tw-gap-2 tw-overflow-hidden tw-flex-1">
                     <Skeleton className="tw-h-4 tw-w-40 tw-bg-zinc-800 tw-animate-pulse" />
@@ -78,7 +106,7 @@ export const TerminalOutputCell: FC<TerminalOutputCellProps> = ({
     }
 
     const renderBodyContent = () => {
-        if (isLoading) {
+        if (isLoading || !lines?.length) {
             return (
                 <div className="tw-font-mono tw-text-xs tw-p-4 tw-bg-black tw-rounded-b-md tw-space-y-1">
                     {Array.from({ length: 6 }).map((_, i) => (
@@ -116,7 +144,7 @@ export const TerminalOutputCell: FC<TerminalOutputCellProps> = ({
 
     return (
         <BaseCell
-            icon={Terminal}
+            icon={icon}
             headerContent={renderHeaderContent()}
             bodyContent={renderBodyContent()}
             className={className}


### PR DESCRIPTION
…ss (#7512)

This commit improves the robustness of agentic chat by enhancing error handling during tool execution and file creation/insertion.

- **AgenticHandler:**
- Adds a catch block to `executeTools` to handle errors during tool execution, preventing the chat from crashing.
- Uses `Promise.allSettled` to execute tools concurrently, allowing the process to continue even if some tools fail.
- Filters out rejected promises and null/undefined results from `Promise.allSettled` to ensure only successful tool results are processed.
- Adds a catch block to `executeSingleTool` to handle errors during individual tool invocations.
  - Throws an error if a tool returns null to signal failure.

- **Edit Tool:**
- Removes `await vscode.window.showTextDocument(doc)` after creating or inserting into a file. This prevents the editor from automatically focusing on the newly created/modified file, improving user experience.

These changes ensure that the agentic chat functionality remains robust even if some tools fail or encounter errors, and improves the user experience by preventing unnecessary focus changes in the editor.

- Manually tested the agentic chat with tools that are known to fail.
- Verified that the chat does not crash when a tool fails.
- Verified that the chat continues to function even if some tools fail.
- Verified that the editor does not automatically focus on newly created/modified files.

Before

<img width="889" alt="image"
src="https://github.com/user-attachments/assets/f3e00815-4aa1-470a-bf7a-4e242a06104d" />

After

<img width="1134" alt="image"
src="https://github.com/user-attachments/assets/430a406d-04f9-480d-b5d3-1922a5ff2c0a" />

(cherry picked from commit dcc305ca7647740628b4a2030799751d44d9b4b5)


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
