### PR TITLE
Fix cody agent model listing command

### DIFF
--- a/agent/src/cli/command-models.ts
+++ b/agent/src/cli/command-models.ts
@@ -1,3 +1,4 @@
+import { getClientIdentificationHeaders } from '@sourcegraph/cody-shared'
 import { Command } from 'commander'
 import { AuthenticatedAccount } from './command-auth/AuthenticatedAccount'
 import { endpointOption } from './command-auth/command-login'
@@ -20,6 +21,7 @@ export const modelsCommand = () =>
                 const results = await fetch(`${account.serverEndpoint}/.api/llm/models`, {
                     headers: {
                         Authorization: `token ${account.accessToken}`,
+                        ...getClientIdentificationHeaders(),
                     },
                 })
                 if (!results.ok) {


### PR DESCRIPTION
This PR fixes issue with `cody model list` command, which was failing because it didn't send `X-Requested-With` header.

## Test plan

- Just run `cody model list` and see if it fails

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
