### PR TITLE
feat(auto-edit): implement smart-throttle

### DIFF
--- a/vscode/src/autoedits/analytics-logger/types.ts
+++ b/vscode/src/autoedits/analytics-logger/types.ts
@@ -112,6 +112,7 @@ export const autoeditDiscardReason = {
     noActiveEditor: 7,
     conflictingDecorationWithEdits: 8,
     notEnoughLinesEditor: 9,
+    staleThrottledRequest: 10,
 } as const
 
 /** We use numeric keys to send these to the analytics backend */

--- a/vscode/src/autoedits/autoedits-provider.test.ts
+++ b/vscode/src/autoedits/autoedits-provider.test.ts
@@ -22,17 +22,18 @@ import {
     telemetryRecorder,
 } from '@sourcegraph/cody-shared'
 
-import { ContextMixer } from '../completions/context/context-mixer'
-
 import { mockLocalStorage } from '../services/LocalStorageProvider'
-import { type AutoeditRequestID, autoeditAnalyticsLogger, autoeditTriggerKind } from './analytics-logger'
-import { AutoeditCompletionItem } from './autoedit-completion-item'
 import {
-    AUTOEDIT_CONTEXT_FETCHING_DEBOUNCE_INTERVAL,
-    AUTOEDIT_TOTAL_DEBOUNCE_INTERVAL,
-} from './autoedits-provider'
+    type AutoeditRequestID,
+    autoeditAnalyticsLogger,
+    autoeditDiscardReason,
+    autoeditTriggerKind,
+} from './analytics-logger'
+import { AutoeditCompletionItem } from './autoedit-completion-item'
+import { AUTOEDIT_INITIAL_DEBOUNCE_INTERVAL_MS } from './autoedits-provider'
 import { initImageSuggestionService } from './renderer/image-gen'
 import { DEFAULT_AUTOEDIT_VISIBLE_DELAY_MS } from './renderer/manager'
