### PR TITLE
feat(chat): Open file in active column when in sidebar view

### DIFF
--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -346,17 +346,25 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                 break
             }
             case 'openFileLink':
-                if (message?.uri?.scheme?.startsWith('http')) {
-                    this.openRemoteFile(message.uri, true)
-                    return
+                {
+                    if (message?.uri?.scheme?.startsWith('http')) {
+                        this.openRemoteFile(message.uri, true)
+                        return
+                    }
+
+                    // Determine if we're in the sidebar view
+                    const isInSidebar =
+                        this._webviewPanelOrView && !('viewColumn' in this._webviewPanelOrView)
+
+                    vscode.commands.executeCommand('vscode.open', message.uri, {
+                        selection: message.range,
+                        preserveFocus: true,
+                        background: false,
+                        preview: true,
+                        // Use the active column if in sidebar, otherwise use Beside
+                        viewColumn: isInSidebar ? vscode.ViewColumn.Active : vscode.ViewColumn.Beside,
+                    })
                 }
-                vscode.commands.executeCommand('vscode.open', message.uri, {
-                    selection: message.range,
-                    preserveFocus: true,
-                    background: false,
-                    preview: true,
-                    viewColumn: vscode.ViewColumn.Beside,
-                })
                 break
             case 'openRemoteFile':
                 this.openRemoteFile(message.uri, message.tryLocal ?? false)


### PR DESCRIPTION
Closes: [CODY-5473](https://linear.app/sourcegraph/issue/CODY-5486/when-you-click-the-file-name-it-opens-a-new-panel)

This commit modifies the `openFileLink` case in the `ChatController` to open files in the active column when the chat view is in the sidebar. Previously, files were always opened in the `Beside` column.

The change introduces a check to determine if the webview is in the sidebar. If it is, the `viewColumn` option for the `vscode.commands.executeCommand('vscode.open')` command is set to `vscode.ViewColumn.Active`. Otherwise, it defaults to `vscode.ViewColumn.Beside`.

This improves the user experience by ensuring that files opened from the chat view in the sidebar are opened in the current editor group, rather than creating a new one.

## Test Plan

1. Ask Cody a question in sidebar view with context included
2. Click on a file from the context list
3. The file should open in your active column as a new tab instead of opening a new column next to your active document

Before

<img width="2052" alt="image" src="https://github.com/user-attachments/assets/7356af76-ecd2-4b0f-976f-1106a8ab78bd" />

After

<img width="2055" alt="image" src="https://github.com/user-attachments/assets/35e47bc2-1371-4d57-98d1-8ece007643e8" />
