### PR TITLE
feat(chat): Remove thinking XML tags and add thinking content part

### DIFF
--- a/lib/shared/src/sourcegraph-api/completions/CompletionsResponseBuilder.ts
+++ b/lib/shared/src/sourcegraph-api/completions/CompletionsResponseBuilder.ts
@@ -1,4 +1,9 @@
-import type { CompletionContentData, CompletionFunctionCallsData, ToolCallContentPart } from './types'
+import type {
+    CompletionContentData,
+    CompletionFunctionCallsData,
+    ThinkingContentPart,
+    ToolCallContentPart,
+} from './types'
 
 /**
  * Helper to build the `completion` text from streaming LLM completions.
@@ -31,17 +36,24 @@ export class CompletionsResponseBuilder {
         } else {
             this.totalCompletion = completion || ''
         }
-        return this.getThinkingText() + this.totalCompletion
+        return this.totalCompletion
     }
 
     /**
      * Adds an incremental thinking step to the buffer
      */
-    public nextThinking(deltaThinking?: string): string {
+    public nextThinking(deltaThinking?: string): ThinkingContentPart | undefined {
         if (deltaThinking) {
             this.thinkingBuffer.push(deltaThinking)
         }
-        return this.getThinkingText()
+        const thinking = this.thinkingBuffer.join('')
+        if (!thinking) {
+            return undefined
+        }
+        return {
+            type: 'thinking',
+            thinking,
+        }
     }
 
     /**
@@ -56,14 +68,6 @@ export class CompletionsResponseBuilder {
             }
         }
         return Array.from(this.toolCalled.values())
-    }
-
-    /**
-     * Returns formatted thinking text with XML tags
-     */
-    private getThinkingText(): string {
-        const thinking = this.thinkingBuffer.join('')
-        return thinking ? `<think>${thinking}</think>\n` : ''
     }
 
     /**

--- a/lib/shared/src/sourcegraph-api/completions/parse.ts
+++ b/lib/shared/src/sourcegraph-api/completions/parse.ts
@@ -59,16 +59,25 @@ function parseEventData(
                 return data
             }
             // Process the delta_thinking and deltaText separately.
-            // The thinking text will be added to the completion text.
-            builder.nextThinking(data.delta_thinking)
+            // The thinking content will be added to the content array.
+            const thinking = builder.nextThinking(data.delta_thinking)
             // Internally, don't handle delta text yet and there's limited value
             // in passing around deltas anyways so we concatenate them here.
             const completion = builder.nextCompletion(data.completion, data.deltaText)
             const toolCalls = builder.nextToolCalls(data?.delta_tool_calls)
             const content: CompletionContentData[] = []
+
+            // Add thinking content if it exists
+            if (thinking?.thinking) {
+                content.push(thinking)
+            }
+
+            // Add text completion if it exists
             if (completion) {
                 content.push({ type: 'text', text: completion })
             }
+
+            // Add tool calls
             content.push(...toolCalls)
             return {
                 type: eventType,

--- a/lib/shared/src/sourcegraph-api/completions/types.ts
+++ b/lib/shared/src/sourcegraph-api/completions/types.ts
@@ -10,7 +10,7 @@ interface CompletionEvent extends CompletionResponse {
     content?: CompletionContentData[] | undefined | null
 }
 
-export type CompletionContentData = TextContentPart | ToolCallContentPart
+export type CompletionContentData = TextContentPart | ToolCallContentPart | ThinkingContentPart
 
 // Tool calls returned by the LLM
 export interface CompletionFunctionCallsData {
@@ -89,6 +89,11 @@ export interface ToolResultContentPart {
         id: string
         content: string
     }
+}
+
+export interface ThinkingContentPart {
+    type: 'thinking'
+    thinking: string
 }
 
 export interface CompletionUsage {


### PR DESCRIPTION
This commit introduces the following changes:

- Removes the XML tags from the thinking text in `CompletionsResponseBuilder.ts`.
- Adds a `ThinkingContentPart` type to `lib/shared/src/sourcegraph-api/completions/types.ts` to represent the thinking content.
- Updates `lib/shared/src/sourcegraph-api/completions/parse.ts` to handle the `delta_thinking` event and add the thinking content to the content array.
- Updates `vscode/src/prompt-builder/sanitize.ts` to remove content between `<think>` tags from the first human message.

These changes allow the client to handle the thinking content separately from the completion text, and remove the need for XML tags.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

x
