### PR TITLE
feat(auto-edit): Change the identifier from experimental to beta

### DIFF
--- a/agent/src/autoedit.test.ts
+++ b/agent/src/autoedit.test.ts
@@ -1,4 +1,5 @@
 import path from 'node:path'
+import { CodyAutoSuggestionMode } from '@sourcegraph/cody-shared'
 import { toMatchImageSnapshot } from 'jest-image-snapshot'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import type * as vscode from 'vscode'
@@ -19,7 +20,7 @@ expect.extend({ toMatchImageSnapshot })
 describe('Autoedit', () => {
     const workspace = new TestWorkspace(path.join(__dirname, '__tests__', 'autoedit'))
     const clientConfiguration: Partial<ExtensionConfiguration> = {
-        suggestionsMode: 'auto-edit (Experimental)',
+        suggestionsMode: CodyAutoSuggestionMode.Autoedit,
     }
 
     beforeAll(async () => {

--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -224,7 +224,7 @@ export enum CodyAutoSuggestionMode {
     /**
      * The suggestion mode where suggestions come from the Cody AI agent chat API.
      */
-    Autoedit = 'auto-edit (Experimental)',
+    Autoedit = 'auto-edit (Beta)',
     /**
      * Disable Cody suggestions altogether.
      */

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -589,7 +589,7 @@
       {
         "command": "cody.command.autoedit-manual-trigger",
         "title": "Autoedits Manual Trigger",
-        "enablement": "cody.activated && config.cody.suggestions.mode == 'auto-edit (Experimental)'"
+        "enablement": "cody.activated && config.cody.suggestions.mode == 'auto-edit (Beta)'"
       },
       {
         "command": "cody.command.autoedit.open-debug-panel",
@@ -714,7 +714,7 @@
       {
         "command": "cody.supersuggest.testExample",
         "key": "ctrl+alt+enter",
-        "when": "cody.activated && config.cody.suggestions.mode == 'auto-edit (Experimental)'"
+        "when": "cody.activated && config.cody.suggestions.mode == 'auto-edit (Beta)'"
       }
     ],
     "submenus": [
@@ -957,7 +957,7 @@
         },
         "cody.suggestions.mode": {
           "type": "string",
-          "enum": ["autocomplete", "auto-edit (Experimental)", "off"],
+          "enum": ["autocomplete", "auto-edit (Beta)", "off"],
           "enumDescriptions": [
             "Suggests standard code completions as you type.",
             "Suggests advanced context-aware code edits as you navigate the codebase. Experimental feature for Pro and Enterprise users.",

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -54,9 +54,9 @@ export function getConfiguration(
 
     // Backward compatibility with the older auto-edit config name.
     // If auto-edit was turned on - override the suggestion mode to "auto-edit".
-    // TODO: clean up after the experimental release
+    // TODO: clean up after the beta release
     // https://linear.app/sourcegraph/issue/CODY-4701/clean-up-backwards-compatbility-settings-after-the-release
-    if (codyAutoSuggestionsMode === 'auto-edits (Experimental)') {
+    if (codyAutoSuggestionsMode === 'auto-edit (Experimental)') {
         codyAutoSuggestionsMode = CodyAutoSuggestionMode.Autoedit
 
         void vscode.workspace

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -628,7 +628,7 @@ export interface ExtensionConfiguration {
 
     autocompleteAdvancedProvider?: string | undefined | null
     autocompleteAdvancedModel?: string | undefined | null
-    suggestionsMode?: 'autocomplete' | 'auto-edit (Experimental)' | 'off' | undefined | null
+    suggestionsMode?: 'autocomplete' | 'auto-edit (Beta)' | 'off' | undefined | null
     debug?: boolean | undefined | null
     verboseDebug?: boolean | undefined | null
     telemetryClientName?: string | undefined | null

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -781,7 +781,7 @@ interface StatusBarLoader {
 
 enum CodyStatusBarSuggestionModeLabels {
     Autocomplete = 'Autocomplete',
-    AutoEdit = 'Auto-edit (experimental)',
+    AutoEdit = 'Auto-edit (Beta)',
     Disabled = 'Disabled',
 }
 


### PR DESCRIPTION
Change the identifier from experimental to beta. Also added backward compatibility for the setting.

![CleanShot 2025-03-25 at 8  01 54@2x](https://github.com/user-attachments/assets/34c6a50b-8591-4c7e-804e-a59d5a7f5136)

![CleanShot 2025-03-25 at 8  02 04@2x](https://github.com/user-attachments/assets/b3019d0f-81e4-4304-8780-6caab613190e)

![CleanShot 2025-03-25 at 8  02 13@2x](https://github.com/user-attachments/assets/96bece03-2b6c-4858-b48e-d50755323c19)


## Test plan
Start in debug mode and ensure `auto-edit` works and have "beta" in the setting
