### PR TITLE
Use current file as fallback for current selection prompt hydration

### DIFF
--- a/vscode/src/prompts/prompt-hydration.ts
+++ b/vscode/src/prompts/prompt-hydration.ts
@@ -116,9 +116,11 @@ async function hydrateWithCurrentSelection(
     initialContext: PromptHydrationInitialContext
 ): Promise<[PromptString, ContextItem[]]> {
     // Check if initial context already contains current file with selection (Cody Web case)
-    const initialContextFile = initialContext.find(item => item.type === 'file' && item.range)
+    const initialContextFile = initialContext.find(item => item.type === 'file')
 
-    const currentSelection = initialContextFile ?? (await getSelectionOrFileContext())[0]
+    const currentSelection = initialContextFile?.range
+        ? initialContextFile
+        : (await getSelectionOrFileContext())[0] ?? initialContextFile
 
     // TODO (vk): Add support for error notification if prompt hydration fails
     if (!currentSelection) {


### PR DESCRIPTION
When current selection is not available, use the whole file as context while hydrating prompt template for `cody://current-selection`

## Test plan

Execute a prompt with current selection on cody web where there is nothing selected. It should hydrate correctly and mention the current file.