+import { THROTTLE_TIME } from './smart-throttle'
 import { autoeditResultFor } from './test-helpers'
 
 describe('AutoeditsProvider', () => {
@@ -140,14 +141,14 @@ describe('AutoeditsProvider', () => {
               "isPartiallyOutsideOfVisibleRanges": 1,
               "isRead": 1,
               "isSelectionStale": 1,
-              "latency": 120,
+              "latency": 100,
               "noActiveTextEditor": 0,
               "otherCompletionProviderEnabled": 0,
               "outsideOfActiveEditor": 1,
               "recordsPrivateMetadataTranscript": 1,
               "source": 1,
               "suggestionsStartedSinceLastSuggestion": 1,
-              "timeFromSuggestedAt": 100,
+              "timeFromSuggestedAt": 110,
               "triggerKind": 1,
               "windowNotFocused": 1,
             },
@@ -203,14 +204,14 @@ describe('AutoeditsProvider', () => {
               "isPartiallyOutsideOfVisibleRanges": 1,
               "isRead": 1,
               "isSelectionStale": 1,
-              "latency": 120,
+              "latency": 100,
               "noActiveTextEditor": 0,
               "otherCompletionProviderEnabled": 0,
               "outsideOfActiveEditor": 1,
               "recordsPrivateMetadataTranscript": 1,
               "source": 1,
               "suggestionsStartedSinceLastSuggestion": 1,
-              "timeFromSuggestedAt": 100,
+              "timeFromSuggestedAt": 110,
               "triggerKind": 1,
               "windowNotFocused": 1,
             },
@@ -275,13 +276,13 @@ describe('AutoeditsProvider', () => {
               "isAccepted": 0,
               "isFuzzyMatch": 0,
               "isRead": 0,
-              "latency": 120,
+              "latency": 100,
               "otherCompletionProviderEnabled": 0,
               "recordsPrivateMetadataTranscript": 1,
               "rejectReason": 1,
               "source": 1,
               "suggestionsStartedSinceLastSuggestion": 2,
-              "timeFromSuggestedAt": 375,
+              "timeFromSuggestedAt": 385,
               "triggerKind": 1,
             },
             "privateMetadata": {
@@ -496,16 +497,17 @@ describe('AutoeditsProvider', () => {
         ])
     })
 
-    describe('Debounce logic', () => {
-        it('waits for exactly AUTOEDIT_TOTAL_DEBOUNCE_INTERVAL before calling getPrediction', async () => {
+    describe('smart-throttle', () => {
+        it('does not wait before calling getPrediction first time', async () => {
             let getModelResponseCalledAt: number | undefined
+            const prediction = 'const x = 1\n'
             const customGetModelResponse = async () => {
                 // Record the current fake timer time when getModelResponse is called
                 getModelResponseCalledAt = Date.now()
                 return {
                     type: 'success',
                     responseBody: {
-                        choices: [{ text: 'const x = 1\n' }],
+                        choices: [{ text: prediction }],
                     },
                     requestUrl: 'test-url.com/completions',
                     requestHeaders: {},
@@ -515,74 +517,191 @@ describe('AutoeditsProvider', () => {
 
             const startTime = Date.now()
             const { promiseResult } = await autoeditResultFor('const x = █\n', {
-                prediction: 'const x = 1\n',
+                prediction,
                 getModelResponse: customGetModelResponse,
                 isAutomaticTimersAdvancementDisabled: true,
             })
 
             // Run all timers to get the result
-            await vi.runAllTimersAsync()
+            await vi.advanceTimersByTimeAsync(10000)
             const result = await promiseResult
+
             expect(result?.inlineCompletionItems[0].insertText).toBe('const x = 1')
             expect(getModelResponseCalledAt).toBeDefined()
-            // Check that getModelResponse was called only after at least AUTOEDIT_TOTAL_DEBOUNCE_INTERVAL have elapsed
-            expect(getModelResponseCalledAt! - startTime).toBe(AUTOEDIT_TOTAL_DEBOUNCE_INTERVAL)
+            // Check that getModelResponse was called only after at least AUTOEDIT_INITIAL_DEBOUNCE_INTERVAL_MS have elapsed
+            expect(getModelResponseCalledAt! - startTime).toBe(0)
         })
 
-        it('aborts the operation if cancellation occurs during the context fetching debounce interval', async () => {
-            let modelResponseCalled = false
-            const customGetModelResponse = async () => {
-                modelResponseCalled = true
+        it('consequtive calls are throttled', async () => {
+            const calls = [
+                { prediction: 'const x = 1\n', getModelResponseCalledAt: -1 },
+                { prediction: 'const x = 12345\n', getModelResponseCalledAt: -1 },
+            ]
+
+            const customGetModelResponse = (call: (typeof calls)[number]) => async () => {
+                // Record the current fake timer time when getModelResponse is called
+                call.getModelResponseCalledAt = performance.now()
+                await vi.advanceTimersByTimeAsync(50)
                 return {
                     type: 'success',
-                    responseBody: { choices: [{ text: 'const x = 1\n' }] },
+                    responseBody: {
+                        choices: [{ text: call.prediction }],
+                    },
                     requestUrl: 'test-url.com/completions',
                     requestHeaders: {},
                     responseHeaders: {},
                 } as const
             }
 
-            const tokenSource = new vscode.CancellationTokenSource()
-            const getContextSpy = vi.spyOn(ContextMixer.prototype, 'getContext')
+            const { promiseResult: promiseResult1, provider } = await autoeditResultFor(
+                'const x = █\n',
+                {
+                    prediction: calls[0].prediction,
+                    getModelResponse: customGetModelResponse(calls[0]),
+                    isAutomaticTimersAdvancementDisabled: true,
+                }
+            )
 
-            const { promiseResult } = await autoeditResultFor('const x = █\n', {
-                prediction: 'const x = 1\n',
-                token: tokenSource.token,
-                getModelResponse: customGetModelResponse,
+            const delayBeforeSecondCall = AUTOEDIT_INITIAL_DEBOUNCE_INTERVAL_MS + 5
+            await vi.advanceTimersByTimeAsync(delayBeforeSecondCall)
+            const secondCallStartedAt = performance.now()
+
+            const { promiseResult: promiseResult2 } = await autoeditResultFor('const x = 123█\n', {
+                prediction: calls[1].prediction,
+                getModelResponse: customGetModelResponse(calls[1]),
                 isAutomaticTimersAdvancementDisabled: true,
+                provider,
             })
 
-            // Wait for the context fetching to start
-            await vi.advanceTimersByTimeAsync(AUTOEDIT_CONTEXT_FETCHING_DEBOUNCE_INTERVAL)
-            expect(getContextSpy).toHaveBeenCalled()
+            // Run all timers to get the result
+            await vi.advanceTimersByTimeAsync(10000)
+            const result1 = await promiseResult1
+            const result2 = await promiseResult2
 
-            // Cancel the auto-edit request
-            tokenSource.cancel()
+            // The first call is aborted because the second call is triggered before the
+            // `customGetModelResponse` function has returned.
+            expect(result1).toBeNull()
 
-            // Wait for the debounce period to complete to get the result
-            await vi.advanceTimersByTimeAsync(AUTOEDIT_TOTAL_DEBOUNCE_INTERVAL)
-            const result = await promiseResult
+            // Insert text includes duplicated the existing numbers becase we have inline decorations
+            // to remove "123" and replace it with "12345".
+            expect(result2?.inlineCompletionItems[0].insertText).toBe('const x = 12312345')
 
-            expect(result).toBeNull()
-            expect(modelResponseCalled).toBe(false)
+            // The first call is executed immediately.
+            expect(calls[0].getModelResponseCalledAt).toBe(0)
+
+            // The second call is executed after the throttle interval.
+            expect(calls[1].getModelResponseCalledAt).toBe(50)
+            expect(calls[1].getModelResponseCalledAt - secondCallStartedAt).toBe(
+                THROTTLE_TIME - delayBeforeSecondCall
+            )
+        })
+
+        it('consequtive calls are throttled and intermediate calls are aborted', async () => {
+            const calls = [
+                { prediction: 'const x = 1\n', getModelResponseCalledAt: -1 },
+                { prediction: 'const x = 12345\n', getModelResponseCalledAt: -1 },
+                { prediction: 'const x = 123\nconst y = 23456\n', getModelResponseCalledAt: -1 },
+                { prediction: 'const x = 123\nconst y = 12345\n', getModelResponseCalledAt: -1 },
+            ]
+
+            const customGetModelResponse = (call: (typeof calls)[number]) => async () => {
+                // Record the current fake timer time when getModelResponse is called
+                call.getModelResponseCalledAt = performance.now()
+                await vi.advanceTimersByTimeAsync(0)
+                return {
+                    type: 'success',
+                    responseBody: {
+                        choices: [{ text: call.prediction }],
+                    },
+                    requestUrl: 'test-url.com/completions',
+                    requestHeaders: {},
+                    responseHeaders: {},
+                } as const
+            }
+
+            const { promiseResult: promiseResult1, provider } = await autoeditResultFor(
+                'const x = █\n',
+                {
+                    prediction: calls[0].prediction,
+                    getModelResponse: customGetModelResponse(calls[0]),
+                    isAutomaticTimersAdvancementDisabled: true,
+                }
+            )
+
+            const delayBeforeSecondCall = AUTOEDIT_INITIAL_DEBOUNCE_INTERVAL_MS + 5
+            await vi.advanceTimersByTimeAsync(delayBeforeSecondCall)
+
+            const { promiseResult: promiseResult2 } = await autoeditResultFor('const x = 123█\n', {
+                prediction: calls[1].prediction,
+                getModelResponse: customGetModelResponse(calls[1]),
+                isAutomaticTimersAdvancementDisabled: true,
+                provider,
+            })
+
+            await vi.advanceTimersByTimeAsync(25)
+
+            const { promiseResult: promiseResult3 } = await autoeditResultFor(
+                'const x = 123\nconst y = █\n',
+                {
+                    prediction: calls[2].prediction,
+                    getModelResponse: customGetModelResponse(calls[2]),
+                    isAutomaticTimersAdvancementDisabled: true,
+                    provider,
+                }
+            )
+
+            await vi.advanceTimersByTimeAsync(11)
+
+            const { promiseResult: promiseResult4 } = await autoeditResultFor(
+                'const x = 123\nconst y = 12█\n',
+                {
+                    prediction: calls[3].prediction,
+                    getModelResponse: customGetModelResponse(calls[3]),
+                    isAutomaticTimersAdvancementDisabled: true,
+                    provider,
+                }
+            )
+
+            // Run all timers to get the result
+            await vi.advanceTimersByTimeAsync(10000)
+            const [result1, result2, result3, result4] = await Promise.all([
+                promiseResult1,
+                promiseResult2,
+                promiseResult3,
+                promiseResult4,
+            ])
+
+            // The first call is aborted because the second call is triggered before the
+            // `customGetModelResponse` function has returned.
+            expect(result1).toBeNull()
+            expect(result2).toBeNull()
+            expect(result3).toBeNull()
+            expect(result4?.inlineCompletionItems[0].insertText).toBe('const y = 1212345')
+
+            // The first call is executed immediately.
+            expect(calls[0].getModelResponseCalledAt).toBe(0)
+            // The second call is aborted because the third call
+            expect(calls[1].getModelResponseCalledAt).toBe(-1)
+            // The third call is throttled against the only executed (first) call
+            expect(calls[2].getModelResponseCalledAt).toBe(50)
         })
 
         it('the abort signal is propagated to the model request', async () => {
-            const tokenSource = new vscode.CancellationTokenSource()
-            const logErrorSpy = vi.spyOn(autoeditAnalyticsLogger, 'logError')
+            const markAsDiscardedSpy = vi.spyOn(autoeditAnalyticsLogger, 'markAsDiscarded')
 
-            const { promiseResult } = await autoeditResultFor('const x = █\n', {
+            const { promiseResult, provider } = await autoeditResultFor('const x = █\n', {
                 prediction: 'const x = 1\n',
-                token: tokenSource.token,
                 isAutomaticTimersAdvancementDisabled: true,
                 getModelResponse: async ({ abortSignal }) => {
-                    if (abortSignal.aborted) {
-                        throw new Error('aborted before the cancellation')
-                    }
+                    provider.smartThrottleService.lastRequest?.abort()
 
-                    tokenSource.cancel()
                     if (abortSignal.aborted) {
-                        throw new Error('aborted after the cancellation')
+                        return {
+                            type: 'aborted',
+                            requestUrl: 'test-url.com/completions',
+                            requestHeaders: {},
+                            responseHeaders: {},
+                        } as const
                     }
 
                     return {
@@ -595,11 +714,15 @@ describe('AutoeditsProvider', () => {
                 },
             })
 
-            await vi.advanceTimersByTimeAsync(AUTOEDIT_TOTAL_DEBOUNCE_INTERVAL)
+            await vi.advanceTimersToNextTimerAsync()
+            await promiseResult
 
-            expect(logErrorSpy).toHaveBeenCalledTimes(1)
-            expect(logErrorSpy).toHaveBeenCalledWith(new Error('aborted after the cancellation'))
             expect(promiseResult).resolves.toBeNull()
+            expect(markAsDiscardedSpy).toHaveBeenCalledTimes(1)
+            expect(markAsDiscardedSpy).toHaveBeenCalledWith({
+                requestId: expect.any(String),
+                discardReason: autoeditDiscardReason.clientAborted,
+            })
         })
     })
 })

--- a/vscode/src/autoedits/autoedits-provider.ts
+++ b/vscode/src/autoedits/autoedits-provider.ts
@@ -85,7 +85,7 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
     private readonly disposables: vscode.Disposable[] = []
     /** Keeps track of the last time the text was changed in the editor. */
     private lastTextChangeTimeStamp: number | undefined
-    private lastManualTriggerTimestamp = performance.now()
+    private lastManualTriggerTimestamp = Number.MIN_SAFE_INTEGER
 
     private readonly onSelectionChangeDebounced: DebouncedFunc<typeof this.onSelectionChange>
 

--- a/vscode/src/autoedits/autoedits-provider.ts
+++ b/vscode/src/autoedits/autoedits-provider.ts
@@ -50,13 +50,13 @@ import {
 } from './renderer/mock-renderer'
 import type { AutoEditRenderOutput } from './renderer/render-output'
 import { shrinkPredictionUntilSuffix } from './shrink-prediction'
+import { SmartThrottleService } from './smart-throttle'
 import { areSameUriDocs, isPredictedTextAlreadyInSuffix } from './utils'
 
 const AUTOEDIT_CONTEXT_STRATEGY = 'auto-edit'
-export const AUTOEDIT_TOTAL_DEBOUNCE_INTERVAL = 20
-export const AUTOEDIT_CONTEXT_FETCHING_DEBOUNCE_INTERVAL = 10
 const RESET_SUGGESTION_ON_CURSOR_CHANGE_AFTER_INTERVAL_MS = 60 * 1000
-const ON_SELECTION_CHANGE_DEFAULT_DEBOUNCE_INTERVAL_MS = 15
+const ON_SELECTION_CHANGE_DEFAULT_DEBOUNCE_INTERVAL_MS = 10
+export const AUTOEDIT_INITIAL_DEBOUNCE_INTERVAL_MS = 10
 
 interface AutoeditEditItem extends AutocompleteEditItem {
     id: AutoeditRequestID
@@ -89,6 +89,7 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
 
     public readonly rendererManager: AutoEditsRendererManager
     private readonly modelAdapter: AutoeditsModelAdapter
+    public readonly smartThrottleService = new SmartThrottleService()
 
     private readonly promptStrategy = new PromptCacheOptimizedV1()
     public readonly filterPrediction = new FilterPredictionBasedOnRecentEdits()
@@ -168,7 +169,7 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
 
     private onDidChangeTextDocument(event: vscode.TextDocumentChangeEvent): void {
         if (event.document.uri.scheme === 'file') {
-            this.lastTextChangeTimeStamp = Date.now()
+            this.lastTextChangeTimeStamp = performance.now()
         }
     }
 
@@ -184,7 +185,7 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
         // Don't show suggestion on cursor movement if the text has not changed for a certain amount of time
         if (
             this.lastTextChangeTimeStamp &&
-            Date.now() - this.lastTextChangeTimeStamp <
+            performance.now() - this.lastTextChangeTimeStamp <
                 RESET_SUGGESTION_ON_CURSOR_CHANGE_AFTER_INTERVAL_MS
         ) {
             await vscode.commands.executeCommand('editor.action.inlineSuggest.trigger')
@@ -198,6 +199,7 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
         token?: vscode.CancellationToken
     ): Promise<AutoeditsResult | null> {
         let stopLoading: (() => void) | undefined
+        const startedAt = getTimeNowInMillis()
 
         if (inlineCompletionContext.selectedCompletionInfo !== undefined) {
             const { range, text } = inlineCompletionContext.selectedCompletionInfo
@@ -216,28 +218,30 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
         }
 
         try {
-            const startedAt = getTimeNowInMillis()
-            const controller = new AbortController()
-            const abortSignal = controller.signal
-            token?.onCancellationRequested(() => controller.abort())
-
-            await new Promise(resolve =>
-                setTimeout(resolve, AUTOEDIT_CONTEXT_FETCHING_DEBOUNCE_INTERVAL)
-            )
-            const remainingDebounceInterval =
-                AUTOEDIT_TOTAL_DEBOUNCE_INTERVAL - AUTOEDIT_CONTEXT_FETCHING_DEBOUNCE_INTERVAL
-            if (abortSignal.aborted) {
-                autoeditsOutputChannelLogger.logDebugIfVerbose(
-                    'provideInlineCompletionItems',
-                    'debounce aborted AUTOEDIT_CONTEXT_FETCHING_DEBOUNCE_INTERVAL'
-                )
-                return null
-            }
-
             stopLoading = this.statusBar.addLoader({
                 title: 'Auto-edits are being generated',
-                timeout: 30_000,
+                timeout: 5_000,
             })
+            const throttledRequest = this.smartThrottleService.throttle({
+                uri: document.uri.toString(),
+                position,
+                isUserInitiated:
+                    inlineCompletionContext.triggerKind === vscode.InlineCompletionTriggerKind.Invoke,
+            })
+            const abortSignal = throttledRequest.abortController.signal
+
+            let remainingThrottleDelay = throttledRequest.delayMs
+            if (throttledRequest.delayMs > AUTOEDIT_INITIAL_DEBOUNCE_INTERVAL_MS) {
+                await new Promise(resolve => setTimeout(resolve, AUTOEDIT_INITIAL_DEBOUNCE_INTERVAL_MS))
+                if (abortSignal.aborted) {
+                    autoeditsOutputChannelLogger.logDebugIfVerbose(
+                        'provideInlineCompletionItems',
+                        `debounce aborted during first ${AUTOEDIT_INITIAL_DEBOUNCE_INTERVAL_MS}ms of throttle`
+                    )
+                    return null
+                }
+                remainingThrottleDelay -= AUTOEDIT_INITIAL_DEBOUNCE_INTERVAL_MS
+            }
 
             autoeditsOutputChannelLogger.logDebugIfVerbose(
                 'provideInlineCompletionItems',
@@ -282,13 +286,13 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
                     docContext,
                     maxChars: 32_000,
                 }),
-                new Promise(resolve => setTimeout(resolve, remainingDebounceInterval)),
+                new Promise(resolve => setTimeout(resolve, remainingThrottleDelay)),
             ])
 
             if (abortSignal.aborted) {
                 autoeditsOutputChannelLogger.logDebugIfVerbose(
                     'provideInlineCompletionItems',
-                    'aborted during context fetch debounce'
+                    'aborted during context fetch and the remaining throttle delay'
                 )
                 return null
             }
@@ -346,6 +350,18 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
                     prediction: initialPrediction,
                 },
             })
+
+            if (throttledRequest.isStale) {
+                autoeditsOutputChannelLogger.logDebugIfVerbose(
+                    'provideInlineCompletionItems',
+                    'throttled request is stale'
+                )
+                autoeditAnalyticsLogger.markAsDiscarded({
+                    requestId,
+                    discardReason: autoeditDiscardReason.staleThrottledRequest,
+                })
+                return null
+            }
 
             if (predictionResult.prediction.length === 0) {
                 autoeditsOutputChannelLogger.logDebugIfVerbose(

--- a/vscode/src/autoedits/smart-throttle.ts
+++ b/vscode/src/autoedits/smart-throttle.ts
@@ -1,0 +1,159 @@
+import type * as vscode from 'vscode'
+
+export const THROTTLE_TIME = 50 as const // ms - standard throttle time for all auto-edits
+
+/**
+ * Smart throttle service that manages the frequency of auto-edit requests,
+ * balancing responsiveness with avoiding excessive processing.
+ */
+export class SmartThrottleService {
+    public lastRequest: ThrottledRequest | undefined
+
+    /**
+     * Check if a request should be throttled based on the last executed request.
+     *
+     * For the examples below, THROTTLE_TIME = 50ms
+     *
+     * For auto-edits, a throttle window of 50ms is enforced relative to the last executed
+     * auto-edit. When a new request arrives:
+     *
+     * - If it is user-initiated, from a different document, or in a sufficiently different context,
+     *   it executes immediately (Case 1).
+     * - Otherwise, the service checks if there is a pending auto-edit (Case 2) or if the last
+     *   auto-edit executed but its throttle window is still active (Case 3).
+     *
+     * Throttle Window (anchored to the last executed request at time T):
+     *   [T, T + THROTTLE_TIME] = [T, T + 50ms]
+     *
+     * CASE 1: Immediate Execution (First Request or User-Initiated)
+     * ------------------------------------------------------------
+     * No prior pending auto-edit exists (or context differs), so the request executes immediately.
+     *
+     *   Time (ms):  0                                50ms
+     *               |----------------------------------|
+     *               Request A executes at t = 0
+     *               Throttle window for A: [0, 50ms]
+     *
+     * CASE 2: New Request Arrives Before Pending Request Execution
+     * ------------------------------------------------------------
+     * A previous request (A) was already scheduled (but not executed) with a computed delay,
+     * meaning its execution is pending. When a new request (B) comes in before A executes,
+     * A is aborted and B adopts the same scheduled execution time.
+     *
+     * Example:
+     *   - Suppose a prior auto-edit (A) was scheduled at t = 0 with delayMs = 30ms,
+     *     so A is set to execute at t = 30ms.
+     *   - Its underlying throttle window is conceptually still based on the last executed time,
+     *     say [0, 50ms].
+     *   - Request B arrives at t = 20ms (before A’s pending execution).
+     *   - New delay for B = A.willBeExecutedAt - now = 30ms - 20ms = 10ms.
+     *   - Thus, B will execute at t = 30ms.
+     *
+     *   Time (ms):  0        10        20        30        40        50
+     *               |--------|---------|---------|---------|---------|
+     *               ↓                  ↓
+     *               Request A          Request B
+     *               (pending; scheduled for t = 30ms)
+     *               Throttle window for A: [0, 50ms]
+     *
+     * CASE 3: New Request Arrives After Last Execution but Within Throttle Window
+     * ---------------------------------------------------------------------------
+     * The previous request (A) has executed, and its throttle window is now active.
+     * A new request (B) arriving within this window is delayed until the window expires.
+     *
+     * Example:
+     *   - Request A executes at t = 0 (immediate execution).
+     *   - Its throttle window is [0, 50ms].
+     *   - Request B arrives at t = 30ms.
+     *   - Time since last execution = 30ms.
+     *   - Remaining throttle time = THROTTLE_TIME - (30ms) = 20ms.
+     *   - B is scheduled with delayMs = 20ms, so it executes at t = 50ms.
+     *
+     *   Time (ms):  0                                50ms                   100ms
+     *               |----------------------------------|
+     *               Request A executes at t = 0
+     *               Throttle window for A: [0, 50ms]
+     *                                  Request B executes at t = 50ms
+     *                                  New throttle window for B: [50ms, 100ms]
+     */
+    public throttle(params: {
+        uri: string
+        position: vscode.Position
+        isUserInitiated: boolean
+    }): ThrottledRequest {
+        const { uri, position, isUserInitiated } = params
+        const now = performance.now()
+
+        const lastRequest = this.lastRequest
+        this.lastRequest = new ThrottledRequest({ uri, position, createdAt: now, delayMs: 0 })
+
+        // CASE 1: First request, different documents, or user-initiated - execute immediately
+        if (isUserInitiated || !lastRequest || !this.areCloseEnough(lastRequest, params)) {
+            lastRequest?.abortController.abort()
+            return this.lastRequest
+        }
+
+        const timeSinceLastRequestExecution = now - lastRequest.willBeExecutedAt
+
+        if (timeSinceLastRequestExecution <= 0) {
+            // CASE 2: We haven't reached the throttle time yet, so abort the last request
+            // and delay the new one by the remaining time from the previous request
+            lastRequest.abortController.abort()
+            this.lastRequest.delayMs = Math.max(0, lastRequest.willBeExecutedAt - now)
+        } else {
+            // CASE 3: The previous request has completed its throttle window,
+            // but we're still within THROTTLE_TIME of it
+            // Mark previous as stale and delay the new one by the remaining throttle time
+            lastRequest.markAsStale()
+            this.lastRequest.delayMs = Math.max(0, THROTTLE_TIME - timeSinceLastRequestExecution)
+        }
+
+        return this.lastRequest
+    }
+
+    private areCloseEnough(
+        lastRequest: { uri: string; position: vscode.Position },
+        newRequest: { uri: string; position: vscode.Position }
+    ): boolean {
+        if (lastRequest.uri !== newRequest.uri) {
+            return false
+        }
+
+        return newRequest.position.line - lastRequest.position.line <= 1
+    }
+}
+
+class ThrottledRequest {
+    public abortController: AbortController
+    public uri: string
+    public position: vscode.Position
+    public createdAt: number
+    public delayMs: number
+    public isStale: boolean
+
+    constructor({
+        uri,
+        position,
+        createdAt,
+        delayMs,
+    }: { uri: string; position: vscode.Position; createdAt: number; delayMs: number }) {
+        this.uri = uri
+        this.position = position
+        this.createdAt = createdAt
+        this.delayMs = delayMs
+        this.abortController = new AbortController()
+        this.isStale = false
+    }
+
+    public get willBeExecutedAt() {
+        return this.createdAt + this.delayMs
+    }
+
+    public abort() {
+        this.abortController.abort()
+    }
+
+    public markAsStale() {
+        this.isStale = true
+    }
+}

--- a/vscode/src/autoedits/smart-throttle.ts
+++ b/vscode/src/autoedits/smart-throttle.ts
@@ -79,16 +79,16 @@ export class SmartThrottleService {
     public throttle(params: {
         uri: string
         position: vscode.Position
-        isUserInitiated: boolean
+        isManuallyTriggered: boolean
     }): ThrottledRequest {
-        const { uri, position, isUserInitiated } = params
+        const { uri, position, isManuallyTriggered } = params
         const now = performance.now()
 
         const lastRequest = this.lastRequest
         this.lastRequest = new ThrottledRequest({ uri, position, createdAt: now, delayMs: 0 })
 
-        // CASE 1: First request, different documents, or user-initiated - execute immediately
-        if (isUserInitiated || !lastRequest || !this.areCloseEnough(lastRequest, params)) {
+        // CASE 1: First request, different documents, or manually triggered - execute immediately
+        if (isManuallyTriggered || !lastRequest || !this.areCloseEnough(lastRequest, params)) {
             lastRequest?.abortController.abort()
             return this.lastRequest
         }

--- a/vscode/src/autoedits/test-helpers.ts
+++ b/vscode/src/autoedits/test-helpers.ts
@@ -12,7 +12,7 @@ import type { CodyStatusBar } from '../services/StatusBar'
 import * as adapters from './adapters/utils'
 import { autoeditTriggerKind } from './analytics-logger'
 import {
-    AUTOEDIT_TOTAL_DEBOUNCE_INTERVAL,
+    AUTOEDIT_INITIAL_DEBOUNCE_INTERVAL_MS,
     AutoeditsProvider,
     type AutoeditsResult,
 } from './autoedits-provider'
@@ -32,7 +32,6 @@ export async function autoeditResultFor(
             selectedCompletionInfo: undefined,
         },
         prediction,
-        token,
         provider: existingProvider,
         getModelResponse,
         isAutomaticTimersAdvancementDisabled = false,
@@ -41,7 +40,6 @@ export async function autoeditResultFor(
         /** provide to reuse an existing provider instance */
         provider?: AutoeditsProvider
         inlineCompletionContext?: vscode.InlineCompletionContext
-        token?: vscode.CancellationToken
         getModelResponse?: typeof adapters.getModelResponse
         isAutomaticTimersAdvancementDisabled?: boolean
     }
@@ -101,7 +99,7 @@ export async function autoeditResultFor(
     let result: AutoeditsResult | null = null
 
     const promiseResult = provider
-        .provideInlineCompletionItems(document, position, inlineCompletionContext, token)
+        .provideInlineCompletionItems(document, position, inlineCompletionContext)
         .then(res => {
             result = res
             return result
@@ -113,7 +111,7 @@ export async function autoeditResultFor(
 
     if (!isAutomaticTimersAdvancementDisabled) {
         // Advance time by the default debounce interval.
-        await vi.advanceTimersByTimeAsync(AUTOEDIT_TOTAL_DEBOUNCE_INTERVAL)
+        await vi.advanceTimersByTimeAsync(AUTOEDIT_INITIAL_DEBOUNCE_INTERVAL_MS)
     }
 
     return { result, promiseResult, document, position, provider, editBuilder }


### PR DESCRIPTION
- Implements smart-throttle for the auto-edit provider. See a doc string comment in the implementation explaining how it works. The smart-throttle service now fully controls abort logic, and we do not use cancellation tokens provided by VS Code.
    - Requests in the new code to rewrite areas are made instantly, without delay.
    - The throttle interval is set to 50ms in this PR. Happy to adjust, but it performed OK locally during the manual testing. We can adjust the value with a backport during the dogfooding phase if we see that the load on the model grows significantly.
- Closes [CODY-5466: Implement smart-throttle](https://linear.app/sourcegraph/issue/CODY-5466/implement-smart-throttle)

## Test plan

CI + new tests + manual testing with the auto-edit debug panel
