### PR TITLE
fix(agent mode): remove dangling tool_call from assistant messages

### DIFF
--- a/vscode/src/prompt-builder/sanitize.test.ts
+++ b/vscode/src/prompt-builder/sanitize.test.ts
@@ -1,0 +1,158 @@
+import { type ChatMessage, ps } from '@sourcegraph/cody-shared'
+import { describe, expect, it } from 'vitest'
+import { sanitizedChatMessages } from './sanitize'
+
+describe('sanitizedChatMessages', () => {
+    it('should handle empty messages array', () => {
+        const messages: ChatMessage[] = []
+        const result = sanitizedChatMessages(messages)
+        expect(result).toEqual([])
+    })
+
+    it('should process messages with no content', () => {
+        const messages: ChatMessage[] = [
+            { speaker: 'human', text: ps`Hello` },
+            { speaker: 'assistant', text: ps`Hi there` },
+        ]
+        const result = sanitizedChatMessages(messages)
+        expect(result).toEqual(messages)
+    })
+
+    it('should remove tool_call from human messages', () => {
+        const messages: ChatMessage[] = [
+            {
+                speaker: 'human',
+                content: [
+                    { type: 'text', text: 'Hello' },
+                    { type: 'tool_call', tool_call: { id: '123', name: 'test', arguments: '{}' } },
+                ],
+            },
+        ]
+        const result = sanitizedChatMessages(messages)
+        expect(result[0].content).toEqual([{ type: 'text', text: 'Hello' }])
+    })
+
+    it('should remove tool_result from assistant messages', () => {
+        const messages: ChatMessage[] = [
+            {
+                speaker: 'assistant',
+                content: [
+                    { type: 'text', text: 'Hello' },
+                    { type: 'tool_result', tool_result: { id: '123', content: 'test result' } },
+                ],
+            },
+        ]
+        const result = sanitizedChatMessages(messages)
+        expect(result[0].content).toEqual([{ type: 'text', text: 'Hello' }])
+    })
+
+    it('should remove tool_call from assistant message if next human message has no tool_result', () => {
+        const messages: ChatMessage[] = [
+            {
+                speaker: 'assistant',
+                content: [
+                    { type: 'text', text: 'I can help with that' },
+                    { type: 'tool_call', tool_call: { id: '123', name: 'test', arguments: '{}' } },
+                ],
+            },
+            {
+                speaker: 'human',
+                content: [{ type: 'text', text: 'Thanks, but I changed my mind' }],
+            },
+        ]
+        const result = sanitizedChatMessages(messages)
+
+        // The tool_call should be removed from the assistant message
+        expect(result[0].content).toEqual([{ type: 'text', text: 'I can help with that' }])
+
+        // The human message should remain unchanged
+        expect(result[1].content).toEqual([{ type: 'text', text: 'Thanks, but I changed my mind' }])
+    })
+
+    it('should keep tool_call in assistant message if next human message has tool_result', () => {
+        const messages: ChatMessage[] = [
+            {
+                speaker: 'assistant',
+                content: [
+                    { type: 'text', text: 'I can help with that' },
+                    { type: 'tool_call', tool_call: { id: '123', name: 'test', arguments: '{}' } },
+                ],
+            },
+            {
+                speaker: 'human',
+                content: [
+                    { type: 'text', text: 'Here is the result' },
+                    { type: 'tool_result', tool_result: { id: '123', content: 'test result' } },
+                ],
+            },
+        ]
+        const result = sanitizedChatMessages(messages)
+
+        // The tool_call should be kept in the assistant message
+        expect(result[0].content).toEqual([
+            { type: 'text', text: 'I can help with that' },
+            { type: 'tool_call', tool_call: { id: '123', name: 'test', arguments: '{}' } },
+        ])
+
+        // The human message should have the tool_result
+        expect(result[1].content).toEqual([
+            { type: 'text', text: 'Here is the result' },
+            { type: 'tool_result', tool_result: { id: '123', content: 'test result' } },
+        ])
+    })
+
+    it('should handle multiple assistant messages with tool_calls', () => {
+        const messages: ChatMessage[] = [
+            {
+                speaker: 'assistant',
+                content: [
+                    { type: 'text', text: 'First message' },
+                    { type: 'tool_call', tool_call: { id: '123', name: 'test1', arguments: '{}' } },
+                ],
+            },
+            {
+                speaker: 'human',
+                content: [
+                    { type: 'text', text: 'First response' },
+                    { type: 'tool_result', tool_result: { id: '123', content: 'test result 1' } },
+                ],
+            },
+            {
+                speaker: 'assistant',
+                content: [
+                    { type: 'text', text: 'Second message' },
+                    { type: 'tool_call', tool_call: { id: '456', name: 'test2', arguments: '{}' } },
+                ],
+            },
+            {
+                speaker: 'human',
+                content: [{ type: 'text', text: 'No tool result this time' }],
+            },
+        ]
+        const result = sanitizedChatMessages(messages)
+
+        // First assistant message should keep its tool_call
+        expect(result[0].content).toEqual([
+            { type: 'text', text: 'First message' },
+            { type: 'tool_call', tool_call: { id: '123', name: 'test1', arguments: '{}' } },
+        ])
+
+        // Second assistant message should have its tool_call removed
+        expect(result[2].content).toEqual([{ type: 'text', text: 'Second message' }])
+    })
+
+    it('should filter out empty text parts', () => {
+        const messages: ChatMessage[] = [
+            {
+                speaker: 'assistant',
+                content: [
+                    { type: 'text', text: '' },
+                    { type: 'text', text: 'Hello' },
+                    { type: 'text', text: '' },
+                ],
+            },
+        ]
+        const result = sanitizedChatMessages(messages)
+        expect(result[0].content).toEqual([{ type: 'text', text: 'Hello' }])
+    })
+})


### PR DESCRIPTION
FIX: https://linear.app/sourcegraph/issue/CODY-5482

This commit addresses a scenario where the assistant's last message contains a `tool_call` but the subsequent human message does not have a corresponding `tool_result`. In such cases, the `tool_call` is removed from the assistant's message to prevent issues with the prompt builder.

The changes involve:

- Modifying the `sanitizedChatMessages` function to identify and remove dangling `tool_call` parts from the last assistant message if a subsequent human message lacks a `tool_result`.
- Creating a copy of the messages array to avoid mutating the original.
- Using `isDefined` to filter out undefined values after mapping.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

1. Ask Cody a question in agent mode until it runs into error, or stop the chat after a tool was used.
2. Then ask a follow up question after the stopped point
3. the chat should still go though

<img width="834" alt="image" src="https://github.com/user-attachments/assets/3384d6cf-0b87-49fa-9af0-40f4defdabeb" />
