### PR TITLE
fix(modes): Hide agentic mode when edit is not enabled

### DIFF
--- a/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/ModeSelectorButton.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/ModeSelectorButton.tsx
@@ -77,8 +77,9 @@ export const ModeSelectorField: React.FunctionComponent<{
                 badge: agenticChatEnabled ? 'Experimental' : 'Pro',
                 icon: Sparkle,
                 intent: 'agentic',
-                hidden: !agenticChatEnabled,
-                disabled: !agenticChatEnabled,
+                // Hide agentic option if not enabled or if edit not enabled
+                hidden: !agenticChatEnabled || !isEditEnabled,
+                disabled: !agenticChatEnabled || !isEditEnabled,
                 value: IntentEnum.Agentic,
             },
             {


### PR DESCRIPTION
This commit updates the `ModeSelectorButton` component to hide the agentic mode option when the edit functionality is not enabled. This ensures that users do not see the agentic mode option if they cannot use it.

This includes Web client


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Agent mode should be hidden for clients that dont support edit