### PR TITLE
feat(models) Set new context limits (CODY-5022)

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -146,7 +146,7 @@ export enum FeatureFlag {
     CodyAutoEditUseWebSocketForFireworksConnections = 'auto-edit-use-web-socket-for-connections',
 
     // Extend context window for Cody Clients
-    LongContextWindow = 'long-context-window',
+    EnhancedContextWindow = 'enhanced-context-window',
 
     /**
      * Internal use only. Enables the next agentic chat experience.

--- a/lib/shared/src/models/model.test.ts
+++ b/lib/shared/src/models/model.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import type { ModelCategory } from '..'
 import { ModelTag, ModelUsage } from '..'
 import { type ServerModel, createModelFromServerModel, getServerModelTags, toLegacyModel } from './model'
 
@@ -61,6 +62,63 @@ describe('toLegacyModel', () => {
 })
 
 describe('createModelFromServerModel', () => {
+    it('handles enhanced context window when flag is enabled', () => {
+        // Arrange
+        const modelWithEnhancedContext = {
+            modelRef: 'test::1::model',
+            displayName: 'Test Model',
+            modelName: 'test-model',
+            capabilities: ['chat'],
+            category: 'balanced' as ModelCategory,
+            status: 'stable',
+            tier: ModelTag.Pro,
+            contextWindow: {
+                maxInputTokens: 10000,
+                maxOutputTokens: 5000,
+                maxUserInputTokens: 6000,
+            },
+        } satisfies ServerModel
+
+        // Act
+        const result = createModelFromServerModel(modelWithEnhancedContext, true)
+
+        // Assert
+        expect(result.contextWindow).toEqual({
+            input: 6000,
+            context: {
+                user: 4000, // 10000 - 6000
+            },
+            output: 5000,
+        })
+    })
+
+    it('uses standard context window when flag is disabled', () => {
+        // Arrange
+        const modelWithEnhancedContext = {
+            modelRef: 'test::1::model',
+            displayName: 'Test Model',
+            modelName: 'test-model',
+            capabilities: ['chat'],
+            category: 'balanced' as ModelCategory,
+            status: 'stable',
+            tier: ModelTag.Pro,
+            contextWindow: {
+                maxInputTokens: 10000,
+                maxOutputTokens: 4000,
+                maxUserInputTokens: 6000,
+            },
+        } satisfies ServerModel
+
+        // Act
+        const result = createModelFromServerModel(modelWithEnhancedContext, false)
+
+        // Assert
+        expect(result.contextWindow).toEqual({
+            input: 10000,
+            output: 4000,
+        })
+    })
+
     it('removes Edit usage from models with reasoning capability', () => {
         // Arrange - model with both reasoning and edit capabilities
         const reasoningEditModel = {

--- a/lib/shared/src/models/model.test.ts
+++ b/lib/shared/src/models/model.test.ts
@@ -63,7 +63,6 @@ describe('toLegacyModel', () => {
 
 describe('createModelFromServerModel', () => {
     it('handles enhanced context window when flag is enabled', () => {
-        // Arrange
         const modelWithEnhancedContext = {
             modelRef: 'test::1::model',
             displayName: 'Test Model',
@@ -79,10 +78,8 @@ describe('createModelFromServerModel', () => {
             },
         } satisfies ServerModel
 
-        // Act
         const result = createModelFromServerModel(modelWithEnhancedContext, true)
 
-        // Assert
         expect(result.contextWindow).toEqual({
             input: 6000,
             context: {
@@ -93,7 +90,6 @@ describe('createModelFromServerModel', () => {
     })
 
     it('uses standard context window when flag is disabled', () => {
-        // Arrange
         const modelWithEnhancedContext = {
             modelRef: 'test::1::model',
             displayName: 'Test Model',
@@ -109,10 +105,8 @@ describe('createModelFromServerModel', () => {
             },
         } satisfies ServerModel
 
-        // Act
         const result = createModelFromServerModel(modelWithEnhancedContext, false)
 
-        // Assert
         expect(result.contextWindow).toEqual({
             input: 10000,
             output: 4000,
@@ -120,7 +114,7 @@ describe('createModelFromServerModel', () => {
     })
 
     it('removes Edit usage from models with reasoning capability', () => {
-        // Arrange - model with both reasoning and edit capabilities
+        // model with both reasoning and edit capabilities
         const reasoningEditModel = {
             modelRef: 'anthropic::1::claude-3-sonnet',
             displayName: 'Claude 3 Sonnet',
@@ -135,17 +129,15 @@ describe('createModelFromServerModel', () => {
             },
         } satisfies ServerModel
 
-        // Act
         const result = createModelFromServerModel(reasoningEditModel, false)
 
-        // Assert
         expect(result.usage).toContain(ModelUsage.Chat)
         expect(result.usage).not.toContain(ModelUsage.Edit)
         expect(result.tags).toContain(ModelTag.Power) // Check that other attributes are preserved
     })
 
     it('preserves Edit usage for models without reasoning capability', () => {
-        // Arrange - similar model but without reasoning capability
+        // similar model but without reasoning capability
         const editOnlyModel = {
             modelRef: 'anthropic::1::claude-instant',
             displayName: 'Claude Instant',
@@ -160,16 +152,14 @@ describe('createModelFromServerModel', () => {
             },
         } satisfies ServerModel
 
-        // Act
         const result = createModelFromServerModel(editOnlyModel, false)
 
-        // Assert
         expect(result.usage).toContain(ModelUsage.Edit)
         expect(result.usage).toContain(ModelUsage.Chat)
     })
 
     it('correctly handles models with reasoning but no edit capability', () => {
-        // Arrange - model with reasoning but no edit capability
+        // model with reasoning but no edit capability
         const reasoningOnlyModel = {
             modelRef: 'anthropic::1::claude-3-opus',
             displayName: 'Claude 3 Opus',
@@ -184,10 +174,8 @@ describe('createModelFromServerModel', () => {
             },
         } satisfies ServerModel
 
-        // Act
         const result = createModelFromServerModel(reasoningOnlyModel, false)
 
-        // Assert
         expect(result.usage).toContain(ModelUsage.Chat)
         expect(result.usage).not.toContain(ModelUsage.Edit)
         // Also check that reasoning is reflected in tags

--- a/lib/shared/src/models/model.test.ts
+++ b/lib/shared/src/models/model.test.ts
@@ -78,7 +78,7 @@ describe('createModelFromServerModel', () => {
         } satisfies ServerModel
 
         // Act
-        const result = createModelFromServerModel(reasoningEditModel)
+        const result = createModelFromServerModel(reasoningEditModel, false)
 
         // Assert
         expect(result.usage).toContain(ModelUsage.Chat)
@@ -103,7 +103,7 @@ describe('createModelFromServerModel', () => {
         } satisfies ServerModel
 
         // Act
-        const result = createModelFromServerModel(editOnlyModel)
+        const result = createModelFromServerModel(editOnlyModel, false)
 
         // Assert
         expect(result.usage).toContain(ModelUsage.Edit)
@@ -127,7 +127,7 @@ describe('createModelFromServerModel', () => {
         } satisfies ServerModel
 
         // Act
-        const result = createModelFromServerModel(reasoningOnlyModel)
+        const result = createModelFromServerModel(reasoningOnlyModel, false)
 
         // Assert
         expect(result.usage).toContain(ModelUsage.Chat)

--- a/lib/shared/src/models/modelsService.ts
+++ b/lib/shared/src/models/modelsService.ts
@@ -59,10 +59,23 @@ export type ModelStatus =
 export type ModelTier = ModelTag.Free | ModelTag.Pro | ModelTag.Enterprise
 /** Must match types on github.com/sourcegraph/sourcegraph/-/blob/internal/modelconfig/types/model.go */
 export type ModelCapability = 'chat' | 'autocomplete' | 'edit' | 'vision' | 'reasoning' | 'tools'
+/** Must match types on github.com/sourcegraph/sourcegraph/-/blob/internal/modelconfig/types/model.go */
+export type ModelConfigAllTiers = {
+    [key in ModelTier]: ModelConfigPerTier
+}
 
+/** Matching github.com/sourcegraph/sourcegraph/-/blob/internal/modelconfig/types/model.go */
+export interface ModelConfigPerTier {
+    contextWindow: ContextWindow
+}
+
+/** Matching github.com/sourcegraph/sourcegraph/-/blob/internal/modelconfig/types/model.go */
 export interface ContextWindow {
     maxInputTokens: number
     maxOutputTokens: number
+    // maxUserInputTokens is the maximum number of tokens user puts into the chat message.
+    // It is part of the input context window (maxInputTokens)
+    maxUserInputTokens?: number
 }
 
 export interface ClientSideConfig {

--- a/lib/shared/src/models/modelsService.ts
+++ b/lib/shared/src/models/modelsService.ts
@@ -61,11 +61,11 @@ export type ModelTier = ModelTag.Free | ModelTag.Pro | ModelTag.Enterprise
 export type ModelCapability = 'chat' | 'autocomplete' | 'edit' | 'vision' | 'reasoning' | 'tools'
 /** Must match types on github.com/sourcegraph/sourcegraph/-/blob/internal/modelconfig/types/model.go */
 export type ModelConfigAllTiers = {
-    [key in ModelTier]: ModelConfigPerTier
+    [key in ModelTier]: ModelConfigByTier
 }
 
 /** Matching github.com/sourcegraph/sourcegraph/-/blob/internal/modelconfig/types/model.go */
-export interface ModelConfigPerTier {
+export interface ModelConfigByTier {
     contextWindow: ContextWindow
 }
 

--- a/lib/shared/src/models/sync.test.ts
+++ b/lib/shared/src/models/sync.test.ts
@@ -60,7 +60,7 @@ describe('server sent models', async () => {
             maxOutputTokens: 4000,
         },
     }
-    const opus = createModelFromServerModel(serverOpus)
+    const opus = createModelFromServerModel(serverOpus, false)
 
     const serverClaude: ServerModel = {
         modelRef: 'anthropic::unknown::anthropic.claude-instant-v1',
@@ -75,7 +75,7 @@ describe('server sent models', async () => {
             maxOutputTokens: 4000,
         },
     }
-    const claude = createModelFromServerModel(serverClaude)
+    const claude = createModelFromServerModel(serverClaude, false)
 
     const serverTitan: ServerModel = {
         modelRef: 'anthropic::unknown::amazon.titan-text-lite-v1',
@@ -90,7 +90,7 @@ describe('server sent models', async () => {
             maxOutputTokens: 4000,
         },
     }
-    const titan = createModelFromServerModel(serverTitan)
+    const titan = createModelFromServerModel(serverTitan, false)
 
     const SERVER_MODELS: ServerModelConfiguration = {
         schemaVersion: '1.0',
@@ -296,7 +296,7 @@ describe('syncModels', () => {
             await vi.advanceTimersByTimeAsync(1)
             const result1: ModelsData = {
                 localModels: [],
-                primaryModels: [createModelFromServerModel(quxModel)],
+                primaryModels: [createModelFromServerModel(quxModel, false)],
                 preferences: {
                     defaults: {
                         autocomplete: 'qux::a::a',
@@ -361,7 +361,7 @@ describe('syncModels', () => {
             expect(values).toStrictEqual<typeof values>([
                 {
                     localModels: [],
-                    primaryModels: [createModelFromServerModel(zzzModel)],
+                    primaryModels: [createModelFromServerModel(zzzModel, false)],
                     preferences: {
                         defaults: {
                             autocomplete: 'zzz::a::a',
@@ -630,7 +630,7 @@ describe('maybeAdjustContextWindows', () => {
 
         const results = maybeAdjustContextWindows(testServerSideModels, {
             tier: 'enterprise',
-            longContextWindowFlagEnabled: false,
+            enhancedContextWindowFlagEnabled: false,
         })
         const mistralModelNamePrefixes = ['mistral', 'mixtral']
         for (const model of results) {
@@ -640,368 +640,5 @@ describe('maybeAdjustContextWindows', () => {
             }
             expect(model.contextWindow.maxInputTokens).toBe(wantMaxInputTokens)
         }
-    })
-
-    it('preserves the context window for enterprise users with Claude-3-Sonnet (Pro tier) when the feature flag is on', () => {
-        const models = [
-            {
-                modelRef: 'anthropic::latest::claude-3-sonnet' as const,
-                modelName: 'claude-3-sonnet',
-                displayName: 'Claude 3 Sonnet',
-                capabilities: ['chat'],
-                category: ModelTag.Power as const,
-                status: ModelTag.Experimental as const,
-                tier: ModelTag.Pro as const,
-                contextWindow: {
-                    maxInputTokens: 175000,
-                    maxOutputTokens: 4000,
-                },
-            },
-        ] satisfies ServerModel[]
-
-        const result = maybeAdjustContextWindows(models, {
-            tier: 'enterprise',
-            longContextWindowFlagEnabled: true,
-        })
-        expect(result[0].contextWindow.maxInputTokens).toBe(175000)
-        expect(result[0].contextWindow.maxOutputTokens).toBe(4000)
-    })
-
-    it('reduces the output tokens for Pro users with Gemini-1.5-Pro (Pro tier) when the feature flag is on', () => {
-        const models = [
-            {
-                modelRef: 'google::v1::gemini-1.5-pro' as const,
-                modelName: 'gemini-1.5-pro',
-                displayName: 'Gemini 1.5 Pro',
-                capabilities: ['chat'],
-                category: ModelTag.Power as const,
-                status: ModelTag.Experimental as const,
-                tier: ModelTag.Pro as const,
-                contextWindow: {
-                    maxInputTokens: 175000,
-                    maxOutputTokens: 8000,
-                },
-            },
-        ] satisfies ServerModel[]
-
-        const result = maybeAdjustContextWindows(models, {
-            tier: 'pro',
-            longContextWindowFlagEnabled: true,
-        })
-        expect(result[0].contextWindow.maxInputTokens).toBe(175000)
-        expect(result[0].contextWindow.maxOutputTokens).toBe(6000)
-    })
-
-    it('reduces the output tokens for Pro users with GPT-o1 (Pro tier) when the feature flag is on', () => {
-        const models = [
-            {
-                modelRef: 'openai::latest::gpt-o1' as const,
-                modelName: 'gpt-o1',
-                displayName: 'GPT-o1',
-                capabilities: ['chat'],
-                category: ModelTag.Balanced as const,
-                status: 'stable' as const,
-                tier: ModelTag.Pro as const,
-                contextWindow: {
-                    maxInputTokens: 175000,
-                    maxOutputTokens: 32000,
-                },
-            },
-        ] satisfies ServerModel[]
-
-        const result = maybeAdjustContextWindows(models, {
-            tier: 'pro',
-            longContextWindowFlagEnabled: true,
-        })
-        expect(result[0].contextWindow.maxInputTokens).toBe(175000)
-        expect(result[0].contextWindow.maxOutputTokens).toBe(6000)
-    })
-
-    it('preserves the context window for enterprise users with GPT-4o (Pro tier) when the feature flag is on', () => {
-        const models = [
-            {
-                modelRef: 'openai::latest::gpt-4o' as const,
-                modelName: 'gpt-4o',
-                displayName: 'GPT-4o',
-                capabilities: ['chat'],
-                category: ModelTag.Balanced as const,
-                status: 'stable' as const,
-                tier: ModelTag.Pro as const,
-                contextWindow: {
-                    maxInputTokens: 100000,
-                    maxOutputTokens: 8000,
-                },
-            },
-        ] satisfies ServerModel[]
-
-        const result = maybeAdjustContextWindows(models, {
-            tier: 'enterprise',
-            longContextWindowFlagEnabled: true,
-        })
-        expect(result[0].contextWindow.maxInputTokens).toBe(100000)
-        expect(result[0].contextWindow.maxOutputTokens).toBe(8000)
-    })
-
-    it('reduces the context window for Pro users with GPT-o1 (Free tier) when the feature flag is off', () => {
-        const models = [
-            {
-                modelRef: 'openai::latest::gpt-o1' as const,
-                modelName: 'gpt-o1',
-                displayName: 'GPT-o1',
-                capabilities: ['chat'],
-                category: ModelTag.Balanced as const,
-                status: 'stable' as const,
-                tier: ModelTag.Free as const,
-                contextWindow: {
-                    maxInputTokens: 175000,
-                    maxOutputTokens: 32000,
-                },
-            },
-        ] satisfies ServerModel[]
-
-        const result = maybeAdjustContextWindows(models, {
-            tier: 'pro',
-            longContextWindowFlagEnabled: false,
-        })
-        expect(result[0].contextWindow.maxInputTokens).toBe(45000)
-        expect(result[0].contextWindow.maxOutputTokens).toBe(6000)
-    })
-
-    it('preserves the context window if the original values are smaller than the adjusted values for Pro users with Claude 3 Opus (Free tier) when the feature flag is off', () => {
-        const models = [
-            {
-                modelRef: 'anthropic::latest::claude-3-opus' as const,
-                modelName: 'claude-3-opus',
-                displayName: 'Claude 3 Opus',
-                capabilities: ['chat', 'reasoning'],
-                category: ModelTag.Power as const,
-                status: 'stable' as const,
-                tier: ModelTag.Free as const,
-                contextWindow: {
-                    maxInputTokens: 32000,
-                    maxOutputTokens: 4000,
-                },
-            },
-        ] satisfies ServerModel[]
-
-        const result = maybeAdjustContextWindows(models, {
-            tier: 'pro',
-            longContextWindowFlagEnabled: false,
-        })
-        expect(result[0].contextWindow.maxInputTokens).toBe(32000)
-        expect(result[0].contextWindow.maxOutputTokens).toBe(4000)
-    })
-
-    it('reduces the context window for Pro users with Claude 3 Opus (Free tier) when the feature flag is off', () => {
-        const models = [
-            {
-                modelRef: 'anthropic::latest::claude-3-opus' as const,
-                modelName: 'claude-3-opus',
-                displayName: 'Claude 3 Opus',
-                capabilities: ['chat', 'reasoning'],
-                category: ModelTag.Power as const,
-                status: 'stable' as const,
-                tier: ModelTag.Free as const,
-                contextWindow: {
-                    maxInputTokens: 175000,
-                    maxOutputTokens: 32000,
-                },
-            },
-        ] satisfies ServerModel[]
-
-        const result = maybeAdjustContextWindows(models, {
-            tier: 'pro',
-            longContextWindowFlagEnabled: false,
-        })
-        expect(result[0].contextWindow.maxInputTokens).toBe(45000)
-        expect(result[0].contextWindow.maxOutputTokens).toBe(16000)
-    })
-
-    it('reduces the input tokens for enterprise users with Claude 3 Opus (Free tier) when the feature flag is off', () => {
-        const models = [
-            {
-                modelRef: 'anthropic::latest::claude-3-opus' as const,
-                modelName: 'claude-3-opus',
-                displayName: 'Claude 3 Opus',
-                capabilities: ['chat', 'reasoning'],
-                category: ModelTag.Power as const,
-                status: 'stable' as const,
-                tier: ModelTag.Free as const,
-                contextWindow: {
-                    maxInputTokens: 175000,
-                    maxOutputTokens: 32000,
-                },
-            },
-        ] satisfies ServerModel[]
-
-        const result = maybeAdjustContextWindows(models, {
-            tier: 'enterprise',
-            longContextWindowFlagEnabled: false,
-        })
-        expect(result[0].contextWindow.maxInputTokens).toBe(45000)
-        expect(result[0].contextWindow.maxOutputTokens).toBe(32000)
-    })
-
-    it('reduces the input tokens for enterprise users with GPT-4o (Pro tier) when the feature flag is off', () => {
-        const models = [
-            {
-                modelRef: 'openai::latest::gpt-4o' as const,
-                modelName: 'gpt-4o',
-                displayName: 'GPT-4o',
-                capabilities: ['chat'],
-                category: ModelTag.Balanced as const,
-                status: 'stable' as const,
-                tier: ModelTag.Pro as const,
-                contextWindow: {
-                    maxInputTokens: 100000,
-                    maxOutputTokens: 8000,
-                },
-            },
-        ] satisfies ServerModel[]
-
-        const result = maybeAdjustContextWindows(models, {
-            tier: 'enterprise',
-            longContextWindowFlagEnabled: false,
-        })
-        expect(result[0].contextWindow.maxInputTokens).toBe(45000)
-        expect(result[0].contextWindow.maxOutputTokens).toBe(8000)
-    })
-
-    it('reduces the context window for free users with GPT-o1 (Free tier) when the feature flag is on', () => {
-        const models = [
-            {
-                modelRef: 'openai::latest::gpt-o1' as const,
-                modelName: 'gpt-o1',
-                displayName: 'GPT-o1',
-                capabilities: ['chat'],
-                category: ModelTag.Balanced as const,
-                status: 'stable' as const,
-                tier: ModelTag.Free as const,
-                contextWindow: {
-                    maxInputTokens: 175000,
-                    maxOutputTokens: 32000,
-                },
-            },
-        ] satisfies ServerModel[]
-
-        const result = maybeAdjustContextWindows(models, {
-            tier: 'free',
-            longContextWindowFlagEnabled: true,
-        })
-        expect(result[0].contextWindow.maxInputTokens).toBe(45000)
-        expect(result[0].contextWindow.maxOutputTokens).toBe(4000)
-    })
-
-    it('reduces the context window for free users with GPT-o1 (Free tier) when the feature flag is off', () => {
-        const models = [
-            {
-                modelRef: 'openai::latest::gpt-o1' as const,
-                modelName: 'gpt-o1',
-                displayName: 'GPT-o1',
-                capabilities: ['chat'],
-                category: ModelTag.Balanced as const,
-                status: 'stable' as const,
-                tier: ModelTag.Free as const,
-                contextWindow: {
-                    maxInputTokens: 175000,
-                    maxOutputTokens: 32000,
-                },
-            },
-        ] satisfies ServerModel[]
-
-        const result = maybeAdjustContextWindows(models, {
-            tier: 'free',
-            longContextWindowFlagEnabled: false,
-        })
-        expect(result[0].contextWindow.maxInputTokens).toBe(45000)
-        expect(result[0].contextWindow.maxOutputTokens).toBe(4000)
-    })
-
-    it('adjusts the context window for Mistral models by reducing it by 15%', () => {
-        const models = [
-            {
-                modelRef: 'mistral::latest::mistral-large' as const,
-                modelName: 'mistral-large',
-                displayName: 'Mistral Large',
-                capabilities: ['chat'],
-                category: ModelTag.Power as const,
-                status: 'stable' as const,
-                tier: ModelTag.Pro as const,
-                contextWindow: {
-                    maxInputTokens: 10000,
-                    maxOutputTokens: 2000,
-                },
-            },
-        ] satisfies ServerModel[]
-
-        const result = maybeAdjustContextWindows(models, {
-            tier: 'enterprise',
-            longContextWindowFlagEnabled: false,
-        })
-        // 10000 * 0.85 = 8500
-        expect(result[0].contextWindow.maxInputTokens).toBe(8500)
-    })
-
-    it('adjusts the context window for Mixtral models by reducing it by 15%', () => {
-        const models = [
-            {
-                modelRef: 'mistral::latest::mixtral-8x7b' as const,
-                modelName: 'mixtral-8x7b',
-                displayName: 'Mixtral 8x7B',
-                capabilities: ['chat'],
-                category: ModelTag.Power as const,
-                status: 'stable' as const,
-                tier: ModelTag.Pro as const,
-                contextWindow: {
-                    maxInputTokens: 12000,
-                    maxOutputTokens: 2000,
-                },
-            },
-        ] satisfies ServerModel[]
-
-        const result = maybeAdjustContextWindows(models, {
-            tier: 'enterprise',
-            longContextWindowFlagEnabled: false,
-        })
-        // 12000 * 0.85 = 10200
-        expect(result[0].contextWindow.maxInputTokens).toBe(10200)
-    })
-
-    it('correctly processes multiple models in a single call', () => {
-        const models = [
-            {
-                modelRef: 'openai::latest::gpt-4' as const,
-                modelName: 'gpt-4',
-                displayName: 'GPT-4',
-                capabilities: ['chat'],
-                category: ModelTag.Balanced as const,
-                status: 'stable' as const,
-                tier: ModelTag.Pro as const,
-                contextWindow: {
-                    maxInputTokens: 8000,
-                    maxOutputTokens: 2000,
-                },
-            },
-            {
-                modelRef: 'mistral::latest::mistral-large' as const,
-                modelName: 'mistral-large',
-                displayName: 'Mistral Large',
-                capabilities: ['chat'],
-                category: ModelTag.Power as const,
-                status: 'stable' as const,
-                tier: ModelTag.Pro as const,
-                contextWindow: {
-                    maxInputTokens: 10000,
-                    maxOutputTokens: 2000,
-                },
-            },
-        ] satisfies ServerModel[]
-
-        const result = maybeAdjustContextWindows(models, {
-            tier: 'enterprise',
-            longContextWindowFlagEnabled: false,
-        })
-        expect(result[0].contextWindow.maxInputTokens).toBe(8000) // No change for OpenAI
-        expect(result[1].contextWindow.maxInputTokens).toBe(8500) // Adjusted for Mistral (10000 * 0.85)
     })
 })

--- a/lib/shared/src/models/sync.test.ts
+++ b/lib/shared/src/models/sync.test.ts
@@ -641,4 +641,110 @@ describe('maybeAdjustContextWindows', () => {
             expect(model.contextWindow.maxInputTokens).toBe(wantMaxInputTokens)
         }
     })
+    it('keeps original context window for old clients', () => {
+        // Arrange
+        const model: ServerModel = {
+            modelRef: 'test::1::model',
+            displayName: 'Test Model',
+            modelName: 'test-model',
+            capabilities: ['chat'],
+            category: 'balanced' as ModelCategory,
+            status: 'stable',
+            tier: ModelTag.Pro,
+            contextWindow: {
+                maxInputTokens: 10000,
+                maxOutputTokens: 4000,
+            },
+            modelConfigAllTiers: {
+                pro: {
+                    contextWindow: {
+                        maxInputTokens: 12000,
+                        maxOutputTokens: 5000,
+                        maxUserInputTokens: 8000,
+                    },
+                },
+                free: {
+                    contextWindow: {
+                        maxInputTokens: 8000,
+                        maxOutputTokens: 4000,
+                        maxUserInputTokens: 6000,
+                    },
+                },
+                enterprise: {
+                    contextWindow: {
+                        maxInputTokens: 12000,
+                        maxOutputTokens: 5000,
+                        maxUserInputTokens: 8000,
+                    },
+                },
+            },
+        }
+        const config = {
+            tier: 'pro' as const,
+            enhancedContextWindowFlagEnabled: false,
+        }
+
+        // Act
+        const result = maybeAdjustContextWindows([model], config)[0]
+
+        // Assert
+        expect(result.contextWindow).toEqual({
+            maxInputTokens: 10000,
+            maxOutputTokens: 4000,
+        })
+    })
+
+    it('applies enhanced context window limits when flag is enabled', () => {
+        // Arrange
+        const model: ServerModel = {
+            modelRef: 'test::1::model',
+            displayName: 'Test Model',
+            modelName: 'test-model',
+            capabilities: ['chat'],
+            category: 'balanced' as ModelCategory,
+            status: 'stable',
+            tier: ModelTag.Pro,
+            contextWindow: {
+                maxInputTokens: 10000,
+                maxOutputTokens: 4000,
+            },
+            modelConfigAllTiers: {
+                pro: {
+                    contextWindow: {
+                        maxInputTokens: 12000,
+                        maxOutputTokens: 5000,
+                        maxUserInputTokens: 8000,
+                    },
+                },
+                free: {
+                    contextWindow: {
+                        maxInputTokens: 8000,
+                        maxOutputTokens: 4000,
+                        maxUserInputTokens: 6000,
+                    },
+                },
+                enterprise: {
+                    contextWindow: {
+                        maxInputTokens: 12000,
+                        maxOutputTokens: 5000,
+                        maxUserInputTokens: 8000,
+                    },
+                },
+            },
+        }
+        const config = {
+            tier: 'pro' as const,
+            enhancedContextWindowFlagEnabled: true,
+        }
+
+        // Act
+        const result = maybeAdjustContextWindows([model], config)[0]
+
+        // Assert
+        expect(result.contextWindow).toEqual({
+            maxInputTokens: 12000,
+            maxOutputTokens: 5000,
+            maxUserInputTokens: 8000,
+        })
+    })
 })

--- a/vscode/src/completions/providers/shared/helpers.ts
+++ b/vscode/src/completions/providers/shared/helpers.ts
@@ -95,7 +95,7 @@ export async function getAutocompleteProviderFromServerSideModelConfig({
 
     vi.spyOn(modelsService, 'modelsChanges', 'get').mockReturnValue(
         Observable.of({
-            primaryModels: mockedConfig.models.map(createModelFromServerModel),
+            primaryModels: mockedConfig.models.map(model => createModelFromServerModel(model, false)),
             localModels: [],
             preferences: {
                 defaults: defaultModelPreferencesFromServerModelsConfig(mockedConfig),


### PR DESCRIPTION
New feature flag `enhanced-context-window` to increase the limits.

Update the limits (controlled by the flag) based the values in [this table](https://docs.google.com/spreadsheets/d/166KyI-B3SxClFF8CXmGYWMUrGdVBoFaCrWtveLUkP4I/edit?gid=0#gid=0).

Server-side PR: https://github.com/sourcegraph/sourcegraph/pull/4321

## Test plan
1. Test all the test cases listed [here](https://docs.google.com/spreadsheets/d/166KyI-B3SxClFF8CXmGYWMUrGdVBoFaCrWtveLUkP4I/edit?gid=194443342#gid=194443342)

Add tests to `model.test.ts` and `sync.test.ts`

2. Test the feature flag and context window changes e2e locally (see server side PR for more details)
- `sg start`
- `sg start cody-gateway`
- check console logs
- Loom: https://www.loom.com/share/00c66bd7e24f4b9788e5a5ec51cce05d

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
