### PR TITLE
fix(chat): Display file path in chat file cell

### DIFF
--- a/vscode/webviews/chat/cells/toolCell/FileCell.story.tsx
+++ b/vscode/webviews/chat/cells/toolCell/FileCell.story.tsx
@@ -1,87 +1,92 @@
-// import { type UIFileView, UIToolStatus } from '@sourcegraph/cody-shared'
-// import type { Meta, StoryObj } from '@storybook/react'
-// import { URI } from 'vscode-uri'
-// import { VSCodeWebview } from '../../../storybook/VSCodeStoryDecorator'
-// import { FileCell } from './FileCell'
+import { UIToolStatus } from '@sourcegraph/cody-shared'
+import type { ContextItemToolState } from '@sourcegraph/cody-shared/src/codebase-context/messages'
+import type { Meta, StoryObj } from '@storybook/react'
+import { URI } from 'vscode-uri'
+import { VSCodeWebview } from '../../../storybook/VSCodeStoryDecorator'
+import { FileCell } from './FileCell'
 
-// const meta: Meta<typeof FileCell> = {
-//     title: 'agentic/FileCell',
-//     component: FileCell,
-//     decorators: [VSCodeWebview],
-// }
-// export default meta
+const meta: Meta<typeof FileCell> = {
+    title: 'agentic/FileCell',
+    component: FileCell,
+    decorators: [VSCodeWebview],
+}
+export default meta
 
-// type Story = StoryObj<typeof FileCell>
+type Story = StoryObj<typeof FileCell>
 
-// export const Default: Story = {
-//     args: {
-//         result: {
-//             id: 'file-1',
-//             name: 'file',
-//             type: 'file-view',
-//             uri: URI.file('path/to/example.ts'),
-//             title: 'path/to/example.ts',
-//             content: 'function example() {\n  console.log("Hello, world!");\n  return true;\n}',
-//             status: UIToolStatus.Done,
-//         } as UIFileView,
-//         defaultOpen: true,
-//     },
-// }
+export const Default: Story = {
+    args: {
+        result: {
+            uri: URI.parse('foo.bar'),
+            type: 'tool-state',
+            outputType: 'file-view',
+            status: UIToolStatus.Info,
+            title: 'File View',
+            toolId: 'file',
+            toolName: 'get_file',
+            content: 'This is the file ontent',
+        } as ContextItemToolState,
+        defaultOpen: false,
+    },
+}
 
-// export const LongFile: Story = {
-//     args: {
-//         result: {
-//             id: 'long-file',
-//             name: 'file',
-//             type: 'file-view',
-//             uri: URI.file('longExample.ts'),
-//             title: 'longExample.ts',
-//             content: Array(20).fill('// This is a line of code').join('\n'),
-//             status: UIToolStatus.Done,
-//         } as UIFileView,
-//     },
-// }
+export const LongFile: Story = {
+    args: {
+        result: {
+            uri: URI.parse('long-file.ts'),
+            type: 'tool-state',
+            outputType: 'file-view',
+            status: UIToolStatus.Info,
+            title: 'File View',
+            toolId: 'file',
+            toolName: 'get_file',
+            content: Array(20).fill('// This is a line of code').join('\n'),
+        } as ContextItemToolState,
+    },
+}
 
-// export const WithCustomClass: Story = {
-//     args: {
-//         result: {
-//             id: 'styled-file',
-//             name: 'file',
-//             type: 'file-view',
-//             uri: URI.file('styled.ts'),
-//             title: 'styled.ts',
-//             content: 'const styles = {\n  color: "blue",\n  fontSize: 14\n}',
-//             status: UIToolStatus.Done,
-//         } as UIFileView,
-//         className: 'tw-max-w-md',
-//     },
-// }
+export const WithCustomClass: Story = {
+    args: {
+        result: {
+            uri: URI.parse('foo.bar'),
+            type: 'tool-state',
+            outputType: 'file-view',
+            status: UIToolStatus.Info,
+            title: 'File View',
+            toolId: 'file',
+            toolName: 'get_file',
+            content: 'const styles = {\n  color: "blue",\n  fontSize: 14\n}',
+        } as ContextItemToolState,
+        className: 'tw-max-w-md',
+    },
+}
 
-// export const Collapsed: Story = {
-//     args: {
-//         result: {
-//             id: 'collapsed-file',
-//             name: 'file',
-//             type: 'file-view',
-//             uri: URI.file('collapsed.ts'),
-//             title: 'collapsed.ts',
-//             content: 'const hidden = "This content is initially hidden";',
-//             status: UIToolStatus.Done,
-//         } as UIFileView,
-//         defaultOpen: false,
-//     },
-// }
+export const Collapsed: Story = {
+    args: {
+        result: {
+            uri: URI.parse('foo.bar'),
+            type: 'tool-state',
+            outputType: 'file-view',
+            status: UIToolStatus.Done,
+            title: 'File View',
+            toolId: 'file',
+            toolName: 'get_file',
+            content: 'const styles = {\n  color: "blue",\n  fontSize: 14\n}',
+        } as ContextItemToolState,
+        defaultOpen: false,
+    },
+}
 
-// export const LongFileName: Story = {
-//     args: {
-//         result: {
-//             id: 'long-filename',
-//             name: 'file',
-//             type: 'file-view',
-//             uri: URI.file('very/long/path/to/some/deeply/nested/component/with/long/name/example.ts'),
-//             title: 'very/long/path/to/some/deeply/nested/component/with/long/name/example.ts',
-//             content: 'export const Component = () => <div>Example</div>;',
-//             status: UIToolStatus.Done,
-//         } as UIFileView,
-//     },
-// }
+export const LongFileName: Story = {
+    args: {
+        result: {
+            type: 'tool-state',
+            outputType: 'file-view',
+            status: UIToolStatus.Done,
+            title: 'File View',
+            toolId: 'file',
+            toolName: 'get_file',
+            uri: URI.file('very/long/path/to/some/deeply/nested/component/with/long/name/example.ts'),
+        } as ContextItemToolState,
+    },
+}

--- a/vscode/webviews/chat/cells/toolCell/FileCell.tsx
+++ b/vscode/webviews/chat/cells/toolCell/FileCell.tsx
@@ -1,3 +1,4 @@
+import { displayPath } from '@sourcegraph/cody-shared'
 import type { ContextItemToolState } from '@sourcegraph/cody-shared/src/codebase-context/messages'
 import { FileCode } from 'lucide-react'
 import type { FC } from 'react'
@@ -29,7 +30,9 @@ export const FileCell: FC<FileCellProps> = ({
                     if (result?.uri) onFileLinkClicked(result?.uri)
                 }}
             >
-                <span className="tw-font-mono">{result.title}</span>
+                <span className="tw-font-mono">
+                    {result.uri ? displayPath(result.uri) : result.title}
+                </span>
             </Button>
         </div>
     )


### PR DESCRIPTION
This commit updates the FileCell component in the chat interface to display the file path instead of just the title. It uses the `displayPath` function from `@sourcegraph/cody-shared` to format the URI for better readability. This change improves the user experience by providing more context about the selected file.

Also fixed storybook for FileCell

## Test Plan

- Ask Cody in agent mode about something that would view a file content
- Confirm File tool / File Cell is displaying the path of the file

Storybook fix
<img width="2055" alt="image" src="https://github.com/user-attachments/assets/cc00b86b-c941-455b-b9df-c43399a219de" />
