### PR TITLE
feat(agent mode): Display modified lines count in DiffCell 

### DIFF
--- a/vscode/webviews/chat/cells/toolCell/DiffCell.tsx
+++ b/vscode/webviews/chat/cells/toolCell/DiffCell.tsx
@@ -49,15 +49,21 @@ export const DiffCell: FC<DiffCellProps> = ({
                 <span className="tw-font-mono">{fileName}</span>
             </Button>
             <div className="tw-ml-2 tw-flex tw-flex-shrink-0 tw-items-center tw-gap-2">
-                <span className="tw-flex tw-items-center tw-text-emerald-500">
-                    <Plus size={14} className="tw-mr-0.5" /> {result.total.added}
-                </span>
-                <span className="tw-flex tw-items-center tw-text-orange-500">
-                    <DiffIcon size={14} className="tw-mr-0.5" /> {result.total.modified}
-                </span>
-                <span className="tw-flex tw-items-center tw-text-rose-500">
-                    <Minus size={14} className="tw-mr-0.5" /> {result.total.removed}
-                </span>
+                {result.total.added > 0 && (
+                    <span className="tw-flex tw-items-center tw-text-emerald-500">
+                        <Plus size={14} className="tw-mr-0.5" /> {result.total.added}
+                    </span>
+                )}
+                {result.total.modified > 0 && (
+                    <span className="tw-flex tw-items-center tw-text-orange-500">
+                        <DiffIcon size={14} className="tw-mr-0.5" /> {result.total.modified}
+                    </span>
+                )}
+                {result.total.removed > 0 && (
+                    <span className="tw-flex tw-items-center tw-text-rose-500">
+                        <Minus size={14} className="tw-mr-0.5" /> {result.total.removed}
+                    </span>
+                )}
             </div>
         </div>
     )

--- a/vscode/webviews/chat/cells/toolCell/DiffCell.tsx
+++ b/vscode/webviews/chat/cells/toolCell/DiffCell.tsx
@@ -1,6 +1,6 @@
 import { displayPath } from '@sourcegraph/cody-shared'
 import type { ContextItemToolState } from '@sourcegraph/cody-shared/src/codebase-context/messages'
-import { GitCompare, Minus, Plus } from 'lucide-react'
+import { DiffIcon, GitCompare, Minus, Plus } from 'lucide-react'
 import { type FC, useMemo } from 'react'
 import type { URI } from 'vscode-uri'
 import { getFileDiff } from '../../../../src/chat/chat-view/utils/diff'
@@ -50,10 +50,13 @@ export const DiffCell: FC<DiffCellProps> = ({
             </Button>
             <div className="tw-ml-2 tw-flex tw-flex-shrink-0 tw-items-center tw-gap-2">
                 <span className="tw-flex tw-items-center tw-text-emerald-500">
-                    <Plus size={14} className="tw-mr-0.5" /> {result.total.added + 1}
+                    <Plus size={14} className="tw-mr-0.5" /> {result.total.added}
+                </span>
+                <span className="tw-flex tw-items-center tw-text-orange-500">
+                    <DiffIcon size={14} className="tw-mr-0.5" /> {result.total.modified}
                 </span>
                 <span className="tw-flex tw-items-center tw-text-rose-500">
-                    <Minus size={14} className="tw-mr-0.5" /> {result.total.removed + 1}
+                    <Minus size={14} className="tw-mr-0.5" /> {result.total.removed}
                 </span>
             </div>
         </div>


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-5472

We were seeing the numbers of diff were off by 1, but the root cause is because those lines were counted toward modified lines instead of add / remove. This PR adds the modified line numbers for display.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

After

Display total number of modified lines

<img width="682" alt="Screenshot 2025-03-24 at 6 53 27 PM" src="https://github.com/user-attachments/assets/b214dce0-7130-4db1-8a33-11dd6a2bc4d3" />

Before

Only added & removed line numbers are displayed

<img width="772" alt="image" src="https://github.com/user-attachments/assets/446aa542-0e2a-4651-adaa-337a9f42a646" />
