### PR TITLE
feat/guardrails: Perform Guardrails checks for edits.

### DIFF
--- a/lib/shared/src/sourcegraph-api/clientConfig.ts
+++ b/lib/shared/src/sourcegraph-api/clientConfig.ts
@@ -274,8 +274,7 @@ export class ClientConfigSingleton {
             autoCompleteEnabled: features.autoComplete,
             customCommandsEnabled: features.commands,
             attributionEnabled: features.attribution,
-            // TODO DONOTCOMMIT forcing enforced mode for testing
-            attribution: features.attribution ? 'enforced' : 'none',
+            attribution: features.attribution ? 'permissive' : 'none',
             smartContextWindowEnabled: smartContextWindow,
 
             // Things that did not exist before logically default to disabled.
@@ -321,8 +320,7 @@ export class ClientConfigSingleton {
                 }
                 if (!clientConfig.attribution) {
                     // Precise attribution mode is not specified, so apply the default interpretation of attributionEnabled.
-                    // TODO DONOTCOMMIT testing only, forcing this to enforced mode for testing
-                    clientConfig.attribution = clientConfig.attributionEnabled ? 'enforced' : 'none'
+                    clientConfig.attribution = clientConfig.attributionEnabled ? 'permissive' : 'none'
                 }
                 if (!['none', 'permissive', 'enforced'].includes(clientConfig.attribution)) {
                     throw new Error(

--- a/lib/shared/src/sourcegraph-api/clientConfig.ts
+++ b/lib/shared/src/sourcegraph-api/clientConfig.ts
@@ -274,7 +274,8 @@ export class ClientConfigSingleton {
             autoCompleteEnabled: features.autoComplete,
             customCommandsEnabled: features.commands,
             attributionEnabled: features.attribution,
-            attribution: features.attribution ? 'permissive' : 'none',
+            // TODO DONOTCOMMIT forcing enforced mode for testing
+            attribution: features.attribution ? 'enforced' : 'none',
             smartContextWindowEnabled: smartContextWindow,
 
             // Things that did not exist before logically default to disabled.
@@ -320,7 +321,8 @@ export class ClientConfigSingleton {
                 }
                 if (!clientConfig.attribution) {
                     // Precise attribution mode is not specified, so apply the default interpretation of attributionEnabled.
-                    clientConfig.attribution = clientConfig.attributionEnabled ? 'permissive' : 'none'
+                    // TODO DONOTCOMMIT testing only, forcing this to enforced mode for testing
+                    clientConfig.attribution = clientConfig.attributionEnabled ? 'enforced' : 'none'
                 }
                 if (!['none', 'permissive', 'enforced'].includes(clientConfig.attribution)) {
                     throw new Error(

--- a/vscode/src/edit/edit-guardrails.ts
+++ b/vscode/src/edit/edit-guardrails.ts
@@ -97,7 +97,13 @@ export class EditGuardrails {
             }
 
             // Synchronously collect the result.
-            const attribution = await result
+            const progressOptions: vscode.ProgressOptions = {
+                title: '$(loading~spin) Checking Guardrails',
+                location: vscode.ProgressLocation.Window,
+            }
+            const attribution = await vscode.window.withProgress(progressOptions, () => {
+                return result
+            })
             if (attribution instanceof Error) {
                 // API errors, network errors, etc.: Present the option to retry.
                 logger.logDebug(

--- a/vscode/src/edit/edit-guardrails.ts
+++ b/vscode/src/edit/edit-guardrails.ts
@@ -13,8 +13,7 @@ async function getGuardrailsMode(): Promise<'none' | 'permissive' | 'enforced'> 
     if (!config) {
         throw new Error('EditGuardrails cannot determine Guardrails mode: no client config')
     }
-    // TODO DONOTCOMMIT forcing enforced mode for testing
-    return 'enforced' // config.attribution
+    return config.attribution
 }
 
 function attributionToMessage(attribution: Attribution): string {
@@ -98,7 +97,7 @@ export class EditGuardrails {
 
             // Synchronously collect the result.
             const progressOptions: vscode.ProgressOptions = {
-                title: '$(loading~spin) Checking Guardrails',
+                title: 'Checking Guardrails',
                 location: vscode.ProgressLocation.Window,
             }
             const attribution = await vscode.window.withProgress(progressOptions, () => {

--- a/vscode/src/edit/edit-guardrails.ts
+++ b/vscode/src/edit/edit-guardrails.ts
@@ -1,0 +1,136 @@
+import { ClientConfigSingleton, type SourcegraphGuardrailsClient } from '@sourcegraph/cody-shared'
+import { Attribution } from '@sourcegraph/cody-shared/src/guardrails'
+import * as vscode from 'vscode'
+import { Logger } from '../output-channel-logger'
+
+const logger = new Logger()
+const LOG_LABEL = 'Guardrails'
+
+async function getGuardrailsMode(): Promise<'none' | 'permissive' | 'enforced'> {
+    const abortController = new AbortController()
+    setTimeout(() => abortController.abort('Timed out retrieving client configuration'), 30 * 1000)
+    const config = await ClientConfigSingleton.getInstance().getConfig(abortController.signal)
+    if (!config) {
+        throw new Error('EditGuardrails cannot determine Guardrails mode: no client config')
+    }
+    // TODO DONOTCOMMIT forcing enforced mode for testing
+    return 'enforced' // config.attribution
+}
+
+function attributionToMessage(attribution: Attribution): string {
+    return `Guardrails - found ${attribution.repositories.length}${
+        attribution.limitHit ? '+' : ''
+    } matching repositories:\n${attribution.repositories.map(repo => repo.name).join('\n')}`
+}
+
+/**
+ * Provides attribution guardrails to proposed edits.
+ */
+export class EditGuardrails {
+    constructor(private readonly client: SourcegraphGuardrailsClient) {}
+
+    /**
+     * Gets whether code should hidden until `canPresentToUser` has checked
+     * the completed edit. For example, if this returns `true`, do not show a
+     * streaming intermediate code result to the user.
+     */
+    public async shouldHideCodeBeforeAttribution(): Promise<boolean> {
+        const mode = await getGuardrailsMode()
+        return mode === 'enforced'
+    }
+
+    /**
+     * Gets whether an edit of `original` into `proposed` can be presented to
+     * the user.
+     *
+     * @param original the source text being edited.
+     * @param proposed the proposed edit produced by the LLM.
+     * @returns `true` if it is OK to show the generated code to the user.
+     */
+    public async canPresentToUser(original: string, proposed: string): Promise<boolean> {
+        let mode: 'none' | 'permissive' | 'enforced' | undefined
+        try {
+            mode = await getGuardrailsMode()
+            if (mode === 'none') {
+                // No work to do!
+                return true
+            }
+
+            // If there are less than 10 new or changed lines, skip the attribution check.
+            const sourceLines = new Set(original.split(/\r?\n/m))
+            const numNewChangedLines = proposed
+                .split(/\r?\n/m)
+                .filter(line => !sourceLines.has(line)).length
+            if (numNewChangedLines < 10) {
+                return true
+            }
+
+            // Start an attribution check.
+            const result = (async () => {
+                try {
+                    return this.client.searchAttribution(proposed)
+                } catch (error) {
+                    // Normalize failures to Error instances and return them as a result.
+                    return error instanceof Error ? error : new Error(`${error}`)
+                }
+            })()
+
+            if (mode === 'permissive') {
+                // Asynchronously collect the result.
+                result.then(attribution => {
+                    if (attribution instanceof Error) {
+                        // Because we are not in enforcement mode, we do not spam the user with error messages.
+                        // TODO: Get product input on whether/how often/how passive mode should surface errors.
+                        logger.logDebug(
+                            LOG_LABEL,
+                            `error performing edits guardrails check, but ignoring because "permissive" mode: ${attribution}`
+                        )
+                        return
+                    }
+                    if (attribution.repositories.length) {
+                        // The code was found, inform the user.
+                        vscode.window.showInformationMessage(attributionToMessage(attribution))
+                    }
+                })
+                // Unblock the edit without waiting for the result.
+                return true
+            }
+
+            // Synchronously collect the result.
+            const attribution = await result
+            if (attribution instanceof Error) {
+                // API errors, network errors, etc.: Present the option to retry.
+                logger.logDebug(
+                    LOG_LABEL,
+                    `error performing edits guardrails check, this prevents edits because "${mode}" mode: ${attribution}`
+                )
+                const choice = await vscode.window.showErrorMessage(
+                    `Guardrails - Error: ${attribution.message}`,
+                    'Retry',
+                    'Cancel'
+                )
+                switch (choice) {
+                    case 'Retry':
+                        return this.canPresentToUser(original, proposed)
+                    default:
+                        return false
+                }
+            }
+            if (attribution.repositories.length !== 0) {
+                // Existing code did match, and we are in enforcement mode--inform the user and prevent the edit.
+                vscode.window.showInformationMessage(attributionToMessage(attribution))
+                return false
+            }
+            return true
+        } catch (error) {
+            if (mode === 'none' || mode === 'permissive') {
+                logger.logDebug(
+                    LOG_LABEL,
+                    `error performing edits guardrails check, but ignoring because attribution "${mode}" mode: ${error}`
+                )
+                return true
+            }
+            throw error
+        }
+    }
+}

--- a/vscode/src/edit/edit-guardrails.ts
+++ b/vscode/src/edit/edit-guardrails.ts
@@ -1,5 +1,5 @@
 import { ClientConfigSingleton, type SourcegraphGuardrailsClient } from '@sourcegraph/cody-shared'
-import { Attribution } from '@sourcegraph/cody-shared/src/guardrails'
+import type { Attribution } from '@sourcegraph/cody-shared/src/guardrails'
 import * as vscode from 'vscode'
 import { Logger } from '../output-channel-logger'
 

--- a/vscode/src/edit/smart-apply-manager.ts
+++ b/vscode/src/edit/smart-apply-manager.ts
@@ -400,6 +400,9 @@ ${replacementCode}`,
             finalReplacement = '\n' + replacement
         }
 
+        const canStream =
+            !(await this.options.editManager.options.guardrails.shouldHideCodeBeforeAttribution())
+
         const task = this.options.editManager.createTaskAndCheckForDuplicates({
             taskId: id,
             document,
@@ -407,6 +410,7 @@ ${replacementCode}`,
             userContextFiles: [],
             selectionRange: insertionRange,
             intent: 'add',
+            isStreamed: canStream,
             mode: 'insert',
             model,
             rules: null,

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -87,6 +87,7 @@ import { createInlineCompletionItemProvider } from './completions/create-inline-
 import { getConfiguration } from './configuration'
 import { observeOpenCtxController } from './context/openctx'
 import { logGlobalStateEmissions } from './dev/helpers'
+import { EditGuardrails } from './edit/edit-guardrails'
 import { EditManager } from './edit/edit-manager'
 import { SmartApplyManager } from './edit/smart-apply-manager'
 import { manageDisplayPathEnvInfoForExtension } from './editor/displayPathEnvInfo'
@@ -272,7 +273,12 @@ const register = async (
     )
     const fixupController = new FixupController(platform.extensionClient)
     const ghostHintDecorator = new GhostHintDecorator({ fixupController })
-    const editManager = new EditManager({ chatClient, editor, fixupController })
+    const editManager = new EditManager({
+        chatClient,
+        editor,
+        fixupController,
+        guardrails: new EditGuardrails(guardrails),
+    })
     const smartApplyManager = new SmartApplyManager({ editManager, chatClient })
 
     CodyToolProvider.initialize(contextRetriever)

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -24,7 +24,6 @@ import {
     type EditMode,
     EditModeTelemetryMetadataMapping,
 } from '../edit/types'
-import { isStreamedIntent } from '../edit/utils/edit-intent'
 import { getOverriddenModelForIntent } from '../edit/utils/edit-models'
 import type { ExtensionClient } from '../extension-client'
 import { isRunningInsideAgent } from '../jsonrpc/isRunningInsideAgent'
@@ -33,6 +32,7 @@ import { charactersLogger } from '../services/CharactersLogger'
 import { splitSafeMetadata } from '../services/telemetry-v2'
 import { countCode } from '../services/utils/code-count'
 
+import { isStreamedIntent } from '../edit/utils/edit-intent'
 import { FixupDocumentEditObserver } from './FixupDocumentEditObserver'
 import type { FixupFile } from './FixupFile'
 import { FixupFileObserver } from './FixupFileObserver'
@@ -56,6 +56,7 @@ export interface CreateTaskOptions {
     userContextFiles: ContextItem[]
     selectionRange: vscode.Range
     intent: EditIntent
+    isStreamed: boolean
     mode: EditMode
     model: EditModel
     rules: Rule[] | null
@@ -465,6 +466,7 @@ export class FixupController
         model: EditModel,
         rules: Rule[] | null,
         intent: EditIntent,
+        canStream: boolean,
         source: EventSource,
         telemetryMetadata?: FixupTelemetryMetadata,
         smartApplyMetadata?: SmartApplyAdditionalMetadata
@@ -491,6 +493,7 @@ export class FixupController
             userContextFiles: input.userContextFiles,
             selectionRange: input.range,
             intent: input.intent,
+            isStreamed: canStream && isStreamedIntent(input.intent),
             mode: input.mode,
             model: input.model,
             rules: input.rules,
@@ -521,6 +524,7 @@ export class FixupController
         userContextFiles,
         selectionRange,
         intent,
+        isStreamed,
         mode,
         model,
         rules,
@@ -540,6 +544,7 @@ export class FixupController
             instruction,
             userContextFiles,
             intent,
+            isStreamed,
             selectionRange,
             mode,
             overriddenModel,
@@ -1170,7 +1175,7 @@ export class FixupController
             return
         }
 
-        if (isStreamedIntent(task.intent)) {
+        if (task.isStreamed) {
             // Text change is most likely coming from the incoming streamed insertions,
             // No need to update the decorator here as it'll cause a flicker.
             return

--- a/vscode/src/non-stop/FixupDocumentEditObserver.ts
+++ b/vscode/src/non-stop/FixupDocumentEditObserver.ts
@@ -1,6 +1,5 @@
 import * as vscode from 'vscode'
 
-import { isStreamedIntent } from '../edit/utils/edit-intent'
 import type { Edit } from './line-diff'
 import type { FixupActor, FixupFileCollection, FixupTextChanged } from './roles'
 import { CodyTaskState } from './state'
@@ -114,7 +113,7 @@ export class FixupDocumentEditObserver {
              * TODO: Instead of collapsing the range, `updateRangeMultipleChanges` should expand to match
              * the new contents.
              */
-            const isCollapsedInsertion = isStreamedIntent(task.intent) && updatedRange.isEmpty
+            const isCollapsedInsertion = task.isStreamed && updatedRange.isEmpty
 
             if (!isCollapsedInsertion && !updatedRange.isEqual(task.selectionRange)) {
                 task.selectionRange = updatedRange

--- a/vscode/src/non-stop/FixupTask.ts
+++ b/vscode/src/non-stop/FixupTask.ts
@@ -74,6 +74,7 @@ export class FixupTask {
         public readonly userContextItems: ContextItem[],
         /* The intent of the edit, derived from the source of the command. */
         public readonly intent: EditIntent,
+        public readonly isStreamed: boolean,
         /* The range being edited. This range is tracked and updates as the user (or Cody) edits code. */
         public selectionRange: vscode.Range,
         /* The mode indicates how code should be inserted */

--- a/vscode/src/non-stop/decorations/compute-decorations.ts
+++ b/vscode/src/non-stop/decorations/compute-decorations.ts
@@ -85,12 +85,12 @@ function trimEmptyLinesFromRange(range: vscode.Range, document: vscode.TextDocum
 
     const startLine = document.lineAt(startLineIndex)
     if (range.start.character === startLine.range.end.character || startLine.text.length === 0) {
-        startLineIndex++
+        startLineIndex = Math.min(startLineIndex + 1, document.lineCount - 1)
     }
 
     const endLine = document.lineAt(startLineIndex)
     if (range.end.character === 0 || endLine.text.length === 0) {
-        endLineIndex--
+        endLineIndex = Math.max(startLineIndex, Math.min(endLineIndex - 1, document.lineCount - 1))
     }
 
     return new vscode.Range(

--- a/vscode/src/non-stop/decorations/compute-decorations.ts
+++ b/vscode/src/non-stop/decorations/compute-decorations.ts
@@ -1,5 +1,4 @@
 import * as vscode from 'vscode'
-import { isStreamedIntent } from '../../edit/utils/edit-intent'
 import type { FixupTask } from '../FixupTask'
 import { getDecorationSuitableText, getLastFullLine } from './utils'
 
@@ -124,7 +123,7 @@ export function computeOngoingDecorations(
         return
     }
 
-    if (isStreamedIntent(task.intent)) {
+    if (task.isStreamed) {
         // We don't provide ongoing decorations for streamed edits, only applied decorations
         // as the incoming changes are immediately applied.
         return


### PR DESCRIPTION
Adds basic Guardrails integration to Edits (Ask Cody to Edit, Document Code, etc.) When Guardrails is off, this is a no-op; when it is in permissive mode, it will notify the user of attribution matches asynchronously; when it is in enforced mode, it turns off streaming edits and will cancel edits that have attribution matches.

Fixes CODY-5084.

## Test plan

In VSCode and JetBrains:

1. Connect to dotcom, which does not use Guardrails. Check that edits (option-k) have a streaming style of presentation for additions; check that document code (option-d) works.
2. Connect to s2, which uses Guardrails in permissive mode. Check that edits and document code work (in streaming mode, where applicable, like dotcom.)
3. In addition, cut and paste 10+ lines from https://sourcegraph.com/github.com/torvalds/linux/-/blob/fs/nfs/proc.c and comment it out with `// `-style comments. Ask Cody to uncomment these lines. This should generate an attribution match; check the dialog appears.
4. Connect to an instance with site config `"attribution.enabled": true, "attribution.mode": "enforced"`. Repeat the same tasks. Streaming should be disabled. Edits which produce attribution matches should be canceled, in addition to the dialog.

![Edits Guardrails in JetBrains](https://github.com/user-attachments/assets/ab3215e4-0763-48f7-acdb-73063c4f161f)
![Edit Guardrails in VSCode](https://github.com/user-attachments/assets/ce4a712f-8ed6-4e67-8b49-7b1e3377d161)