### PR TITLE
Store all cody keyring secrets in a single entry

### DIFF
--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentClient.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentClient.kt
@@ -130,18 +130,19 @@ class CodyAgentClient(private val project: Project, private val webview: NativeW
 
   @JsonRequest("secrets/get")
   fun secrets_get(params: Secrets_GetParams): CompletableFuture<String?> {
-    return CompletableFuture.completedFuture(CodySecureStore.getFromSecureStore(params.key))
+    return CompletableFuture.completedFuture(
+        CodySecureStore.getInstance().getFromSecureStore(params.key))
   }
 
   @JsonRequest("secrets/store")
   fun secrets_store(params: Secrets_StoreParams): CompletableFuture<Null?> {
-    CodySecureStore.writeToSecureStore(params.key, params.value)
+    CodySecureStore.getInstance().writeToSecureStore(params.key, params.value)
     return CompletableFuture.completedFuture(null)
   }
 
   @JsonRequest("secrets/delete")
   fun secrets_delete(params: Secrets_DeleteParams): CompletableFuture<Null?> {
-    CodySecureStore.writeToSecureStore(params.key, null)
+    CodySecureStore.getInstance().writeToSecureStore(params.key, null)
     return CompletableFuture.completedFuture(null)
   }
 

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/auth/CodySecureStore.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/auth/CodySecureStore.kt
@@ -4,16 +4,88 @@ import com.intellij.credentialStore.CredentialAttributes
 import com.intellij.credentialStore.Credentials
 import com.intellij.credentialStore.generateServiceName
 import com.intellij.ide.passwordSafe.PasswordSafe
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.Service
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.security.KeyStore
+import javax.crypto.spec.SecretKeySpec
+import org.apache.commons.lang.RandomStringUtils
 
-object CodySecureStore {
-  private fun credentialAttributes(key: String): CredentialAttributes =
-      CredentialAttributes(generateServiceName("Sourcegraph", key))
+@Service(Service.Level.APP)
+class CodySecureStore {
+  private val keyStoreFile = File(System.getProperty("user.home"), ".sourcegraph/cody.keystore")
+
+  init {
+    if (!keyStoreFile.exists()) {
+      keyStoreFile.parentFile.mkdirs()
+      val password = getKeyStorePassword()
+      val keyStore = KeyStore.getInstance(KeyStore.getDefaultType())
+      keyStore.load(null, password)
+      FileOutputStream(keyStoreFile).use { fos -> keyStore.store(fos, password) }
+    }
+  }
 
   fun getFromSecureStore(key: String): String? {
-    return PasswordSafe.instance.get(credentialAttributes(key))?.getPasswordAsString()
+    val keyStore = getKeyStore()
+    if (!keyStore.containsAlias(key)) return null
+
+    val protParam = KeyStore.PasswordProtection(getKeyStorePassword())
+    val entry = keyStore.getEntry(key, protParam) as? KeyStore.SecretKeyEntry
+    return entry?.secretKey?.encoded?.toString(Charsets.UTF_8)
+        ?: CodyPasswordStore.getFromPasswordStore(key)
   }
 
   fun writeToSecureStore(key: String, value: String?) {
-    PasswordSafe.instance.set(credentialAttributes(key), Credentials(user = "", value))
+    val keyStore = getKeyStore()
+    if (value == null) {
+      keyStore.deleteEntry(key)
+    } else {
+      val secretKey = SecretKeySpec(value.toByteArray(Charsets.UTF_8), "AES")
+      val keyEntry = KeyStore.SecretKeyEntry(secretKey)
+      val protParam = KeyStore.PasswordProtection(getKeyStorePassword())
+      keyStore.setEntry(key, keyEntry, protParam)
+    }
+
+    FileOutputStream(keyStoreFile).use { fos -> keyStore.store(fos, getKeyStorePassword()) }
+  }
+
+  private fun getKeyStorePassword(): CharArray {
+    val passwordKey = "KeyStorePassword"
+    var password = CodyPasswordStore.getFromPasswordStore(passwordKey)
+
+    if (password == null) {
+      password = RandomStringUtils.randomAlphabetic(64)
+      CodyPasswordStore.writeToPasswordStore(passwordKey, password)
+    }
+
+    return password!!.toCharArray()
+  }
+
+  private fun getKeyStore(): KeyStore {
+    val keyStore = KeyStore.getInstance(KeyStore.getDefaultType())
+    FileInputStream(keyStoreFile).use { fis -> keyStore.load(fis, getKeyStorePassword()) }
+    return keyStore
+  }
+
+  private object CodyPasswordStore {
+    private fun credentialAttributes(key: String): CredentialAttributes =
+        CredentialAttributes(generateServiceName("Sourcegraph", key))
+
+    fun getFromPasswordStore(key: String): String? {
+      return PasswordSafe.instance.get(credentialAttributes(key))?.getPasswordAsString()
+    }
+
+    fun writeToPasswordStore(key: String, value: String?) {
+      PasswordSafe.instance.set(credentialAttributes(key), Credentials(user = "", value))
+    }
+  }
+
+  companion object {
+    @JvmStatic
+    fun getInstance(): CodySecureStore {
+      return ApplicationManager.getApplication().getService(CodySecureStore::class.java)
+    }
   }
 }

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/migration/AccountsMigration.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/migration/AccountsMigration.kt
@@ -9,7 +9,7 @@ object AccountsMigration {
     codyAccountManager.getAccounts().forEach { oldAccount ->
       val token = codyAccountManager.getTokenForAccount(oldAccount)
       if (token != null) {
-        CodySecureStore.writeToSecureStore(oldAccount.server.url, token)
+        CodySecureStore.getInstance().writeToSecureStore(oldAccount.server.url, token)
       }
     }
   }

--- a/jetbrains/src/main/kotlin/com/sourcegraph/config/ConfigUtil.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/config/ConfigUtil.kt
@@ -123,7 +123,7 @@ object ConfigUtil {
         }
       }
     } else {
-      val token = CodySecureStore.getFromSecureStore(endpoint.url)
+      val token = CodySecureStore.getInstance().getFromSecureStore(endpoint.url)
       if (token != null) {
         authHeaders.complete(mapOf("Authorization" to "token $token"))
       }


### PR DESCRIPTION
## Changes

This PR partially mitigates the issue where users faces multiple prompt passwords if they change the endpoints in different IDEs.
To fully solve that issue it would need to be done on the JetBrains level, as I described there: https://platform.jetbrains.com/t/group-keyring-access-for-all-ides-from-jetbrains-familly/1002

With my changes only password to Cody secret store is stored in a keyring using `PasswordSafe`, and all secrets are stored in a custom java [KeyStore](https://docs.oracle.com/javase/8/docs/api/java/security/KeyStore.html). That means password need to be typed only once per different IntelliJ executable (no matter between how many endpoints user switches).

## Test plan

**Backward compatibility test**

1. Open your keychain settings and search for `IntelliJ Platform Sourcegraph`, and then delete all entries 
![image](https://github.com/user-attachments/assets/3b39c24c-a607-4f27-9d97-e3d366735c34)
2. Open first IDE (e.g. IntelliJ Community)  with old version of Cody installed (without this changes)
3. Login to `sourcegraph.com`
4. Switch to some private instance (e.g. to sg02)
3. Open second, but different, IntelliJ IDE, e.g. Pycharm, with new version of Cody installed (with this changes)
5. IntelliJ should ask you about password to the keyring (twice!) and then log you in to your second instance
6. In the second IDE switch back to  `sourcegraph.com`
7. IntelliJ should ask you about password to the keyring AGAIN (and twice as well) and then log you in to `sourcegraph.com`

**Only new version test**
1. Open your keychain settings and search for `IntelliJ Platform Sourcegraph`, and then delete all entries 
2. Open first IDE (e.g. IntelliJ Community)  with new version of Cody installed (with this changes)
3. Login to `sourcegraph.com`
4. Switch to some private instance (e.g. to sg02)
3. Open second, but different, IntelliJ IDE, e.g. Pycharm, with new version of Cody installed (with this changes)
5. IntelliJ should ask you about password to the keyring (once!) and then log you in to your second instance
6. In the second IDE switch back to `sourcegraph.com`
7. IntelliJ should NOT ask you about any password anymore an just switch the account without any fuss
