### PR TITLE
Consistent capitalization of 'Guardrails' in UI text

### DIFF
--- a/vscode/webviews/components/CodeBlockPlaceholder.tsx
+++ b/vscode/webviews/components/CodeBlockPlaceholder.tsx
@@ -10,7 +10,7 @@ interface CodeBlockPlaceholderProps {
 
 /**
  * CodeBlockPlaceholder shows a shimmer loading animation when code is being generated
- * or checked by guardrails.
+ * or checked by Guardrails.
  */
 export const CodeBlockPlaceholder: React.FC<CodeBlockPlaceholderProps> = ({
     text,

--- a/vscode/webviews/components/GuardrailsApplicator.tsx
+++ b/vscode/webviews/components/GuardrailsApplicator.tsx
@@ -239,7 +239,7 @@ export const GuardrailsApplicator: React.FC<GuardrailsApplicatorProps> = ({
                     className={styles.button}
                     type="button"
                     onClick={handleRetry}
-                    title="Retry guardrails check"
+                    title="Retry Guardrails check"
                 >
                     <div className={styles.iconContainer}>
                         <RefreshCwIcon size={14} />

--- a/vscode/webviews/components/GuardrailsStatus.tsx
+++ b/vscode/webviews/components/GuardrailsStatus.tsx
@@ -41,7 +41,7 @@ export const GuardrailsStatus: React.FC<GuardrailsStatusProps> = ({
             {status === GuardrailsCheckStatus.Checking && (
                 <div className={styles.status}>
                     <LoaderIcon className={clsx('tw-animate-spin', styles.iconContainer)} size={14} />
-                    <span className={styles.fileNameContainer}>Checking guardrails</span>
+                    <span className={styles.fileNameContainer}>Checking Guardrails</span>
                 </div>
             )}
             {status === GuardrailsCheckStatus.Success && (
@@ -92,7 +92,7 @@ export const GuardrailsStatus: React.FC<GuardrailsStatusProps> = ({
                             onClick={onRetry}
                             type="button"
                             className={styles.button}
-                            title="Retry guardrails check"
+                            title="Retry Guardrails check"
                         >
                             <div className={styles.iconContainer}>
                                 <RefreshCwIcon size={12} />


### PR DESCRIPTION
## Summary
- Update capitalization of 'Guardrails' to be consistent throughout the UI text
- Applied to status messages, tooltips, and documentation comments

## Test plan
- Verify all UI text now uses 'Guardrails' with proper capitalization
- Confirm changes in GuardrailsStatus.tsx, GuardrailsApplicator.tsx, and CodeBlockPlaceholder.tsx