### PR TITLE
refactor(chat): Remove loading dots from context display

### DIFF
--- a/vscode/webviews/chat/Transcript.test.tsx
+++ b/vscode/webviews/chat/Transcript.test.tsx
@@ -389,12 +389,8 @@ function expectCells(expectedCells: CellMatcher[], containerElement?: HTMLElemen
                 expect(textElement.innerText.trim()).toBe(expectedCell.message)
             } else if ('loading' in expectedCell.message) {
                 const statusElement = cell.querySelector('[role="status"]')
-                if (i === expectedCells.length - 1) {
-                    expect(statusElement).not.toBeNull()
-                    expect(statusElement).toHaveAttribute('aria-busy', 'true')
-                } else {
-                    expect(statusElement).toBeNull()
-                }
+                // This has been moved to the Transcript level.
+                expect(statusElement).toBeNull()
             }
             if (expectedCell.canSubmit !== undefined) {
                 const submitButton = cell.querySelector('button[type="submit"]')
@@ -415,8 +411,8 @@ function expectCells(expectedCells: CellMatcher[], containerElement?: HTMLElemen
                 )
             } else if (expectedCell.context.loading) {
                 const statusElement = cell.querySelector('[role="status"]')
-                expect(statusElement).not.toBeNull()
-                expect(statusElement).toHaveAttribute('aria-busy', 'true')
+                // This has been moved to the Transcript level.
+                expect(statusElement).toBeNull()
             }
         } else {
             throw new Error('unknown cell')

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
@@ -15,7 +15,6 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from '../../../components/shadcn/ui/tooltip'
 import { useTelemetryRecorder } from '../../../utils/telemetry'
 import { useConfig } from '../../../utils/useConfig'
-import { LoadingDots } from '../../components/LoadingDots'
 import { Cell } from '../Cell'
 import styles from './ContextCell.module.css'
 
@@ -165,112 +164,102 @@ export const ContextCell: FunctionComponent<{
                             data-testid="context"
                             aria-disabled={isContextLoading || !hasContent}
                         >
-                            {isContextLoading && !isAgenticChat ? (
-                                <LoadingDots />
-                            ) : (
-                                <>
-                                    <AccordionContent className="tw-flex tw-flex-col" overflow={false}>
-                                        {internalDebugContext && contextAlternatives && (
-                                            <div>
-                                                <button onClick={prevSelectedAlternative} type="button">
-                                                    ←
-                                                </button>
-                                                <button onClick={nextSelectedAlternative} type="button">
-                                                    →
-                                                </button>{' '}
-                                                Ranking mechanism:{' '}
-                                                {selectedAlternative === undefined
-                                                    ? 'actual'
-                                                    : `${
-                                                          contextAlternatives[selectedAlternative]
-                                                              .strategy
-                                                      }: (${(selectedAlternative ?? -1) + 1} of ${
-                                                          contextAlternatives.length
-                                                      })`}
-                                            </div>
-                                        )}
-                                        <ul className="tw-list-none tw-flex tw-flex-col tw-gap-2 tw-pt-4">
-                                            {contextItemsToDisplay?.map((item, i) => (
-                                                <li
-                                                    // biome-ignore lint/correctness/useJsxKeyInIterable:
-                                                    // biome-ignore lint/suspicious/noArrayIndexKey: stable order
-                                                    key={i}
-                                                    data-testid="context-item"
-                                                >
-                                                    <FileLink
-                                                        uri={item.uri}
-                                                        repoName={item.repoName}
-                                                        revision={item.revision}
-                                                        source={item.source}
-                                                        range={item.range}
-                                                        title={item.title}
-                                                        isTooLarge={item.isTooLarge}
-                                                        isTooLargeReason={item.isTooLargeReason}
-                                                        isIgnored={item.isIgnored}
-                                                        providerUri={
-                                                            item.type === 'openctx'
-                                                                ? item.providerUri
-                                                                : undefined
-                                                        }
-                                                        linkClassName={styles.contextItemLink}
-                                                        className={clsx(
-                                                            styles.linkContainer,
-                                                            MENTION_CLASS_NAME
-                                                        )}
-                                                    />
-                                                    {internalDebugContext &&
-                                                        item.metadata &&
-                                                        item.metadata.length > 0 && (
-                                                            <span className={styles.contextItemMetadata}>
-                                                                {item.metadata.join(', ')}
-                                                            </span>
-                                                        )}
-                                                </li>
-                                            ))}
-
-                                            {!isForFirstMessage && (
-                                                <span
+                            <>
+                                <AccordionContent className="tw-flex tw-flex-col" overflow={false}>
+                                    {internalDebugContext && contextAlternatives && (
+                                        <div>
+                                            <button onClick={prevSelectedAlternative} type="button">
+                                                ←
+                                            </button>
+                                            <button onClick={nextSelectedAlternative} type="button">
+                                                →
+                                            </button>{' '}
+                                            Ranking mechanism:{' '}
+                                            {selectedAlternative === undefined
+                                                ? 'actual'
+                                                : `${
+                                                      contextAlternatives[selectedAlternative].strategy
+                                                  }: (${(selectedAlternative ?? -1) + 1} of ${
+                                                      contextAlternatives.length
+                                                  })`}
+                                        </div>
+                                    )}
+                                    <ul className="tw-list-none tw-flex tw-flex-col tw-gap-2 tw-pt-4">
+                                        {contextItemsToDisplay?.map((item, i) => (
+                                            <li
+                                                // biome-ignore lint/correctness/useJsxKeyInIterable:
+                                                // biome-ignore lint/suspicious/noArrayIndexKey: stable order
+                                                key={i}
+                                                data-testid="context-item"
+                                            >
+                                                <FileLink
+                                                    uri={item.uri}
+                                                    repoName={item.repoName}
+                                                    revision={item.revision}
+                                                    source={item.source}
+                                                    range={item.range}
+                                                    title={item.title}
+                                                    isTooLarge={item.isTooLarge}
+                                                    isTooLargeReason={item.isTooLargeReason}
+                                                    isIgnored={item.isIgnored}
+                                                    providerUri={
+                                                        item.type === 'openctx'
+                                                            ? item.providerUri
+                                                            : undefined
+                                                    }
+                                                    linkClassName={styles.contextItemLink}
                                                     className={clsx(
-                                                        styles.contextItem,
-                                                        'tw-flex tw-items-center tw-gap-2'
+                                                        styles.linkContainer,
+                                                        MENTION_CLASS_NAME
                                                     )}
-                                                >
-                                                    <MessagesSquareIcon size={14} className="tw-ml-1" />
-                                                    <span>
-                                                        Prior messages and context in this conversation
-                                                    </span>
+                                                />
+                                                {internalDebugContext &&
+                                                    item.metadata &&
+                                                    item.metadata.length > 0 && (
+                                                        <span className={styles.contextItemMetadata}>
+                                                            {item.metadata.join(', ')}
+                                                        </span>
+                                                    )}
+                                            </li>
+                                        ))}
+
+                                        {!isForFirstMessage && (
+                                            <span
+                                                className={clsx(
+                                                    styles.contextItem,
+                                                    'tw-flex tw-items-center tw-gap-2'
+                                                )}
+                                            >
+                                                <MessagesSquareIcon size={14} className="tw-ml-1" />
+                                                <span>
+                                                    Prior messages and context in this conversation
                                                 </span>
-                                            )}
-                                            {!isContextLoading && isAgenticChat && (
-                                                <li>
-                                                    <Tooltip>
-                                                        <TooltipTrigger asChild>
-                                                            <span
-                                                                className={clsx(
-                                                                    styles.contextItem,
-                                                                    'tw-flex tw-items-center tw-gap-2 tw-text-muted-foreground'
-                                                                )}
-                                                            >
-                                                                <BrainIcon
-                                                                    size={14}
-                                                                    className="tw-ml-1"
-                                                                />
-                                                                <span>
-                                                                    Selected from agentic context
-                                                                </span>
-                                                            </span>
-                                                        </TooltipTrigger>
-                                                        <TooltipContent side="bottom">
-                                                            Fetches additional context to improve
-                                                            response quality when needed
-                                                        </TooltipContent>
-                                                    </Tooltip>
-                                                </li>
-                                            )}
-                                        </ul>
-                                    </AccordionContent>
-                                </>
-                            )}
+                                            </span>
+                                        )}
+                                        {!isContextLoading && isAgenticChat && (
+                                            <li>
+                                                <Tooltip>
+                                                    <TooltipTrigger asChild>
+                                                        <span
+                                                            className={clsx(
+                                                                styles.contextItem,
+                                                                'tw-flex tw-items-center tw-gap-2 tw-text-muted-foreground'
+                                                            )}
+                                                        >
+                                                            <BrainIcon size={14} className="tw-ml-1" />
+                                                            <span>Selected from agentic context</span>
+                                                        </span>
+                                                    </TooltipTrigger>
+                                                    <TooltipContent side="bottom">
+                                                        Fetches additional context to improve response
+                                                        quality when needed
+                                                    </TooltipContent>
+                                                </Tooltip>
+                                            </li>
+                                        )}
+                                    </ul>
+                                </AccordionContent>
+                            </>
                         </Cell>
                     </AccordionItem>
                 </Accordion>


### PR DESCRIPTION
Follows up on https://github.com/sourcegraph/cody/pull/7502 which add the LoadingDots at Transcript level, where the LoadingDots will show up at the end of the transcript when there is an assistant message in progress.

This commit refactors the `ContextCell` component to remove the `LoadingDots` component and simplify the display of context items.

The `LoadingDots` component was previously used to indicate that the context was loading. However, it was only displayed when `isContextLoading` was true and `isAgenticChat` was false. This logic was removed, and the context items are now always displayed within the `AccordionContent`.

This change simplifies the component and improves the user experience by providing a consistent display of context items, regardless of the loading state or chat mode.

## Test Plan

Ensures there are no multple loading dots showing up in the UI at any time.
