### PR TITLE
fix(agent mode): Include initial context in conversation loop

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/Constants.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/Constants.kt
@@ -19,7 +19,7 @@ object Constants {
   const val ask = "ask"
   const val assistant = "assistant"
   const val authenticated = "authenticated"
-  const val `auto-edit-Experimental` = "auto-edit (Experimental)"
+  const val `auto-edit-Beta` = "auto-edit (Beta)"
   const val autocomplete = "autocomplete"
   const val balanced = "balanced"
   const val byok = "byok"

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/ExtensionConfiguration.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/ExtensionConfiguration.kt
@@ -11,7 +11,7 @@ data class ExtensionConfiguration(
   val anonymousUserID: String? = null,
   val autocompleteAdvancedProvider: String? = null,
   val autocompleteAdvancedModel: String? = null,
-  val suggestionsMode: SuggestionsModeEnum? = null, // Oneof: autocomplete, auto-edit (Experimental), off
+  val suggestionsMode: SuggestionsModeEnum? = null, // Oneof: autocomplete, auto-edit (Beta), off
   val debug: Boolean? = null,
   val verboseDebug: Boolean? = null,
   val telemetryClientName: String? = null,
@@ -23,7 +23,7 @@ data class ExtensionConfiguration(
 
   enum class SuggestionsModeEnum {
     @SerializedName("autocomplete") Autocomplete,
-    @SerializedName("auto-edit (Experimental)") `Auto-edit-Experimental`,
+    @SerializedName("auto-edit (Beta)") `Auto-edit-Beta`,
     @SerializedName("off") Off,
   }
 }

--- a/vscode/src/chat/chat-view/handlers/AgenticHandler.test.ts
+++ b/vscode/src/chat/chat-view/handlers/AgenticHandler.test.ts
@@ -26,8 +26,8 @@ vi.mock('../prompts', () => ({
 describe('AgenticHandler', () => {
     // Mock dependencies
     const mockContextRetriever = {
-        retrieveContext: vi.fn(),
-        computeDidYouMean: vi.fn(),
+        retrieveContext: vi.fn().mockResolvedValue([]),
+        computeDidYouMean: vi.fn().mockResolvedValue(undefined),
     }
 
     const mockEditor = {} as any
@@ -130,7 +130,8 @@ describe('AgenticHandler', () => {
             mockDelegate,
             mockRecorder,
             mockSpan,
-            abortController.signal
+            abortController.signal,
+            expect.any(Array) // contextItems
         )
 
         // Verify delegate.postDone was called

--- a/vscode/src/chat/chat-view/tools/file.ts
+++ b/vscode/src/chat/chat-view/tools/file.ts
@@ -59,7 +59,7 @@ function createFileToolState(
         outputType: 'file-view',
 
         // ContextItemCommon properties
-        uri: uri || URI.parse(`cody:/tools/file/${toolId}`),
+        uri: uri || URI.parse(`cody:///tools/file?error=${filePath}`),
         content,
         title: filePath,
         description: `File: ${filePath}`,

--- a/vscode/src/chat/chat-view/tools/shell.ts
+++ b/vscode/src/chat/chat-view/tools/shell.ts
@@ -61,28 +61,23 @@ export const shellTool: AgentTool = {
             return createShellToolState(validInput.command, content, UIToolStatus.Done, error)
         } catch (error) {
             if (error instanceof CommandError) {
-                if (error instanceof CommandError) {
-                    // Format the error output as an array of TerminalLine objects
-                    const lines: UITerminalLine[] = [
-                        { content: validInput.command, type: UITerminalOutputType.Input },
-                        {
-                            content: `Exited with code ${error.result.code}`,
-                            type: UITerminalOutputType.Error,
-                        },
-                        ...formatOutputToTerminalLines(error.result.stdout, UITerminalOutputType.Output),
-                        ...formatOutputToTerminalLines(error.result.stderr, UITerminalOutputType.Error),
-                    ].filter(line => line.content.trim() !== '')
-                    const content = lines.join('\n')
+                // Format the error output as an array of TerminalLine objects
+                const lines: UITerminalLine[] = [
+                    { content: validInput.command, type: UITerminalOutputType.Input },
+                    {
+                        content: `Exited with code ${error.result.code}`,
+                        type: UITerminalOutputType.Error,
+                    },
+                    ...formatOutputToTerminalLines(error.result.stdout, UITerminalOutputType.Output),
+                    ...formatOutputToTerminalLines(error.result.stderr, UITerminalOutputType.Error),
+                ].filter(line => line.content.trim() !== '')
 
-                    return createShellToolState(validInput.command, content, UIToolStatus.Error)
-                }
+                // Extract just the content from each line object
+                const contentString = lines.map(line => line.content).join('\n')
 
-                return createShellToolState(
-                    validInput.command,
-                    `Failed to run terminal command: ${validInput.command}: ${error}`,
-                    UIToolStatus.Error
-                )
+                return createShellToolState(validInput.command, contentString, UIToolStatus.Error)
             }
+
             throw new Error(`Failed to run terminal command: ${input.command}: ${error}`)
         }
     },

--- a/vscode/webviews/chat/cells/toolCell/DiffCell.tsx
+++ b/vscode/webviews/chat/cells/toolCell/DiffCell.tsx
@@ -39,7 +39,7 @@ export const DiffCell: FC<DiffCellProps> = ({
         <div className="tw-flex tw-items-center tw-gap-2 tw-overflow-hidden">
             <Button
                 variant="ghost"
-                className="tw-text-left tw-truncate tw-flex tw-items-center tw-gap-2 tw-overflow-hidden tw-p-0"
+                className="tw-text-left tw-truncate tw-flex tw-items-center tw-gap-2 tw-overflow-hidden tw-p-0 hover:tw-bg-transparent"
                 onClick={e => {
                     e.preventDefault()
                     e.stopPropagation()

--- a/vscode/webviews/chat/cells/toolCell/FileCell.tsx
+++ b/vscode/webviews/chat/cells/toolCell/FileCell.tsx
@@ -1,6 +1,6 @@
-import { displayPath } from '@sourcegraph/cody-shared'
+import { UIToolStatus, displayPath } from '@sourcegraph/cody-shared'
 import type { ContextItemToolState } from '@sourcegraph/cody-shared/src/codebase-context/messages'
-import { FileCode } from 'lucide-react'
+import { FileCode, FileX } from 'lucide-react'
 import type { FC } from 'react'
 import type { URI } from 'vscode-uri'
 import { Button } from '../../../components/shadcn/ui/button'
@@ -27,11 +27,12 @@ export const FileCell: FC<FileCellProps> = ({
                 onClick={e => {
                     e.preventDefault()
                     e.stopPropagation()
-                    if (result?.uri) onFileLinkClicked(result?.uri)
+                    if (result?.uri && result?.status !== UIToolStatus.Error)
+                        onFileLinkClicked(result?.uri)
                 }}
             >
                 <span className="tw-font-mono">
-                    {result.uri ? displayPath(result.uri) : result.title}
+                    {!UIToolStatus.Error && result.uri ? displayPath(result.uri) : result.title}
                 </span>
             </Button>
         </div>
@@ -39,11 +40,11 @@ export const FileCell: FC<FileCellProps> = ({
 
     return (
         <BaseCell
-            icon={FileCode}
+            icon={UIToolStatus.Error ? FileX : FileCode}
             headerContent={renderHeaderContent()}
             bodyContent={undefined}
             className={className}
-            defaultOpen={false} // Always closed since there's no content to show
+            defaultOpen={defaultOpen} // Always closed since there's no content to show
         />
     )
 }

--- a/vscode/webviews/chat/cells/toolCell/FileCell.tsx
+++ b/vscode/webviews/chat/cells/toolCell/FileCell.tsx
@@ -23,7 +23,7 @@ export const FileCell: FC<FileCellProps> = ({
         <div className="tw-flex tw-items-center tw-gap-2 tw-overflow-hidden tw-flex-row">
             <Button
                 variant="ghost"
-                className="tw-flex tw-items-center tw-gap-2 tw-overflow-hidden tw-p-0 tw-text-left tw-truncate tw-w-full"
+                className="tw-flex tw-items-center tw-gap-2 tw-overflow-hidden tw-p-0 tw-text-left tw-truncate tw-w-full hover:tw-bg-transparent"
                 onClick={e => {
                     e.preventDefault()
                     e.stopPropagation()

--- a/vscode/webviews/chat/cells/toolCell/TerminalOutputCell.tsx
+++ b/vscode/webviews/chat/cells/toolCell/TerminalOutputCell.tsx
@@ -2,6 +2,7 @@ import { type UITerminalLine, UITerminalOutputType, UIToolStatus } from '@source
 import type { ContextItemToolState } from '@sourcegraph/cody-shared/src/codebase-context/messages'
 import { Bug, BugOff, Terminal } from 'lucide-react'
 import { type FC, useMemo } from 'react'
+import { Button } from '../../../components/shadcn/ui/button'
 import { Skeleton } from '../../../components/shadcn/ui/skeleton'
 import { cn } from '../../../components/shadcn/utils'
 import { BaseCell } from './BaseCell'
@@ -85,7 +86,7 @@ export const TerminalOutputCell: FC<TerminalOutputCellProps> = ({
             return convertToTerminalLines(item.title ?? 'Terminal', item.content)
         }
         return []
-    }, [item.title, item?.content])
+    }, [item?.title, item?.content])
 
     const renderHeaderContent = () => {
         if (isLoading && item?.title) {
@@ -98,9 +99,12 @@ export const TerminalOutputCell: FC<TerminalOutputCellProps> = ({
 
         return (
             <div className="tw-flex tw-items-center tw-gap-2 tw-overflow-hidden">
-                <code className="tw-text-left tw-truncate tw-font-mono tw-bg-zinc-800 tw-px-2 tw-py-0.5 tw-rounded tw-text-zinc-200">
-                    $ {lines[0]?.content}
-                </code>
+                <Button
+                    variant="ghost"
+                    className="tw-text-left tw-truncate tw-flex tw-items-center tw-gap-2 tw-overflow-hidden tw-p-0 hover:tw-bg-transparent"
+                >
+                    <span className="tw-font-mono">$ {lines[0]?.content}</span>
+                </Button>
             </div>
         )
     }


### PR DESCRIPTION
FIX https://linear.app/sourcegraph/issue/CODY-5494

    This commit modifies the `AgenticHandler` to include the initial context provided by the user in the conversation loop.

    The initial context is computed using `this.computeContext` and passed to the `runConversationLoop` function. This ensures that the agent has access to the user's initial input and any mentioned context items throughout the conversation.

    Additionally, the context is reset after each turn to prevent it from accumulating and potentially influencing subsequent turns in unintended ways. A debug log was added to catch errors when executing tools.

    This is the same implementation we are using for regular chat in ChatHandler.

## Test Plan

    1. Ask Cody a question in agent mode and at mention an image
    2. The agent should be able to answer you question about your image

After

<img width="680" alt="image" src="https://github.com/user-attachments/assets/24de011e-2915-4bc3-a158-c506671cc0bb" />

Before

<img width="678" alt="image" src="https://github.com/user-attachments/assets/08b1e308-d244-4d82-891d-6b4b0acbe4f2" />

