### PR TITLE
[JetBrains] Run agent once per test class

### DIFF
--- a/jetbrains/build.gradle.kts
+++ b/jetbrains/build.gradle.kts
@@ -166,6 +166,7 @@ spotless {
     trimTrailingWhitespace()
     target("src/**/*.kt")
     targetExclude("src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/**")
+    targetExclude("src/integrationTest/resources/testProjects/**")
     toggleOffOn()
   }
 }

--- a/jetbrains/build.gradle.kts
+++ b/jetbrains/build.gradle.kts
@@ -165,8 +165,9 @@ spotless {
     ktfmt()
     trimTrailingWhitespace()
     target("src/**/*.kt")
-    targetExclude("src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/**")
-    targetExclude("src/integrationTest/resources/testProjects/**")
+    targetExclude(
+        "src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/**",
+        "src/integrationTest/resources/testProjects/**")
     toggleOffOn()
   }
 }

--- a/jetbrains/build.gradle.kts
+++ b/jetbrains/build.gradle.kts
@@ -328,7 +328,6 @@ fun Test.sharedIntegrationTestConfig(buildCodyDir: File, mode: String) {
 
   environment(
       "CODY_RECORDING_MODE" to mode,
-      "CODY_RECORDING_NAME" to "integration-test",
       "CODY_RECORDING_DIRECTORY" to resourcesDir.resolve("recordings").absolutePath,
       "CODY_SHIM_TESTING" to "true",
       "CODY_TEMPERATURE_ZERO" to "true",

--- a/jetbrains/src/integrationTest/kotlin/com/sourcegraph/cody/edit/DocumentCodeTest.kt
+++ b/jetbrains/src/integrationTest/kotlin/com/sourcegraph/cody/edit/DocumentCodeTest.kt
@@ -1,6 +1,8 @@
 package com.sourcegraph.cody.edit
 
+import com.intellij.openapi.command.WriteCommandAction
 import com.sourcegraph.cody.edit.actions.DocumentCodeAction
+import com.sourcegraph.cody.edit.lenses.LensesService
 import com.sourcegraph.cody.edit.lenses.actions.EditAcceptAction
 import com.sourcegraph.cody.edit.lenses.actions.EditCancelAction
 import com.sourcegraph.cody.edit.lenses.actions.EditUndoAction
@@ -8,21 +10,50 @@ import com.sourcegraph.cody.edit.lenses.providers.EditAcceptCodeVisionProvider
 import com.sourcegraph.cody.edit.lenses.providers.EditCancelCodeVisionProvider
 import com.sourcegraph.cody.edit.lenses.providers.EditUndoCodeVisionProvider
 import com.sourcegraph.cody.edit.lenses.providers.EditWorkingCodeVisionProvider
-import com.sourcegraph.cody.util.CodyIntegrationTextFixture
 import com.sourcegraph.cody.util.CustomJunitClassRunner
+import com.sourcegraph.cody.util.EditCodeFixture
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.containsString
+import org.junit.After
+import org.junit.AfterClass
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(CustomJunitClassRunner::class)
-class DocumentCodeTest : CodyIntegrationTextFixture() {
+class DocumentCodeTest {
+
+  companion object {
+    val fixture = EditCodeFixture()
+
+    @JvmStatic
+    @AfterClass
+    fun shutdown() {
+      fixture.shutdown()
+    }
+  }
+
+  @Before
+  fun setUp() {
+    fixture.openFile(relativeFilePath = "documentCode/src/main/java/Foo.java")
+    LensesService.getInstance(fixture.project).addListener(fixture)
+  }
+
+  @After
+  fun tearDown() {
+    LensesService.getInstance(fixture.project).removeListener(fixture)
+    WriteCommandAction.runWriteCommandAction(fixture.project) { fixture.file.delete(this) }
+  }
 
   @Ignore
   @Test
   fun testGetsWorkingGroupLens() {
-    val codeLenses = runAndWaitForLenses(DocumentCodeAction.ID, EditCancelAction.ID)
+    val codeLenses = fixture.runAndWaitForLenses(DocumentCodeAction.ID, EditCancelAction.ID)
 
     assertEquals("There are 2 lenses expected, working lens and cancel lens", 2, codeLenses.size)
     // Lens group should match the expected structure.
@@ -37,14 +68,14 @@ class DocumentCodeTest : CodyIntegrationTextFixture() {
 
     // We could try to Cancel the action, but there is no guarantee we can do it before edit will
     // finish. It is safer to just wait for edit to finish and then undo it.
-    waitForSuccessfulEdit()
+    fixture.waitForSuccessfulEdit()
 
-    runAndWaitForCleanState(EditUndoAction.ID)
+    fixture.runAndWaitForCleanState(EditUndoAction.ID)
   }
 
   @Test
   fun testShowsAcceptLens() {
-    val codeLenses = runAndWaitForLenses(DocumentCodeAction.ID, EditAcceptAction.ID)
+    val codeLenses = fixture.runAndWaitForLenses(DocumentCodeAction.ID, EditAcceptAction.ID)
     assertNotNull("Lens group should be displayed", codeLenses.isNotEmpty())
 
     assertEquals("Lens group should have 2 lenses", 2, codeLenses.size)
@@ -58,28 +89,31 @@ class DocumentCodeTest : CodyIntegrationTextFixture() {
         EditUndoCodeVisionProvider.command)
 
     // Make sure a doc comment was inserted.
-    assertTrue(hasJavadocComment(editor.document.text))
+    assertTrue(fixture.hasJavadocComment(getEditorDocumentText()))
 
-    runAndWaitForCleanState(EditUndoAction.ID)
+    fixture.runAndWaitForCleanState(EditUndoAction.ID)
   }
 
   @Test
   fun testAccept() {
-    val codeLenses = runAndWaitForLenses(DocumentCodeAction.ID, EditAcceptAction.ID)
+    val codeLenses = fixture.runAndWaitForLenses(DocumentCodeAction.ID, EditAcceptAction.ID)
     assertNotNull("Lens group should be displayed", codeLenses.isNotEmpty())
 
-    runAndWaitForCleanState(EditAcceptAction.ID)
-    assertThat(editor.document.text, containsString("*/\n    public void foo() {"))
+    fixture.runAndWaitForCleanState(EditAcceptAction.ID)
+    assertThat(getEditorDocumentText(), containsString("*/\n    public void foo() {"))
   }
 
   @Test
   fun testUndo() {
-    val originalDocument = editor.document.text
-    val codeLenses = runAndWaitForLenses(DocumentCodeAction.ID, EditUndoAction.ID)
+    val originalDocument = getEditorDocumentText()
+    val codeLenses = fixture.runAndWaitForLenses(DocumentCodeAction.ID, EditUndoAction.ID)
     assertNotNull("Lens group should be displayed", codeLenses.isNotEmpty())
-    assertNotSame("Expected document to be changed", originalDocument, editor.document.text)
+    assertNotSame("Expected document to be changed", originalDocument, getEditorDocumentText())
 
-    runAndWaitForCleanState(EditUndoAction.ID)
-    assertEquals("Expected document changes to be reverted", originalDocument, editor.document.text)
+    fixture.runAndWaitForCleanState(EditUndoAction.ID)
+    assertEquals(
+        "Expected document changes to be reverted", originalDocument, getEditorDocumentText())
   }
+
+  private fun getEditorDocumentText() = fixture.editor.document.text
 }

--- a/jetbrains/src/integrationTest/kotlin/com/sourcegraph/cody/edit/DocumentCodeTest.kt
+++ b/jetbrains/src/integrationTest/kotlin/com/sourcegraph/cody/edit/DocumentCodeTest.kt
@@ -29,7 +29,7 @@ import org.junit.runner.RunWith
 class DocumentCodeTest {
 
   companion object {
-    val fixture = EditCodeFixture()
+    val fixture = EditCodeFixture("documentCode")
 
     @JvmStatic
     @AfterClass

--- a/jetbrains/src/integrationTest/kotlin/com/sourcegraph/cody/util/BaseIntegrationTextFixture.kt
+++ b/jetbrains/src/integrationTest/kotlin/com/sourcegraph/cody/util/BaseIntegrationTextFixture.kt
@@ -28,7 +28,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 
-abstract class BaseIntegrationTextFixture {
+open class BaseIntegrationTextFixture(private val recordingName: String) {
   private val logger = Logger.getInstance(BaseIntegrationTextFixture::class.java)
 
   // We don't want to use .!! or .? everywhere in the tests,
@@ -118,6 +118,8 @@ abstract class BaseIntegrationTextFixture {
     val endpoint = SourcegraphServerPath.from(credentials.serverEndpoint, "")
     val token = credentials.token ?: credentials.redactedToken
 
+    System.setProperty("CODY_RECORDING_NAME", recordingName)
+
     assertNotNull(
         "Unable to start agent in a timely fashion!",
         CodyAgentService.getInstance(project)
@@ -148,7 +150,7 @@ abstract class BaseIntegrationTextFixture {
     assertFalse("Project should not be in LightEdit mode", isLightEditMode)
   }
 
-  abstract fun checkInitialConditionsForOpenFile()
+  open fun checkInitialConditionsForOpenFile() {}
 
   private fun isAuthenticated() {
     val authenticated = CompletableFuture<Boolean>()
@@ -205,7 +207,7 @@ abstract class BaseIntegrationTextFixture {
     }
   }
 
-  protected fun triggerAction(actionId: String) {
+  fun triggerAction(actionId: String) {
     runInEdtAndWait {
       PlatformTestUtil.dispatchAllEventsInIdeEventQueue()
       EditorTestUtil.executeAction(editor, actionId)

--- a/jetbrains/src/integrationTest/kotlin/com/sourcegraph/cody/util/BaseIntegrationTextFixture.kt
+++ b/jetbrains/src/integrationTest/kotlin/com/sourcegraph/cody/util/BaseIntegrationTextFixture.kt
@@ -1,100 +1,94 @@
 package com.sourcegraph.cody.util
 
 import com.intellij.ide.lightEdit.LightEdit
-import com.intellij.openapi.actionSystem.ActionManager
-import com.intellij.openapi.actionSystem.AnActionEvent
-import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Editor
-import com.intellij.openapi.editor.ex.EditorEx
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.OpenFileDescriptor
 import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.testFramework.EditorTestUtil
 import com.intellij.testFramework.PlatformTestUtil
-import com.intellij.testFramework.UsefulTestCase
 import com.intellij.testFramework.fixtures.HeavyIdeaTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
 import com.intellij.testFramework.runInEdtAndWait
 import com.sourcegraph.cody.agent.CodyAgentService
 import com.sourcegraph.cody.agent.protocol_generated.ProtocolAuthenticatedAuthStatus
-import com.sourcegraph.cody.agent.protocol_generated.ProtocolCodeLens
 import com.sourcegraph.cody.auth.SourcegraphServerPath
-import com.sourcegraph.cody.edit.lenses.LensListener
-import com.sourcegraph.cody.edit.lenses.LensesService
-import com.sourcegraph.cody.edit.lenses.providers.EditAcceptCodeVisionProvider
 import java.io.File
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 import java.util.regex.Pattern
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 
-open class CodyIntegrationTextFixture : UsefulTestCase(), LensListener {
-  private val logger = Logger.getInstance(CodyIntegrationTextFixture::class.java)
-  private val lensSubscribers = mutableListOf<(List<ProtocolCodeLens>) -> Boolean>()
+abstract class BaseIntegrationTextFixture {
+  private val logger = Logger.getInstance(BaseIntegrationTextFixture::class.java)
 
   // We don't want to use .!! or .? everywhere in the tests,
   // and if those won't be initialized test should crash anyway
   lateinit var editor: Editor
-  private lateinit var file: VirtualFile
-  private lateinit var myProject: Project
-  private lateinit var myFixture: HeavyIdeaTestFixture
+  lateinit var file: VirtualFile
+  val project: Project
 
-  override fun setUp() {
-    super.setUp()
+  protected val myFixture: HeavyIdeaTestFixture
 
-    val projectBuilder = IdeaTestFixtureFactory.getFixtureFactory().createFixtureBuilder(name)
+  init {
+    val projectBuilder =
+        IdeaTestFixtureFactory.getFixtureFactory().createFixtureBuilder(this::class.java.name)
 
     myFixture = projectBuilder.fixture as HeavyIdeaTestFixture
     myFixture.setUp()
-    myProject = myFixture.project
+    project = myFixture.project
+    Disposer.register(myFixture.testRootDisposable) { shutdown() }
 
+    initCredentialsAndAgent()
+    baseCheckInitialConditions()
+  }
+
+  fun openFile(relativeFilePath: String) {
     val testDataPath = System.getProperty("test.resources.dir")
-    val relativeFilePath = "src/main/java/Foo.java"
-    val sourceFile = "$testDataPath/testProjects/documentCode/$relativeFilePath"
-    val basePath = myProject.basePath!!
-
-    WriteCommandAction.runWriteCommandAction(myProject) {
+    val sourceFile = "$testDataPath/testProjects/$relativeFilePath"
+    val basePath = project.basePath!!
+    WriteCommandAction.runWriteCommandAction(project) {
       file =
           myFixture
               .addFileToProject(basePath, relativeFilePath, File(sourceFile).readText())
               ?.virtualFile!!
 
       editor =
-          FileEditorManager.getInstance(myProject)
-              .openTextEditor(OpenFileDescriptor(myProject, file), true)!!
+          FileEditorManager.getInstance(project)
+              .openTextEditor(OpenFileDescriptor(project, file), true)!!
     }
 
-    initCredentialsAndAgent()
     initCaretPosition()
+    checkInitialConditionsForOpenFile()
+  }
 
+  private fun awaitPendingPromises() {
     val done = CompletableFuture<Void>()
-    CodyAgentService.withAgent(myProject) { agent ->
+    CodyAgentService.withAgent(project) { agent ->
       agent.server.testing_awaitPendingPromises(null).thenAccept { done.complete(null) }
     }
     done.get(ASYNC_WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-
-    checkInitialConditions()
-    LensesService.getInstance(myProject).addListener(this)
   }
 
-  override fun tearDown() {
-    try {
-      LensesService.getInstance(myProject).removeListener(this)
-
-      val recordingsFuture = CompletableFuture<Void>()
-      CodyAgentService.withAgent(myProject) { agent ->
-        val errors = agent.server.testing_requestErrors(null).get()
-        // We extract polly.js errors to notify users about the missing recordings, if any
-        val missingRecordings =
-            errors.errors.filter { it.error?.contains("`recordIfMissing` is") == true }
-        missingRecordings.forEach { missing ->
-          logger.error(
-              """Recording is missing: ${missing.error}
+  fun shutdown() {
+    val recordingsFuture = CompletableFuture<Void>()
+    CodyAgentService.withAgent(project) { agent ->
+      val errors = agent.server.testing_requestErrors(null).get()
+      // We extract polly.js errors to notify users about the missing recordings, if any
+      val missingRecordings =
+          errors.errors.filter { it.error?.contains("`recordIfMissing` is") == true }
+      missingRecordings.forEach { missing ->
+        logger.error(
+            """Recording is missing: ${missing.error}
                 |
                 |${missing.body}
                 |
@@ -104,18 +98,15 @@ open class CodyIntegrationTextFixture : UsefulTestCase(), LensListener {
                 |`agent/scripts/export-cody-http-recording-tokens.sh`
                 |------------------------------------------------------------------------------------------
               """
-                  .trimMargin())
-        }
-        recordingsFuture.complete(null)
+                .trimMargin())
       }
-      recordingsFuture.get(ASYNC_WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-      CodyAgentService.getInstance(myProject)
-          .stopAgent()
-          ?.get(ASYNC_WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-      CodyAgentService.getInstance(myProject).dispose()
-    } finally {
-      super.tearDown()
+      recordingsFuture.complete(null)
     }
+    recordingsFuture.get(ASYNC_WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+    CodyAgentService.getInstance(project)
+        .stopAgent()
+        ?.get(ASYNC_WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+    CodyAgentService.getInstance(project).dispose()
   }
 
   // Ideally we should call this method only once per recording session, but since we need a
@@ -129,13 +120,14 @@ open class CodyIntegrationTextFixture : UsefulTestCase(), LensListener {
 
     assertNotNull(
         "Unable to start agent in a timely fashion!",
-        CodyAgentService.getInstance(myProject)
+        CodyAgentService.getInstance(project)
             .startAgent(endpoint, token)
             .completeOnTimeout(null, ASYNC_WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
             .get())
   }
 
-  private fun checkInitialConditions() {
+  private fun baseCheckInitialConditions() {
+    awaitPendingPromises()
     isAuthenticated()
 
     // If you don't specify this system property with this setting when running the tests,
@@ -154,20 +146,13 @@ open class CodyIntegrationTextFixture : UsefulTestCase(), LensListener {
     // Check if the project is in LightEdit mode
     val isLightEditMode = LightEdit.owns(project)
     assertFalse("Project should not be in LightEdit mode", isLightEditMode)
-
-    // Check the initial state of the action's presentation
-    val action = ActionManager.getInstance().getAction("cody.documentCodeAction")
-    val event = AnActionEvent.createFromAnAction(action, null, "", createEditorContext(editor))
-    action.update(event)
-    val presentation = event.presentation
-    assertEquals("Action description should be empty", "", presentation.description)
-    assertTrue("Action should be enabled", presentation.isEnabled)
-    assertTrue("Action should be visible", presentation.isVisible)
   }
+
+  abstract fun checkInitialConditionsForOpenFile()
 
   private fun isAuthenticated() {
     val authenticated = CompletableFuture<Boolean>()
-    CodyAgentService.withAgent(myProject) { agent ->
+    CodyAgentService.withAgent(project) { agent ->
       agent.server.extensionConfiguration_status(null).thenAccept { authStatus ->
         authenticated.complete(authStatus is ProtocolAuthenticatedAuthStatus)
       }
@@ -178,10 +163,6 @@ open class CodyIntegrationTextFixture : UsefulTestCase(), LensListener {
         authenticated.completeOnTimeout(false, ASYNC_WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS).get())
   }
 
-  private fun createEditorContext(editor: Editor): DataContext {
-    return (editor as? EditorEx)?.dataContext ?: DataContext.EMPTY_CONTEXT
-  }
-
   // This provides a crude mechanism for specifying the caret position in the test file.
   private fun initCaretPosition() {
     runInEdtAndWait {
@@ -190,7 +171,7 @@ open class CodyIntegrationTextFixture : UsefulTestCase(), LensListener {
       val caretIndex = document.text.indexOf(caretToken)
 
       if (caretIndex != -1) { // Remove caret token from doc
-        WriteCommandAction.runWriteCommandAction(myProject) {
+        WriteCommandAction.runWriteCommandAction(project) {
           document.deleteString(caretIndex, caretIndex + caretToken.length)
         }
         // Place the caret at the position where the token was found.
@@ -224,78 +205,14 @@ open class CodyIntegrationTextFixture : UsefulTestCase(), LensListener {
     }
   }
 
-  private fun triggerAction(actionId: String) {
+  protected fun triggerAction(actionId: String) {
     runInEdtAndWait {
       PlatformTestUtil.dispatchAllEventsInIdeEventQueue()
       EditorTestUtil.executeAction(editor, actionId)
     }
   }
 
-  override fun onLensesUpdate(vf: VirtualFile, codeLenses: List<ProtocolCodeLens>) {
-    synchronized(lensSubscribers) { lensSubscribers.removeAll { it(codeLenses) } }
-  }
-
-  fun waitForSuccessfulEdit() {
-    var attempts = 0
-    val maxAttempts = 10
-
-    while (attempts < maxAttempts) {
-      val hasAcceptLens =
-          LensesService.getInstance(myFixture.project).getLenses(editor).any {
-            it.command?.command == EditAcceptCodeVisionProvider.command
-          }
-
-      if (hasAcceptLens) break
-      Thread.sleep(1000)
-      attempts++
-    }
-    if (attempts >= maxAttempts) {
-      assertTrue(
-          "Awaiting successful edit: No accept lens found after $maxAttempts attempts", false)
-    }
-  }
-
-  fun runAndWaitForCleanState(actionIdToRun: String) {
-    runAndWaitForLenses(actionIdToRun)
-  }
-
-  fun runAndWaitForLenses(
-      actionIdToRun: String,
-      vararg expectedLenses: String
-  ): List<ProtocolCodeLens> {
-    val future = CompletableFuture<List<ProtocolCodeLens>>()
-    synchronized(lensSubscribers) {
-      lensSubscribers.add { codeLenses ->
-        val error = codeLenses.find { it.command?.command == "cody.fixup.codelens.error" }
-        if (error != null) {
-          future.completeExceptionally(
-              IllegalStateException("Error group shown: ${error.command?.title}"))
-          return@add false
-        }
-
-        if ((expectedLenses.isEmpty() && codeLenses.isEmpty()) ||
-            expectedLenses.all { expected -> codeLenses.any { it.command?.command == expected } }) {
-          future.complete(codeLenses)
-          return@add true
-        }
-        return@add false
-      }
-    }
-
-    triggerAction(actionIdToRun)
-
-    try {
-      return future.get(ASYNC_WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-    } catch (e: Exception) {
-      val codeLenses = LensesService.getInstance(myFixture.project).getLenses(editor)
-      assertTrue(
-          "Error while awaiting after action $actionIdToRun. Expected lenses: [${expectedLenses.joinToString()}], got: $codeLenses",
-          false)
-      throw e
-    }
-  }
-
-  protected fun hasJavadocComment(text: String): Boolean {
+  fun hasJavadocComment(text: String): Boolean {
     // TODO: Check for the exact contents once they are frozen.
     val javadocPattern = Pattern.compile("/\\*\\*.*?\\*/", Pattern.DOTALL)
     return javadocPattern.matcher(text).find()

--- a/jetbrains/src/integrationTest/kotlin/com/sourcegraph/cody/util/EditCodeFixture.kt
+++ b/jetbrains/src/integrationTest/kotlin/com/sourcegraph/cody/util/EditCodeFixture.kt
@@ -16,7 +16,8 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 
-class EditCodeFixture : BaseIntegrationTextFixture(), LensListener {
+class EditCodeFixture(recordingName: String) :
+    BaseIntegrationTextFixture(recordingName), LensListener {
   private val lensSubscribers = mutableListOf<(List<ProtocolCodeLens>) -> Boolean>()
 
   override fun checkInitialConditionsForOpenFile() {

--- a/jetbrains/src/integrationTest/kotlin/com/sourcegraph/cody/util/EditCodeFixture.kt
+++ b/jetbrains/src/integrationTest/kotlin/com/sourcegraph/cody/util/EditCodeFixture.kt
@@ -1,0 +1,103 @@
+package com.sourcegraph.cody.util
+
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.ex.EditorEx
+import com.intellij.openapi.vfs.VirtualFile
+import com.sourcegraph.cody.agent.protocol_generated.ProtocolCodeLens
+import com.sourcegraph.cody.edit.lenses.LensListener
+import com.sourcegraph.cody.edit.lenses.LensesService
+import com.sourcegraph.cody.edit.lenses.providers.EditAcceptCodeVisionProvider
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+
+class EditCodeFixture : BaseIntegrationTextFixture(), LensListener {
+  private val lensSubscribers = mutableListOf<(List<ProtocolCodeLens>) -> Boolean>()
+
+  override fun checkInitialConditionsForOpenFile() {
+
+    // Check the initial state of the action's presentation
+    val action = ActionManager.getInstance().getAction("cody.documentCodeAction")
+    val event = AnActionEvent.createFromAnAction(action, null, "", createEditorContext(editor))
+    action.update(event)
+    val presentation = event.presentation
+    assertEquals("Action description should be empty", "", presentation.description)
+    assertTrue("Action should be enabled", presentation.isEnabled)
+    assertTrue("Action should be visible", presentation.isVisible)
+  }
+
+  private fun createEditorContext(editor: Editor): DataContext {
+    return (editor as? EditorEx)?.dataContext ?: DataContext.EMPTY_CONTEXT
+  }
+
+  override fun onLensesUpdate(vf: VirtualFile, codeLenses: List<ProtocolCodeLens>) {
+    synchronized(lensSubscribers) { lensSubscribers.removeAll { it(codeLenses) } }
+  }
+
+  fun waitForSuccessfulEdit() {
+    var attempts = 0
+    val maxAttempts = 10
+
+    while (attempts < maxAttempts) {
+      val hasAcceptLens =
+          LensesService.getInstance(myFixture.project).getLenses(editor).any {
+            it.command?.command == EditAcceptCodeVisionProvider.command
+          }
+
+      if (hasAcceptLens) break
+      Thread.sleep(1000)
+      attempts++
+    }
+    if (attempts >= maxAttempts) {
+      fail("Awaiting successful edit: No accept lens found after $maxAttempts attempts")
+    }
+  }
+
+  fun runAndWaitForCleanState(actionIdToRun: String) {
+    runAndWaitForLenses(actionIdToRun)
+  }
+
+  fun runAndWaitForLenses(
+      actionIdToRun: String,
+      vararg expectedLenses: String
+  ): List<ProtocolCodeLens> {
+    val future = CompletableFuture<List<ProtocolCodeLens>>()
+    synchronized(lensSubscribers) {
+      lensSubscribers.add { codeLenses ->
+        val error = codeLenses.find { it.command?.command == "cody.fixup.codelens.error" }
+        if (error != null) {
+          future.completeExceptionally(
+              IllegalStateException("Error group shown: ${error.command?.title}"))
+          return@add false
+        }
+
+        if ((expectedLenses.isEmpty() && codeLenses.isEmpty()) ||
+            expectedLenses.all { expected -> codeLenses.any { it.command?.command == expected } }) {
+          future.complete(codeLenses)
+          return@add true
+        }
+        return@add false
+      }
+    }
+
+    triggerAction(actionIdToRun)
+
+    try {
+      return future.get(ASYNC_WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+    } catch (e: Exception) {
+      val codeLenses = LensesService.getInstance(myFixture.project).getLenses(editor)
+      fail(
+          "Error while awaiting after action $actionIdToRun. Expected lenses: [${expectedLenses.joinToString()}], got: $codeLenses")
+      throw e
+    }
+  }
+
+  companion object {
+    const val ASYNC_WAIT_TIMEOUT_SECONDS = 20L
+  }
+}

--- a/jetbrains/src/integrationTest/resources/recordings/documentCode_2994921345/recording.har.yaml
+++ b/jetbrains/src/integrationTest/resources/recordings/documentCode_2994921345/recording.har.yaml
@@ -1,5 +1,5 @@
 log:
-  _recordingName: integration-test
+  _recordingName: documentCode
   creator:
     comment: persister:fs
     name: Polly.JS
@@ -37,7 +37,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 25 Mar 2025 22:47:35 GMT
+            value: Tue, 25 Mar 2025 23:17:27 GMT
           - name: content-type
             value: application/json
           - name: content-length
@@ -61,8 +61,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-03-25T22:47:35.426Z
-      time: 236
+      startedDateTime: 2025-03-25T23:17:27.547Z
+      time: 245
       timings:
         blocked: -1
         connect: -1
@@ -70,7 +70,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 236
+        wait: 245
     - _id: 6e977d3842ddb417bf941a0f568426d9
       _order: 0
       cache: {}
@@ -106,7 +106,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 25 Mar 2025 22:47:35 GMT
+            value: Tue, 25 Mar 2025 23:17:27 GMT
           - name: content-type
             value: application/json
           - name: content-length
@@ -130,8 +130,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-03-25T22:47:35.463Z
-      time: 245
+      startedDateTime: 2025-03-25T23:17:27.589Z
+      time: 222
       timings:
         blocked: -1
         connect: -1
@@ -139,7 +139,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 245
+        wait: 222
     - _id: 897d3731ab8e15a1549f29445eafd1e1
       _order: 0
       cache: {}
@@ -186,7 +186,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 25 Mar 2025 22:47:30 GMT
+            value: Tue, 25 Mar 2025 23:17:22 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: transfer-encoding
@@ -217,8 +217,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-03-25T22:47:30.166Z
-      time: 251
+      startedDateTime: 2025-03-25T23:17:22.253Z
+      time: 280
       timings:
         blocked: -1
         connect: -1
@@ -226,7 +226,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 251
+        wait: 280
     - _id: d339f9e066a991b97bfa2860eeb610bc
       _order: 0
       cache: {}
@@ -244,7 +244,7 @@ log:
           - name: content-type
             value: application/json
           - name: traceparent
-            value: 00-f7cfede58dc6351be9e2112731cfa0ab-7fc0dd4c51ebd761-01
+            value: 00-ba81a920c3250e0bfcfc350aee802da2-b238bebe1889f836-01
           - name: user-agent
             value: jetbrains/6.0-localbuild (Node.js v20.12.2)
           - name: x-requested-with
@@ -353,14 +353,14 @@ log:
             value: 6.0-localbuild
         url: https://sourcegraph.com/.api/completions/stream?api-version=9&client-name=jetbrains&client-version=6.0-localbuild
       response:
-        bodySize: 1117
+        bodySize: 1577
         content:
           mimeType: text/event-stream
-          size: 1117
+          size: 1577
           text: >+
             event: completion
 
-            data: {"deltaText":"\n    /**\n     * Generates and prints the first 10 numbers of the Fibonacci sequence.\n     * This method creates a list of Fibonacci numbers starting from 0 and 1,\n     * and prints each number to the console.\n     */\n","stopReason":"stop_sequence"}
+            data: {"deltaText":"\n    /**\n     * Generates and prints the first 10 numbers of the Fibonacci sequence.\n     * Initializes the sequence with 0 and 1, then calculates subsequent numbers\n     * by adding the two preceding numbers, and prints each number to the console.\n     */\n","stopReason":"stop_sequence"}
 
 
             event: done
@@ -370,7 +370,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 25 Mar 2025 22:47:35 GMT
+            value: Tue, 25 Mar 2025 23:17:26 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -399,8 +399,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-03-25T22:47:32.524Z
-      time: 3778
+      startedDateTime: 2025-03-25T23:17:24.389Z
+      time: 3683
       timings:
         blocked: -1
         connect: -1
@@ -408,7 +408,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 3778
+        wait: 3683
     - _id: f1b1cde4cd57488b7f0137954f0302f5
       _order: 0
       cache: {}
@@ -466,7 +466,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 25 Mar 2025 22:47:31 GMT
+            value: Tue, 25 Mar 2025 23:17:23 GMT
           - name: content-type
             value: application/json
           - name: content-length
@@ -495,8 +495,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-03-25T22:47:31.707Z
-      time: 235
+      startedDateTime: 2025-03-25T23:17:23.637Z
+      time: 273
       timings:
         blocked: -1
         connect: -1
@@ -504,7 +504,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 235
+        wait: 273
     - _id: a376faab1c8a1993bb48c745757f0a4a
       _order: 0
       cache: {}
@@ -585,7 +585,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 25 Mar 2025 22:47:31 GMT
+            value: Tue, 25 Mar 2025 23:17:23 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -616,8 +616,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-03-25T22:47:31.095Z
-      time: 303
+      startedDateTime: 2025-03-25T23:17:23.066Z
+      time: 301
       timings:
         blocked: -1
         connect: -1
@@ -625,7 +625,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 303
+        wait: 301
     - _id: 0484c4d780805faf3dd3ddabae814640
       _order: 0
       cache: {}
@@ -694,7 +694,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 25 Mar 2025 22:47:31 GMT
+            value: Tue, 25 Mar 2025 23:17:23 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -725,8 +725,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-03-25T22:47:31.140Z
-      time: 272
+      startedDateTime: 2025-03-25T23:17:23.119Z
+      time: 250
       timings:
         blocked: -1
         connect: -1
@@ -734,7 +734,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 272
+        wait: 250
     - _id: e141c56e63809042300db9bf8551d492
       _order: 0
       cache: {}
@@ -803,7 +803,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 25 Mar 2025 22:47:31 GMT
+            value: Tue, 25 Mar 2025 23:17:23 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -834,7 +834,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-03-25T22:47:31.118Z
+      startedDateTime: 2025-03-25T23:17:23.095Z
       time: 278
       timings:
         blocked: -1
@@ -934,7 +934,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 25 Mar 2025 22:47:30 GMT
+            value: Tue, 25 Mar 2025 23:17:22 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -965,8 +965,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-03-25T22:47:29.837Z
-      time: 317
+      startedDateTime: 2025-03-25T23:17:21.936Z
+      time: 304
       timings:
         blocked: -1
         connect: -1
@@ -974,7 +974,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 317
+        wait: 304
     - _id: aef0c9fe7483280d9c05ac8e97e37571
       _order: 0
       cache: {}
@@ -1053,7 +1053,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 25 Mar 2025 22:47:31 GMT
+            value: Tue, 25 Mar 2025 23:17:23 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -1084,8 +1084,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-03-25T22:47:31.186Z
-      time: 368
+      startedDateTime: 2025-03-25T23:17:23.164Z
+      time: 348
       timings:
         blocked: -1
         connect: -1
@@ -1093,7 +1093,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 368
+        wait: 348
     - _id: 4504fab53d7cb602861f73dc2aa883d2
       _order: 0
       cache: {}
@@ -1159,7 +1159,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 25 Mar 2025 22:47:31 GMT
+            value: Tue, 25 Mar 2025 23:17:23 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -1190,8 +1190,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-03-25T22:47:31.162Z
-      time: 261
+      startedDateTime: 2025-03-25T23:17:23.141Z
+      time: 232
       timings:
         blocked: -1
         connect: -1
@@ -1199,7 +1199,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 261
+        wait: 232
     - _id: fd0fee4687419870bc82cba9d1023319
       _order: 0
       cache: {}
@@ -1272,7 +1272,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 25 Mar 2025 22:47:31 GMT
+            value: Tue, 25 Mar 2025 23:17:23 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -1303,8 +1303,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-03-25T22:47:31.683Z
-      time: 261
+      startedDateTime: 2025-03-25T23:17:23.615Z
+      time: 256
       timings:
         blocked: -1
         connect: -1
@@ -1312,7 +1312,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 261
+        wait: 256
     - _id: fbb23499ae0eec5c2e188687b429531b
       _order: 0
       cache: {}
@@ -1390,7 +1390,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 25 Mar 2025 22:47:32 GMT
+            value: Tue, 25 Mar 2025 23:17:24 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: transfer-encoding
@@ -1421,8 +1421,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-03-25T22:47:31.951Z
-      time: 408
+      startedDateTime: 2025-03-25T23:17:23.917Z
+      time: 305
       timings:
         blocked: -1
         connect: -1
@@ -1430,6 +1430,6 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 408
+        wait: 305
   pages: []
   version: "1.2"

--- a/jetbrains/src/integrationTest/resources/recordings/integration-test_2927926756/recording.har.yaml
+++ b/jetbrains/src/integrationTest/resources/recordings/integration-test_2927926756/recording.har.yaml
@@ -5,6 +5,141 @@ log:
     name: Polly.JS
     version: 6.0.6
   entries:
+    - _id: 552812cf39ed3cf6f1898a5b36818fd8
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 20
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: user-agent
+            value: OTel-OTLP-Exporter-JavaScript/0.45.1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 169
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            resourceSpans: []
+        queryString: []
+        url: https://sourcegraph.com/-/debug/otlp/v1/traces
+      response:
+        bodySize: 21
+        content:
+          mimeType: application/json
+          size: 21
+          text: "{\"partialSuccess\":{}}"
+        cookies: []
+        headers:
+          - name: date
+            value: Tue, 25 Mar 2025 22:47:35 GMT
+          - name: content-type
+            value: application/json
+          - name: content-length
+            value: "21"
+          - name: connection
+            value: keep-alive
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1218
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2025-03-25T22:47:35.426Z
+      time: 236
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 236
+    - _id: 6e977d3842ddb417bf941a0f568426d9
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 20
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: authorization
+            value: token
+              REDACTED_fc324d3667e841181b0779375f26dedc911d26b303d23b29b1a2d7ee63dc77eb
+          - name: user-agent
+            value: OTel-OTLP-Exporter-JavaScript/0.45.1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 253
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            resourceSpans: []
+        queryString: []
+        url: https://sourcegraph.com/-/debug/otlp/v1/traces
+      response:
+        bodySize: 21
+        content:
+          mimeType: application/json
+          size: 21
+          text: "{\"partialSuccess\":{}}"
+        cookies: []
+        headers:
+          - name: date
+            value: Tue, 25 Mar 2025 22:47:35 GMT
+          - name: content-type
+            value: application/json
+          - name: content-length
+            value: "21"
+          - name: connection
+            value: keep-alive
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1218
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2025-03-25T22:47:35.463Z
+      time: 245
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 245
     - _id: 897d3731ab8e15a1549f29445eafd1e1
       _order: 0
       cache: {}
@@ -44,14 +179,14 @@ log:
           encoding: base64
           mimeType: text/plain; charset=utf-8
           size: 224
-          text: "[\"H4sIAAAAAAAAA2yOsQrCMBRF935F6OwHSLcSHLoVCjq/micG8vJK3g0q4r+7VFwyn3MP9\
-            90551x/1fA6ZVoTh35wKJUPO7gTmoAq1KtsicHtZTWoeBWhHKzdAEpcK6LmP79Rsp9g\
-            QgVeM/iJS8xBH82OaOBk4zy1K4nAhqVumxZw2F9HzbagMMk4T2cuFjX3gzt2n+4LAAD\
-            //wMAI//xkhUBAAA=\"]"
+          text: "[\"H4sIAAAAAAAAA2yOsQrCMBRF935F6OwP2K0Eh26Fgs6v5omBvLySd4OK+O8uFZfM59zDf\
+            XfOOddfNbxOmdbEoR8cSuXDDu6EJqAK9SpbYnB7WQ0qXkUoB2s3gBLXiqj5z2+U7CeY\
+            UIHXDH7iEnPQR7MjGjjZOE/tSiKwYanbpgUc9tdRsy0oTDLO05mLRc394I7dp/sCAAD\
+            //wMARphNKhUBAAA=\"]"
         cookies: []
         headers:
           - name: date
-            value: Wed, 19 Mar 2025 16:13:30 GMT
+            value: Tue, 25 Mar 2025 22:47:30 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: transfer-encoding
@@ -82,8 +217,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-03-19T16:13:30.391Z
-      time: 205
+      startedDateTime: 2025-03-25T22:47:30.166Z
+      time: 251
       timings:
         blocked: -1
         connect: -1
@@ -91,12 +226,12 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 205
-    - _id: a0d8cef48d37908b5185f156b67b3804
+        wait: 251
+    - _id: d339f9e066a991b97bfa2860eeb610bc
       _order: 0
       cache: {}
       request:
-        bodySize: 3240
+        bodySize: 3305
         cookies: []
         headers:
           - name: accept-encoding
@@ -109,7 +244,7 @@ log:
           - name: content-type
             value: application/json
           - name: traceparent
-            value: 00-c2a56feb8a091b3064b9ea58921134f9-09eaa8c4a197909f-01
+            value: 00-f7cfede58dc6351be9e2112731cfa0ab-7fc0dd4c51ebd761-01
           - name: user-agent
             value: jetbrains/6.0-localbuild (Node.js v20.12.2)
           - name: x-requested-with
@@ -123,7 +258,7 @@ log:
           mimeType: application/json
           params: []
           textJSON:
-            maxTokensToSample: 6000
+            maxTokensToSample: 4000
             messages:
               - speaker: system
                 text: >-
@@ -149,8 +284,9 @@ log:
                   - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
               - speaker: human
                 text: >+
-                  Codebase context from file path src/main/java/Foo.java:
-                  Codebase context from file src/main/java/Foo.java:
+                  Codebase context from file path
+                  documentCode/src/main/java/Foo.java: Codebase context from
+                  file documentCode/src/main/java/Foo.java:
 
                   import java.util.*;
 
@@ -161,15 +297,16 @@ log:
                 text: Ok.
               - speaker: human
                 text: >
-                  Codebase context from file path src/main/java/Foo.java:
-                  Codebase context from file src/main/java/Foo.java:
+                  Codebase context from file path
+                  documentCode/src/main/java/Foo.java: Codebase context from
+                  file documentCode/src/main/java/Foo.java:
 
                   }
               - speaker: assistant
                 text: Ok.
               - speaker: human
                 text: >-
-                  This is part of the file: src/main/java/Foo.java
+                  This is part of the file: documentCode/src/main/java/Foo.java
 
 
                   The user has the following code in their selection:
@@ -209,21 +346,21 @@ log:
             topP: -1
         queryString:
           - name: api-version
-            value: "8"
+            value: "9"
           - name: client-name
             value: jetbrains
           - name: client-version
             value: 6.0-localbuild
-        url: https://sourcegraph.com/.api/completions/stream?api-version=8&client-name=jetbrains&client-version=6.0-localbuild
+        url: https://sourcegraph.com/.api/completions/stream?api-version=9&client-name=jetbrains&client-version=6.0-localbuild
       response:
-        bodySize: 1244
+        bodySize: 1117
         content:
           mimeType: text/event-stream
-          size: 1244
+          size: 1117
           text: >+
             event: completion
 
-            data: {"deltaText":"\n    /**\n     * Generates and prints the first 10 numbers of the Fibonacci sequence.\n     * Calculates each subsequent number by adding the two preceding numbers,\n     * starting with 0 and 1, and then prints each number to the console.\n     */\n","stopReason":"stop_sequence"}
+            data: {"deltaText":"\n    /**\n     * Generates and prints the first 10 numbers of the Fibonacci sequence.\n     * This method creates a list of Fibonacci numbers starting from 0 and 1,\n     * and prints each number to the console.\n     */\n","stopReason":"stop_sequence"}
 
 
             event: done
@@ -233,7 +370,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 19 Mar 2025 16:13:33 GMT
+            value: Tue, 25 Mar 2025 22:47:35 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -262,8 +399,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-03-19T16:13:31.771Z
-      time: 2777
+      startedDateTime: 2025-03-25T22:47:32.524Z
+      time: 3778
       timings:
         blocked: -1
         connect: -1
@@ -271,7 +408,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 2777
+        wait: 3778
     - _id: f1b1cde4cd57488b7f0137954f0302f5
       _order: 0
       cache: {}
@@ -329,7 +466,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 19 Mar 2025 16:13:31 GMT
+            value: Tue, 25 Mar 2025 22:47:31 GMT
           - name: content-type
             value: application/json
           - name: content-length
@@ -358,8 +495,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-03-19T16:13:31.177Z
-      time: 211
+      startedDateTime: 2025-03-25T22:47:31.707Z
+      time: 235
       timings:
         blocked: -1
         connect: -1
@@ -367,7 +504,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 211
+        wait: 235
     - _id: a376faab1c8a1993bb48c745757f0a4a
       _order: 0
       cache: {}
@@ -448,7 +585,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 19 Mar 2025 16:13:30 GMT
+            value: Tue, 25 Mar 2025 22:47:31 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -479,8 +616,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-03-19T16:13:30.625Z
-      time: 272
+      startedDateTime: 2025-03-25T22:47:31.095Z
+      time: 303
       timings:
         blocked: -1
         connect: -1
@@ -488,7 +625,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 272
+        wait: 303
     - _id: 0484c4d780805faf3dd3ddabae814640
       _order: 0
       cache: {}
@@ -542,18 +679,22 @@ log:
             value: null
         url: https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration
       response:
-        bodySize: 139
+        bodySize: 136
         content:
           encoding: base64
           mimeType: application/json
-          size: 139
+          size: 136
           text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eWD53MSiE\
-            uf8vJLUipLwzLyU/HIlK6WUzOLEpJzUFKXa2tpaAAAAAP//\",\"AwArMNn0TAAAAA==\
-            \"]"
+            uf8vJLUipLwzLyU/HIlK6WUzOLEpJzUFKXa2tpaAAAAAP//AwArMNn0TAAAAA==\"]"
+          textDecoded:
+            data:
+              site:
+                codyLLMConfiguration:
+                  smartContextWindow: disabled
         cookies: []
         headers:
           - name: date
-            value: Wed, 19 Mar 2025 16:13:30 GMT
+            value: Tue, 25 Mar 2025 22:47:31 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -584,8 +725,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-03-19T16:13:30.654Z
-      time: 285
+      startedDateTime: 2025-03-25T22:47:31.140Z
+      time: 272
       timings:
         blocked: -1
         connect: -1
@@ -593,7 +734,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 285
+        wait: 272
     - _id: e141c56e63809042300db9bf8551d492
       _order: 0
       cache: {}
@@ -647,17 +788,22 @@ log:
             value: null
         url: https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmProvider
       response:
-        bodySize: 131
+        bodySize: 128
         content:
           encoding: base64
           mimeType: application/json
-          size: 131
+          size: 128
           text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eSDxgqL8s\
-            syU1CIlK6Xi/NKi5NT0osSCDKXa2tpaAAAAAP//\",\"AwAfFAXARQAAAA==\"]"
+            syU1CIlK6Xi/NKi5NT0osSCDKXa2tpaAAAAAP//AwAfFAXARQAAAA==\"]"
+          textDecoded:
+            data:
+              site:
+                codyLLMConfiguration:
+                  provider: sourcegraph
         cookies: []
         headers:
           - name: date
-            value: Wed, 19 Mar 2025 16:13:30 GMT
+            value: Tue, 25 Mar 2025 22:47:31 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -688,8 +834,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-03-19T16:13:30.639Z
-      time: 254
+      startedDateTime: 2025-03-25T22:47:31.118Z
+      time: 278
       timings:
         blocked: -1
         connect: -1
@@ -697,7 +843,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 254
+        wait: 278
     - _id: 5b9030a4e18d1e000c71d6000a7cef6f
       _order: 0
       cache: {}
@@ -788,7 +934,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 19 Mar 2025 16:13:30 GMT
+            value: Tue, 25 Mar 2025 22:47:30 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -819,8 +965,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-03-19T16:13:30.159Z
-      time: 227
+      startedDateTime: 2025-03-25T22:47:29.837Z
+      time: 317
       timings:
         blocked: -1
         connect: -1
@@ -828,7 +974,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 227
+        wait: 317
     - _id: aef0c9fe7483280d9c05ac8e97e37571
       _order: 0
       cache: {}
@@ -907,7 +1053,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 19 Mar 2025 16:13:31 GMT
+            value: Tue, 25 Mar 2025 22:47:31 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -938,8 +1084,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-03-19T16:13:30.670Z
-      time: 371
+      startedDateTime: 2025-03-25T22:47:31.186Z
+      time: 368
       timings:
         blocked: -1
         connect: -1
@@ -947,7 +1093,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 371
+        wait: 368
     - _id: 4504fab53d7cb602861f73dc2aa883d2
       _order: 0
       cache: {}
@@ -1004,16 +1150,16 @@ log:
           encoding: base64
           mimeType: application/json
           size: 136
-          text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSsaGZpYWJvFGB\
-            kamugbGuoYW8WZ6hrqGaYZmlqZpiUbmaaZKtbW1AAAAAP//AwAL08z4SQAAAA==\"]"
+          text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSsaGFgbmxvFGB\
+            kamugbGukam8WZ6hrrmlkaGRkZJFkkmJslKtbW1AAAAAP//AwCd8JPVSQAAAA==\"]"
           textDecoded:
             data:
               site:
-                productVersion: 316984_2025-03-18_6.1-1f1695fa27f5
+                productVersion: 318073_2025-03-25_6.1-792122b8b44c
         cookies: []
         headers:
           - name: date
-            value: Wed, 19 Mar 2025 16:13:30 GMT
+            value: Tue, 25 Mar 2025 22:47:31 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -1044,8 +1190,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-03-19T16:13:30.609Z
-      time: 312
+      startedDateTime: 2025-03-25T22:47:31.162Z
+      time: 261
       timings:
         blocked: -1
         connect: -1
@@ -1053,7 +1199,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 312
+        wait: 261
     - _id: fd0fee4687419870bc82cba9d1023319
       _order: 0
       cache: {}
@@ -1126,7 +1272,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 19 Mar 2025 16:13:31 GMT
+            value: Tue, 25 Mar 2025 22:47:31 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -1157,8 +1303,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-03-19T16:13:31.162Z
-      time: 233
+      startedDateTime: 2025-03-25T22:47:31.683Z
+      time: 261
       timings:
         blocked: -1
         connect: -1
@@ -1166,7 +1312,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 233
+        wait: 261
     - _id: fbb23499ae0eec5c2e188687b429531b
       _order: 0
       cache: {}
@@ -1198,53 +1344,53 @@ log:
         queryString: []
         url: https://sourcegraph.com/.api/modelconfig/supported-models.json
       response:
-        bodySize: 2547
+        bodySize: 2515
         content:
           encoding: base64
           mimeType: text/plain; charset=utf-8
-          size: 2547
-          text: "[\"H4sIAAAJbogA/+yc33ObOhbH3/NXaHjdyAUR4qzf0ty2e2dut91tp/uwcx9kOLY1AcSCc\
-            JO50/99R9jGwRZIxOAfLTwl4ehIjj/+6pzDsf66QgghK/MXENFvkGaMx9YEWc7Itq5X\
-            91JYss2f7ZE9sv8WwHJzM0n5kgWQZtYE/bewl9df5U/yslggXdJYLFKeMN+6rt4OWJa\
-            E9PmfNAJpd1/alV5+XDe7nrEUvvP0MdO4fl/aGbuecz4PQeP3w8rIeL08gZgyjdNPCc\
-            T3v5s7jVgmUhpqvH5cW23dFj/9uX4/Ix5A2PhmFhb/hlnlLZ1MiE1usGNjQiYTP6R5A\
-            NjFY5zxOAaBQyogE5qlPRTDkDsaoy/FsF37YuqNtekkPk3olIVMMKi+rs1l+Qu6O0pe\
-            1hp7xR3BeZht/4Uv/oGby/KpgDlPn+ULo76fp9R/3nFlZYKKXC5K/jTdp0wwSOXdWQp\
-            793weC3gS/2FxwL9bkx0k5GVF9On3OMnFV/4IsZzGGXu2bV8rLT/l4qXpnW3bFbsXH0\
-            F5WZAJFlEBwUf5pjzwTKgXkcdM3rEiwR93XoO8LFau8DPE8eo9cpWL5LnYN3W83XVeK\
-            VbcBcLwJCAOIMBiweJHFs81MrZHM3q39oC+1ng4M74VQ1KgGY/li6/c+/O68mun8Ccp\
-            PzL7LhngX8HvvU6/vVb6rZlEzzcETKnfg64Pur7WdRfbt9h2XoQmPMl10eJGwdEnha2\
-            aZekVy4+STcjfOybZWHG5WEBaH2sEkKQgFTqoizc6ktwb42jj5pSCK1GrTleP5bjvcM\
-            PDC8oe8xotrAF05KF/yFFmjDZPoZdbmgvu8ygJQeyq16vkuKXoZglAMETSZpH0nTHZN\
-            52Cva+3CxWgdYLbgubC70pyXXt8ZJqNg2ANtHpJ7grc8UVIMvFMBdkhXp9hwmgTnBqS\
-            O4S+Zeh7PKYvJM44p+i3BK8QzluyKfbqlPm1fNdNc9HJ3UD4GRPeSrZbQf3yk3PJWV5\
-            XIcUgv3r5dV4WH8jIMQuEFYYqJBVmB+rq5UF4GXHtnXkIQDpPyHYYNNzyycg2Y9AeGB\
-            wY3GGwfC4/mSydySQTNPV5AKkGvS+Cpg8qu4r61XrTi18l6TcG7SwqT8S+uTOCjHi3F\
-            bNj7rXEHLHDRG4HsAAgyQAecUEZXhIcMgF4SjPQqN1vAMkXgEf0jaA/mAD0VjGmgh/1\
-            fZ7HInuT8Tz1YZ7SZPGmsMjetFjHAGsfsJqCasxpP5guXc0mvMXSNYOxnGkPxaXbHr1\
-            2G/GQMRcZs6lInoa9LKKpwDRJwmf8v+8Q4wBmNA+FpgD0RQ5D93IY+td3iNFv6mHVHd\
-            pwLr0GFp6K2TvbruEpgZRFEAsa9r1pO8Q0PXE67z0x3bPPBEeXTLGUHbx0NAnKHpIue\
-            Yu+OY1ENm3aq89EsqAZYJ9HUxZDsF3T0hmoHahdUyvzB9l1lBmq530u+Dtpj8oOZCMB\
-            9XnwjIu/YDklXs1Z7vGv19NeEqDzVNRfbH9/ieY6CSlyjxpUdoo+95vRqIw8i0QcfSO\
-            NO33LWU+U9ExB0DrR7KrN1FgzBy7zmM0YBHie0jgPaYoDNpv1BWjTxl/Cu3RxyGLAIS\
-            whxCGP51hAGpUrDTJZU5DlBAzYSbyB61+P69UXglb1pjlELGbYGXlYoR872vqhMEbOy\
-            EOfU95Ia7NfvXp2U1if0pDG/umrSJfSbOeYty0d+vRbASEZ2XgW0myB4SkxQ5GMbPRe\
-            DkHvGkI3FZmNkx3IZ59NHRoh/SU6OqZtkLZt2zjFksrfH9Zm6loi3Yrin4fgn7/9+UL\
-            xLfIhswg=\",\"oWQY/6EY0yzHqll60+MB2j6gHbf4Porbl+QmKZdbO7YJtj2zwFZia\
-            xjYamc44xBCHxWb1MG6KjecMDQ2jSGMYe48dpB5mXJ/r8/M3qvMVZJb6/tAdLsKBIZQ\
-            dieUPa6srg/jWGVoEXuSv+C7p/EUszgTae4LDZMfV2PQ3dP4bSOPZWWrLLhtHmgZTav\
-            HtV0TwNlgeRndeJ6xOnqHyWMNkIS8gkhCDkeSkEOY7KbANXQvt+pedszb+pwD+/oqtG\
-            7r8xt8lkTD6vaB64baTp4PxDDHduKQ2bZBoH5JeoqHp7A/zVPY1Yle62OwZEojC7OJw\
-            Ddco6ofPn9VGFUjTqWfA0WyzxRJ3wjYXKbqKjmybdMY4KTHXRHzIMDZW+eVYsWv4hTL\
-            tEYTAqxgVVoqiFXanTG2mtC1mdmuQoFLgdYxftZ12z2x3C3YwhEELI80cevaGKmNK9y\
-            uTdszW1f27+W8tKP2WZkXmE57bJrjGIvozU0PRDqa7Ik7zeQ5xReKsUOw84pTTM6Ov+\
-            PXN0+MX4vq0u3eQrvaxLHI0ynX5PHFJo6+qiz3N3G1xwM3cWMWD07QO8LwQvJz2zbWQ\
-            LcvBt2RZ0yhPE7EjMNar8ci8eCy5i9FYouzFhq+Ylw5mHrdv/xxcz719p+1eif1Rz6q\
-            znKyZjQTD2bj944wk+358LBqUl6fj77T9Nr0fdQrhBD6cfXj6v8DAGsUX6uDXQAA\"]"
+          size: 2515
+          text: "[\"H4sIAAAJbogA/+ycQXOjOhLH7/kUKq4beUAOcda3TN7M7Kt62ZndpLKHrTnI0LZVAcSCc\
+            Jyamu++JWyTYAskYkjsBE5OaLVk8+Ov7kbo1wlCCFmpN4eQ3kGSMh5ZY2Q5A9s6XZ1L\
+            YME2/7YH9sD+mw+Lzck44QvmQ5JaY/Tf3F4ev4pP8rCYL13SSMwTHjPPOi2f9lkaB/T\
+            xnzQEaXdZ2BVefp/Wu56yBB54cp9qXH8t7IxdzzifBaDx+21lZDxeHkNEmcbp9xiiyz\
+            /NnYYsFQkNNF6v11ZPbvNPP9fXM+Q+BLUXM7f4N0xLl3Q8JjY5w46NCRmPvYBmPuAhH\
+            uGURxEIHFABqdAM7SpvhoaDEbrJm23b511vrE078WhMJyxggkH5e20Oy5vT7VbysNbY\
+            K84IzoP06Sd89gNuDsujAmY8eZRfjHpellDvccuVlQoqMjko+WmyS5lgkMiz0wR2znk\
+            8ErAU/2GRzx+s8RYS8rBCuvwzijNxy+8hkt2cubZtnyoNv2eiZGnbdsnu2R0oDwtSwU\
+            IqwL+W1+SKp0I9hixi8owVCn6/9RXkYbFigD8gilaXaKgcJM/Erqnjbo/zRDHiNgiGp\
+            YDIBx+LOYvuWTTTqNgOzOjL2gO6rfBwYHgrmiRAUx7JL1869/O09Ger7McJ79F/E/Td\
+            l4m320i8NZ3o6QafKcW7F/Ve1FeiPsT2ObadZ2EJjzNdpLiRb/RdYatGWXrF8k6yCfl\
+            7yyAbyy0Xc0iq4wwf4gSkPPtVscbH0lsZP5S7q441Rl3HGi6eU3afVUhhBaADF/1Dtj\
+            JjtL4LvdrSTHCPh3EAYlu8XqTGDTU3jQH8Poo2iqIvjME+a5XrXbmdq/is0tsGMOd+V\
+            4o7tEevDLNxAKxhVq/IbXE7Oorkj7imeuwQt8XUbwfbwSY0NSS3D3yLwPf1mD4SLX67\
+            isauGhfg5cJ5TjZ1Xp0yv5Tvqm6OOrXrCT9gwhvJdiOon985x5zkfbBQ+E3l13leeyA\
+            DxywQVhiqkFSY7amrxwfhccS1F+YMktYTsi0GDad8MrDNGLR7BnsGtxgsHsmPxwtnPE\
+            4FTTzuQ6JB70bQ5EplV1K/Sm968Ssl/cagHUThidhnF0aQEfe8ZPaacy0xR2w/kdsCz\
+            AeIU4B7nFOGFwQHTACe0BQ0avcHQHwDcI/uCPqLCUCfFW1K+FHP41kk0k8pzxIPZgmN\
+            559yi/RTg3H0sHYB66QBrI4pq04nqC6GxmgOzYAsboodHBfD5vg1m4wPKWt2yJsFhYf\
+            PXxrSRGAax8Ej/t8DRNiHKc0CoSkE3chm6FI2Q/96gAj9oW5WnqkN+9JrYe4p7721aR\
+            uWMSQshEjQoOvJ25zI3LI0mPcviTuYDMkES/nBC0eTrOxgOSSf0Z1TS2XdBL4aRDynK\
+            WCPhxMWgf80poXTk9uT+4xcmU/INUipoYpeZoJ/kfaoWIxsJKQe9x9x/h8su8SrPovB\
+            vFxXO0mIDlNZWy8AHRee68Qkz0cqcNkqBF1u4EZFkpQn5+iO1M76DXt9o0RoAoJWiWd\
+            Ly6D6OLQmDlVQkkVsysDHs4RGWUAT7LPptCtI64KAYmiLIQ5YBDiABQQ44NEMC0jCYq\
+            R+KmsNssyAATux27P9MdlevSe0AnsGIYsYdgYuVujIlsZ+y42RM3DRj4TXElvvV6+i7\
+            RTdJzSgkff2FaYjWfvhmK9o2vfZo4JBMrDxNKDpHMMyNiORDGz0VTZBX2qiOBWYtZ3t\
+            iWeX6z00WvohFns0CmVt9Z2nrBPIm687rM3EtUC6EcXvh+B3vzD6SOnNsyKz+KBAGP8=\
+            \",\"pWhTr8aqXjqT457ZDpgdNXhPZdiV4MYJlxM7tgm2XbOoVlJrGNVqezjgAEIfEp\
+            sUxFqqObxhXNxIhk0leL8HDQqWZV6mnOCrM7OvKnOV6Fb63pPetiKBPpbdimVfV1nXe\
+            3SscAzZUv6BL5ajCWZRKpLMExomr1dt0MVy9LmWx6K6VTwi2DzgMupWj2uzxQEHg+Vx\
+            rNRzjWd7d7/cqgJIQl5AJCH7I0nIPky2U+DqVzY3WtnsmC/5c/Zc81ei9alGv8FnQTS\
+            sPj183VDbyjOCCGbYjh0yfVowUD0kPcX9E9l39UR2tdnXeocsmdnISDQW+IxrlPXbj1\
+            uFUTnqVPrZUyi7zJT0iwTra1XHnyM1CQOIeRzg7NxJrWGKZWajiQJWrCotFcAq7Q6YW\
+            k30Wo9sW9HAkTDrGD/uOm8fWD7M0cIh+CwLNZHr2hipjUvYrk2bI1tV+e9kJ7XXXHV1\
+            LDQ6xgp6dtYBj44me+JOPXdO/rIxdgh2XrDDycHR97Gm7ya7S513Nn9jkSUTrsni8/k\
+            b3aosd+dvtcc9529jEvdOz1uC8Eiyc9ucwWFXDA4HrjGFcqMRMw4rvb4WiXsXNT8UiQ\
+            12Yah5+bi0W/V6FfP1ZtPqpx9rdSX1m4WodnmypjQVV2btdzY3kwv14Wq1VHm9aXpRg\
+            de/qXqCEEK/T36f/H8AifVYcJhdAAA=\"]"
         cookies: []
         headers:
           - name: date
-            value: Wed, 19 Mar 2025 16:13:31 GMT
+            value: Tue, 25 Mar 2025 22:47:32 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: transfer-encoding
@@ -1275,8 +1421,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-03-19T16:13:31.401Z
-      time: 250
+      startedDateTime: 2025-03-25T22:47:31.951Z
+      time: 408
       timings:
         blocked: -1
         connect: -1
@@ -1284,6 +1430,6 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 250
+        wait: 408
   pages: []
   version: "1.2"

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgent.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgent.kt
@@ -283,6 +283,9 @@ private constructor(
       // N.B. Do not set CODY_TESTING=true -- that is for Agent-side tests.
       if (!ConfigUtil.isIntegrationTestModeEnabled()) return
 
+      processBuilder.environment()["CODY_RECORDING_NAME"] =
+          System.getProperty("CODY_RECORDING_NAME")
+
       processBuilder.environment().apply {
         // N.B. If you set CODY_RECORDING_MODE, you must set CODY_RECORDING_DIRECTORY,
         // or the Agent will throw an error and your test will fail.


### PR DESCRIPTION
We had a major issue in our integration tests. `setUp` and `tearDown` methods are called before and after EACH case. That means we initialized (and shutdown-ed) the agent not once per the class but multiple times. And the recordings were recorded multiple times overriding the previous version. We were lucky it worked for document code test class.

This PR is a prerequisite for integration tests for autocomplete.

Additionally, this PR provides a mechanism to specify the recording name that will help us later with autocomplete and probably other test classes. 

It will likely speed up tests. Let's see once CI passes.

## Test plan
- green ci
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
