### PR TITLE
fix(chat): Temporarily disable Swift tree-sitter parsing due to VSCode 1.98+ compatibility issue

### DIFF
--- a/vscode/src/tree-sitter/parse-tree-cache.ts
+++ b/vscode/src/tree-sitter/parse-tree-cache.ts
@@ -44,12 +44,6 @@ export async function parseDocument(document: TextDocument): Promise<void> {
         return
     }
 
-    // CODY-5459: Swift grammar is not working with VSCode 1.98+
-    // TODO: Fix Swift grammar crash of extension host
-    if (parseLanguage === 'swift') {
-        return
-    }
-
     const parser = await createParser({ language: parseLanguage })
     if (!parser) {
         return
@@ -65,6 +59,12 @@ export function updateParseTreeCache(document: TextDocument, parser: WrappedPars
 
 function getLanguageIfTreeSitterEnabled(document: TextDocument): SupportedLanguage | null {
     const { languageId } = document
+
+    // CODY-5459: Swift grammar is not working with VSCode 1.98+
+    // TODO: Fix Swift grammar crash of extension host
+    if (languageId === 'swift') {
+        return null
+    }
 
     /**
      * 1. Do not use tree-sitter for unsupported languages.

--- a/vscode/src/tree-sitter/parse-tree-cache.ts
+++ b/vscode/src/tree-sitter/parse-tree-cache.ts
@@ -44,6 +44,12 @@ export async function parseDocument(document: TextDocument): Promise<void> {
         return
     }
 
+    // CODY-5459: Swift grammar is not working with VSCode 1.98+
+    // TODO: Fix Swift grammar crash of extension host
+    if (parseLanguage === 'swift') {
+        return
+    }
+
     const parser = await createParser({ language: parseLanguage })
     if (!parser) {
         return


### PR DESCRIPTION
CLOSE CODY-5459

The Swift grammar is currently crashing the extension host in VSCode 1.98 and later. This commit temporarily disables the Swift grammar to prevent crashes.

This is a temporary measure, and the Swift grammar will be re-enabled once the compatibility issue is resolved.

## Test plan

- Verify that the extension host does not crash when opening Swift files and Cody still can give you answers regarding the file passed as context.
