### PR TITLE
fix(Agent Mode): Exclude tool-state context items from prompt

### DIFF
--- a/vscode/src/chat/chat-view/handlers/AgenticHandler.ts
+++ b/vscode/src/chat/chat-view/handlers/AgenticHandler.ts
@@ -433,15 +433,29 @@ class AgenticChatPrompter {
 
             promptBuilder.tryAddMessages(reversedTranscript)
 
-            await promptBuilder.tryAddContext('user', context)
+            await this.tryAddContext(promptBuilder, context)
 
             const historyItems = reversedTranscript
                 .flatMap(m => (m.contextFiles ? [...m.contextFiles].reverse() : []))
                 .filter(isDefined)
 
-            await promptBuilder.tryAddContext('history', historyItems.reverse())
+            await this.tryAddContext(promptBuilder, historyItems, 'history')
 
             return promptBuilder.build()
         })
+    }
+
+    private async tryAddContext(
+        builder: PromptBuilder,
+        context: ContextItem[],
+        type = 'user'
+    ): Promise<void> {
+        try {
+            const contextItems = context.filter(item => item.type !== 'tool-state')
+            builder.tryAddContext(type === 'history' ? 'history' : 'user', contextItems)
+        } catch {
+            logDebug('AgenticChatPrompter', 'Error adding context to prompt')
+            return
+        }
     }
 }

--- a/vscode/src/chat/chat-view/tools/edit.ts
+++ b/vscode/src/chat/chat-view/tools/edit.ts
@@ -15,7 +15,7 @@ import { type EditToolInput, EditToolSchema } from './schema'
 function createEditToolState(
     id: string,
     status: UIToolStatus,
-    uri: vscode.Uri | undefined,
+    uri: vscode.Uri,
     content: string | undefined,
     outputType: 'file-view' | 'file-diff' | 'status' = 'file-view'
 ): ContextItemToolState {
@@ -26,7 +26,7 @@ function createEditToolState(
         status,
         outputType,
         // ContextItemCommon properties
-        uri: uri || vscode.Uri.parse(`cody:/tools/edit/${id}`),
+        uri: uri,
         content,
         title: 'Text Editor Operation',
         description: content?.split('\n')[0] || 'File edit operation',
@@ -76,7 +76,7 @@ export const editTool = {
                 return createEditToolState(
                     `undo-${Date.now()}`,
                     UIToolStatus.Error,
-                    undefined,
+                    fileUri,
                     'Undo is not supported directly. Use the Source Control UI to revert changes.',
                     'status'
                 )

--- a/vscode/src/chat/chat-view/tools/edit.ts
+++ b/vscode/src/chat/chat-view/tools/edit.ts
@@ -28,7 +28,7 @@ function createEditToolState(
         // ContextItemCommon properties
         uri: uri,
         content,
-        title: 'Text Editor Operation',
+        title: 'Text Editor Tool',
         description: content?.split('\n')[0] || 'File edit operation',
         source: ContextItemSource.Agentic,
         icon: 'edit',

--- a/vscode/src/chat/chat-view/tools/file.ts
+++ b/vscode/src/chat/chat-view/tools/file.ts
@@ -58,7 +58,6 @@ function createFileToolState(
         toolName: 'get_file',
         status,
         outputType: 'file-view',
-
         // ContextItemCommon properties
         uri,
         content,

--- a/vscode/src/chat/chat-view/tools/file.ts
+++ b/vscode/src/chat/chat-view/tools/file.ts
@@ -34,7 +34,8 @@ export const getFileTool: AgentTool = {
             return createFileToolState(
                 validInput.name,
                 `get_file for ${validInput.name} failed: ${error}`,
-                UIToolStatus.Error
+                UIToolStatus.Error,
+                URI.parse('')
             )
         }
     },
@@ -47,7 +48,7 @@ function createFileToolState(
     filePath: string,
     content: string,
     status: UIToolStatus,
-    uri?: URI
+    uri: URI
 ): ContextItemToolState {
     const toolId = `get_file-${filePath.replace(/[^\w]/g, '_')}-${Date.now()}`
 
@@ -59,7 +60,7 @@ function createFileToolState(
         outputType: 'file-view',
 
         // ContextItemCommon properties
-        uri: uri || URI.parse(`cody:///tools/file?error=${filePath}`),
+        uri,
         content,
         title: filePath,
         description: `File: ${filePath}`,

--- a/vscode/src/chat/chat-view/tools/schema.ts
+++ b/vscode/src/chat/chat-view/tools/schema.ts
@@ -21,7 +21,15 @@ export const RunTerminalCommandSchema = z.object({
 })
 
 export const GetDiagnosticSchema = z.object({
-    name: z.string().describe('The name of the file for which to retrieve diagnostics from.'),
+    name: z
+        .string()
+        .describe(
+            'The name of the file for which to retrieve diagnostics from. Put "*" to get all diagnostics from current codebase.'
+        ),
+    type: z
+        .enum(['error', 'warning', 'all'])
+        .optional()
+        .describe('The type of diagnostics to retrieve. Default to error type when not specificied.'),
 })
 
 export const CodeSearchSchema = z.object({

--- a/vscode/src/chat/chat-view/tools/search.ts
+++ b/vscode/src/chat/chat-view/tools/search.ts
@@ -91,14 +91,18 @@ export function createSearchToolStateItem(
     const description = `Search for "${query}" (${searchResults.length} results)\n`
 
     // Group search results by file name with code content
-    const groupedResults = searchResults
-        .map(({ uri, content }) => {
-            if (!content?.length) return ''
-            const remote = !uri.scheme.startsWith('file') && uri.path?.split('/-/blob/')?.pop()
-            const filePath = remote || displayPath(uri)
-            return `\`\`\`${filePath}\n${content}\n\`\`\`\n`
-        })
-        .join('\n\n')
+    const isRemoteSearch = searchResults.some(r => r?.uri?.scheme === 'http')
+    const prefix = isRemoteSearch ? 'Remote search results:\n' : 'Search results:\n'
+    const groupedResults =
+        prefix +
+        searchResults
+            .map(({ uri, content }) => {
+                if (!content?.length) return ''
+                const remote = isRemoteSearch && uri.path?.split('/-/blob/')?.pop()
+                const filePath = remote || displayPath(uri)
+                return `\`\`\`${filePath}\n${content}\n\`\`\`\n`
+            })
+            .join('\n\n')
 
     return {
         type: 'tool-state',

--- a/vscode/src/chat/chat-view/tools/shell.ts
+++ b/vscode/src/chat/chat-view/tools/shell.ts
@@ -5,6 +5,7 @@ import {
     type ContextItemToolState,
 } from '@sourcegraph/cody-shared/src/codebase-context/messages'
 import * as vscode from 'vscode'
+import { URI } from 'vscode-uri'
 import type { AgentTool } from '.'
 import { validateWithZod } from '../utils/input'
 import { zodToolSchema } from '../utils/parse'
@@ -208,7 +209,7 @@ function createShellToolState(
         icon: 'terminal',
         status,
         source: ContextItemSource.Agentic,
-        uri: vscode.Uri.parse(`cody-tool://shell?id=${toolId}`),
+        uri: URI.parse(''),
     }
 }
 

--- a/vscode/src/chat/chat-view/tools/shell.ts
+++ b/vscode/src/chat/chat-view/tools/shell.ts
@@ -78,7 +78,11 @@ export const shellTool: AgentTool = {
                 return createShellToolState(validInput.command, contentString, UIToolStatus.Error)
             }
 
-            throw new Error(`Failed to run terminal command: ${input.command}: ${error}`)
+            return createShellToolState(
+                validInput.command ?? 'unknown command',
+                `Failed to run terminal command: ${input.command}: ${error}`,
+                UIToolStatus.Error
+            )
         }
     },
 }

--- a/vscode/src/chat/chat-view/utils/diff.ts
+++ b/vscode/src/chat/chat-view/utils/diff.ts
@@ -5,9 +5,9 @@ import type { URI } from 'vscode-uri'
 /**
  * Generate a markdown git diff with line numbers, showing only the section with changes
  */
-export function diffWithLineNum(oldText: string, newText: string): string {
+export function diffWithLineNum(oldText: string, newText: string, markdownFormat = true): string {
     const diff = Diff.diffLines(oldText, newText)
-    let output = '```diff\n'
+    let output = markdownFormat ? '```diff\n' : ''
 
     // First pass: find the first and last changed lines
     let firstChangedOldLine = Number.POSITIVE_INFINITY
@@ -124,7 +124,8 @@ export function diffWithLineNum(oldText: string, newText: string): string {
         }
     }
 
-    output += '```'
+    output += markdownFormat ? '```' : ''
+
     return output
 }
 

--- a/vscode/src/prompt-builder/index.ts
+++ b/vscode/src/prompt-builder/index.ts
@@ -88,10 +88,12 @@ export class PromptBuilder {
      */
     private buildContextMessages(): Message[] {
         const contextMessages: Message[] = []
-
+        // NOTE: Remove tool-state context items from the list of context items,
+        // as we are turning them into part of chat messages.
+        const filteredContextItems = this.contextItems.filter(i => i.type !== 'tool-state')
         if (this.isCacheEnabled) {
             // Filter valid context items (ignoring 'media') and collect their texts.
-            const texts = this.contextItems.reduce<PromptString[]>((acc, item) => {
+            const texts = filteredContextItems.reduce<PromptString[]>((acc, item) => {
                 const msg = renderContextItem(item)
                 if (msg) {
                     if (item.type === 'media') {
@@ -113,7 +115,7 @@ export class PromptBuilder {
             }
         } else {
             // For each valid context item, include both ASSISTANT_MESSAGE and the message.
-            for (const item of this.contextItems) {
+            for (const item of filteredContextItems) {
                 const msg = renderContextItem(item)
                 if (msg) {
                     contextMessages.push(ASSISTANT_MESSAGE, msg)

--- a/vscode/src/prompt-builder/sanitize.test.ts
+++ b/vscode/src/prompt-builder/sanitize.test.ts
@@ -18,6 +18,45 @@ describe('sanitizedChatMessages', () => {
         expect(result).toEqual(messages)
     })
 
+    it('should remove content between <think> tags in first human message', () => {
+        const messages: ChatMessage[] = [
+            { speaker: 'human', text: ps`<think>This should be removed</think>Keep this text` },
+            { speaker: 'assistant', text: ps`Response` },
+        ]
+        const result = sanitizedChatMessages(messages)
+        expect(result[0].text).toEqual(ps`Keep this text`)
+    })
+
+    it('should only process <think> tags if they start at the beginning of the message', () => {
+        const messages: ChatMessage[] = [
+            { speaker: 'human', text: ps`Text before <think>This should not be removed</think>` },
+            { speaker: 'assistant', text: ps`Response` },
+        ]
+        const result = sanitizedChatMessages(messages)
+        expect(result[0].text).toEqual(ps`Text before <think>This should not be removed</think>`)
+    })
+
+    it('should handle multiple <think> tags if the first one starts at the beginning', () => {
+        const messages: ChatMessage[] = [
+            {
+                speaker: 'human',
+                text: ps`<think>Remove this</think>Keep\n\nthis<think>And \nalso this \n</think>`,
+            },
+            { speaker: 'assistant', text: ps`Response` },
+        ]
+        const result = sanitizedChatMessages(messages)
+        expect(result[0].text).toEqual(ps`Keep\n\nthis<think>And \nalso this \n</think>`)
+    })
+
+    it('should not modify human message without <think> tags', () => {
+        const messages: ChatMessage[] = [
+            { speaker: 'human', text: ps`This message has no think tags` },
+            { speaker: 'assistant', text: ps`Response` },
+        ]
+        const result = sanitizedChatMessages(messages)
+        expect(result[0].text).toEqual(ps`This message has no think tags`)
+    })
+
     it('should remove tool_call from human messages', () => {
         const messages: ChatMessage[] = [
             {

--- a/vscode/webviews/chat/cells/toolCell/BaseCell.tsx
+++ b/vscode/webviews/chat/cells/toolCell/BaseCell.tsx
@@ -58,7 +58,7 @@ const BaseCellComponent: FC<BaseCellProps> = ({
                         headerBgClass,
                         isLoading && 'tw-cursor-wait'
                     )}
-                    disabled={isLoading || !bodyContent}
+                    disabled={isLoading}
                 >
                     <div className="tw-flex tw-items-center tw-gap-2 tw-overflow-hidden">
                         {Icon && <Icon size={16} className="tw-flex-shrink-0 tw-text-zinc-400" />}

--- a/vscode/webviews/chat/cells/toolCell/BaseCell.tsx
+++ b/vscode/webviews/chat/cells/toolCell/BaseCell.tsx
@@ -1,3 +1,4 @@
+import { UIToolStatus } from '@sourcegraph/cody-shared'
 import { ChevronDown, ChevronRight, type LucideProps } from 'lucide-react'
 import {
     type FC,
@@ -33,6 +34,7 @@ export interface BaseCellProps {
     defaultOpen?: boolean
     /** Theme variant (affects background colors) */
     theme?: ThemeVariant
+    status?: UIToolStatus
 }
 
 const BaseCellComponent: FC<BaseCellProps> = ({
@@ -42,12 +44,17 @@ const BaseCellComponent: FC<BaseCellProps> = ({
     className,
     isLoading = false,
     defaultOpen = false,
+    status = UIToolStatus.Done,
 }) => {
     const [isOpen, setIsOpen] = useState(defaultOpen)
 
     // Define standard background colors based on theme
     const headerBgClass = 'tw-bg-zinc-900 light:tw-bg-gray-100'
-    const bodyBgClass = 'tw-bg-zinc-950 light:tw-bg-gray-50'
+    const bodyBgClasses = ['tw-bg-zinc-950', 'light:tw-bg-gray-50']
+    if (status === UIToolStatus.Error) {
+        bodyBgClasses.push('tw-bg-red-500 light:tw-bg-red-500')
+    }
+    const bodyBgClass = bodyBgClasses.join(' ')
 
     return (
         <div className={cn('tw-rounded-md tw-border tw-border-border tw-w-full', className)}>

--- a/vscode/webviews/chat/cells/toolCell/DiffCell.tsx
+++ b/vscode/webviews/chat/cells/toolCell/DiffCell.tsx
@@ -3,7 +3,7 @@ import type { ContextItemToolState } from '@sourcegraph/cody-shared/src/codebase
 import { DiffIcon, GitCompare, Minus, Plus } from 'lucide-react'
 import { type FC, useMemo } from 'react'
 import type { URI } from 'vscode-uri'
-import { getFileDiff } from '../../../../src/chat/chat-view/utils/diff'
+import { diffWithLineNum, getFileDiff } from '../../../../src/chat/chat-view/utils/diff'
 import { Button } from '../../../components/shadcn/ui/button'
 import { cn } from '../../../components/shadcn/utils'
 import { BaseCell } from './BaseCell'
@@ -22,13 +22,16 @@ export const DiffCell: FC<DiffCellProps> = ({
     defaultOpen = false,
 }) => {
     const fileName = useMemo(() => (item.uri ? displayPath(item.uri) : 'Unknown'), [item.uri])
-    const result = useMemo(() => {
+    const { result } = useMemo(() => {
         const oldFile = item.metadata?.[0] || ''
         const newFile = item.metadata?.[1] || ''
         if (!oldFile && !newFile) {
-            return null
+            return { result: null, content: null }
         }
-        return getFileDiff(item.uri, oldFile, newFile)
+        return {
+            result: getFileDiff(item.uri, oldFile, newFile),
+            content: diffWithLineNum(oldFile, newFile, false),
+        }
     }, [item])
 
     if (!result) {
@@ -45,6 +48,7 @@ export const DiffCell: FC<DiffCellProps> = ({
                     e.stopPropagation()
                     if (item.uri) onFileLinkClicked(item.uri)
                 }}
+                title={fileName}
             >
                 <span className="tw-font-mono">{fileName}</span>
             </Button>
@@ -72,7 +76,7 @@ export const DiffCell: FC<DiffCellProps> = ({
         <pre className="tw-font-mono tw-text-xs tw-leading-relaxed  tw-bg-zinc-950">
             <table className="tw-w-full tw-h-full tw-border-collapse">
                 <tbody>
-                    {result.changes.map((change, _index) => (
+                    {result.changes.map((change, index) => (
                         <tr
                             key={change.lineNumber}
                             className={cn(
@@ -82,7 +86,9 @@ export const DiffCell: FC<DiffCellProps> = ({
                             )}
                         >
                             <td className="tw-select-none tw-border-r tw-border-r-zinc-700 tw-px-2 tw-text-right tw-text-zinc-500 tw-w-12">
-                                {change.lineNumber}
+                                {index === 0 && change.content?.startsWith('@@')
+                                    ? ''
+                                    : change.lineNumber}
                             </td>
                             <td className="tw-px-4 tw-py-0.5 tw-text-zinc-200 tw-whitespace-pre">
                                 <div className="tw-flex tw-items-center">
@@ -111,6 +117,7 @@ export const DiffCell: FC<DiffCellProps> = ({
             bodyContent={renderBodyContent()}
             className={className}
             defaultOpen={defaultOpen}
+            status={item?.status}
         />
     )
 }

--- a/vscode/webviews/chat/cells/toolCell/FileCell.tsx
+++ b/vscode/webviews/chat/cells/toolCell/FileCell.tsx
@@ -21,28 +21,23 @@ export const FileCell: FC<FileCellProps> = ({
 }) => {
     const isError = result?.status === UIToolStatus.Error
     const renderHeaderContent = () => (
-        <div className="tw-flex tw-items-center tw-gap-2 tw-overflow-hidden tw-flex-row">
-            <Button
-                variant="ghost"
-                className="tw-flex tw-items-center tw-gap-2 tw-overflow-hidden tw-p-0 tw-text-left tw-truncate tw-w-full hover:tw-bg-transparent"
-                onClick={e => {
-                    e.preventDefault()
-                    e.stopPropagation()
-                    if (result?.uri && result?.uri.scheme !== 'cody') onFileLinkClicked(result?.uri)
-                }}
-            >
-                <span className="tw-font-mono">
-                    {result.uri ? displayPath(result.uri) : result.title}
-                </span>
-            </Button>
-        </div>
+        <Button
+            variant="ghost"
+            className="tw-flex tw-items-center tw-gap-2 tw-overflow-hidden tw-p-0 tw-w-full tw-text-left tw-truncate tw-z-10 hover:tw-bg-transparent tw-font-mono"
+            onClick={e => {
+                e.preventDefault()
+                e.stopPropagation()
+                if (result?.uri) onFileLinkClicked(result.uri)
+            }}
+        >
+            {result.uri ? displayPath(result.uri) : result.title}
+        </Button>
     )
 
     return (
         <BaseCell
             icon={isError ? FileX : FileCode}
             headerContent={renderHeaderContent()}
-            bodyContent={undefined}
             className={className}
             defaultOpen={defaultOpen} // Always closed since there's no content to show
         />

--- a/vscode/webviews/chat/cells/toolCell/FileCell.tsx
+++ b/vscode/webviews/chat/cells/toolCell/FileCell.tsx
@@ -20,17 +20,24 @@ export const FileCell: FC<FileCellProps> = ({
     defaultOpen = false,
 }) => {
     const isError = result?.status === UIToolStatus.Error
+    const title = result.uri ? displayPath(result.uri) : result.title
     const renderHeaderContent = () => (
         <Button
             variant="ghost"
-            className="tw-flex tw-items-center tw-gap-2 tw-overflow-hidden tw-p-0 tw-w-full tw-text-left tw-truncate tw-z-10 hover:tw-bg-transparent tw-font-mono"
+            className={
+                'tw-flex tw-items-center tw-gap-2 tw-overflow-hidden tw-p-0 tw-w-full tw-text-left tw-truncate tw-z-10 hover:tw-bg-transparent tw-font-mono' +
+                isError
+                    ? ' tw-border-red-700'
+                    : ''
+            }
+            title={title}
             onClick={e => {
                 e.preventDefault()
                 e.stopPropagation()
                 if (result?.uri) onFileLinkClicked(result.uri)
             }}
         >
-            {result.uri ? displayPath(result.uri) : result.title}
+            {title}
         </Button>
     )
 
@@ -40,6 +47,7 @@ export const FileCell: FC<FileCellProps> = ({
             headerContent={renderHeaderContent()}
             className={className}
             defaultOpen={defaultOpen} // Always closed since there's no content to show
+            status={result?.status}
         />
     )
 }

--- a/vscode/webviews/chat/cells/toolCell/FileCell.tsx
+++ b/vscode/webviews/chat/cells/toolCell/FileCell.tsx
@@ -19,6 +19,7 @@ export const FileCell: FC<FileCellProps> = ({
     onFileLinkClicked,
     defaultOpen = false,
 }) => {
+    const isError = result?.status === UIToolStatus.Error
     const renderHeaderContent = () => (
         <div className="tw-flex tw-items-center tw-gap-2 tw-overflow-hidden tw-flex-row">
             <Button
@@ -27,12 +28,11 @@ export const FileCell: FC<FileCellProps> = ({
                 onClick={e => {
                     e.preventDefault()
                     e.stopPropagation()
-                    if (result?.uri && result?.status !== UIToolStatus.Error)
-                        onFileLinkClicked(result?.uri)
+                    if (result?.uri && result?.uri.scheme !== 'cody') onFileLinkClicked(result?.uri)
                 }}
             >
                 <span className="tw-font-mono">
-                    {!UIToolStatus.Error && result.uri ? displayPath(result.uri) : result.title}
+                    {result.uri ? displayPath(result.uri) : result.title}
                 </span>
             </Button>
         </div>
@@ -40,7 +40,7 @@ export const FileCell: FC<FileCellProps> = ({
 
     return (
         <BaseCell
-            icon={UIToolStatus.Error ? FileX : FileCode}
+            icon={isError ? FileX : FileCode}
             headerContent={renderHeaderContent()}
             bodyContent={undefined}
             className={className}

--- a/vscode/webviews/chat/cells/toolCell/OutputStatusCell.tsx
+++ b/vscode/webviews/chat/cells/toolCell/OutputStatusCell.tsx
@@ -1,3 +1,4 @@
+import { UIToolStatus } from '@sourcegraph/cody-shared'
 import type { ContextItemToolState } from '@sourcegraph/cody-shared/src/codebase-context/messages'
 import { AlertCircle, CheckCircle, Info } from 'lucide-react'
 import type { FC } from 'react'
@@ -12,39 +13,36 @@ interface OutputStatusProps {
 }
 
 // Extract mapping functions outside the component
-const getStatusIcon = (status: string) => {
+const getStatusIcon = (status: UIToolStatus) => {
     switch (status) {
-        case 'success':
+        case UIToolStatus.Done:
             return CheckCircle
-        case 'error':
-        case 'warning':
+        case UIToolStatus.Error:
             return AlertCircle
         default:
             return Info
     }
 }
 
-const getStatusClass = (status: string) => {
+const getStatusClass = (status: UIToolStatus) => {
     switch (status) {
-        case 'success':
+        case UIToolStatus.Done:
             return 'tw-bg-emerald-950/30 tw-border-emerald-800/50'
-        case 'error':
+        case UIToolStatus.Error:
             return 'tw-bg-red-950/30 tw-border-red-800/50'
-        case 'warning':
+        case UIToolStatus.Pending:
             return 'tw-bg-yellow-950/30 tw-border-yellow-800/50'
         default:
             return 'tw-bg-blue-950/30 tw-border-blue-800/50'
     }
 }
 
-const getStatusLabel = (status: string) => {
+const getStatusLabel = (status: UIToolStatus) => {
     switch (status) {
-        case 'success':
+        case UIToolStatus.Done:
             return 'Success'
-        case 'error':
+        case UIToolStatus.Error:
             return 'Error'
-        case 'warning':
-            return 'Warning'
         default:
             return 'Info'
     }
@@ -68,7 +66,7 @@ export const OutputStatusCell: FC<OutputStatusProps> = ({ item, className, defau
         return null
     }
 
-    const status = item.status || 'info'
+    const status = item.status || UIToolStatus.Info
     const StatusIcon = getStatusIcon(status)
 
     // Define headerContent directly as JSX

--- a/vscode/webviews/chat/cells/toolCell/OutputStatusCell.tsx
+++ b/vscode/webviews/chat/cells/toolCell/OutputStatusCell.tsx
@@ -101,6 +101,7 @@ export const OutputStatusCell: FC<OutputStatusProps> = ({ item, className, defau
             bodyContent={bodyContent}
             className={className}
             defaultOpen={defaultOpen}
+            status={item?.status}
         />
     )
 }

--- a/vscode/webviews/chat/cells/toolCell/SearchResultsCell.tsx
+++ b/vscode/webviews/chat/cells/toolCell/SearchResultsCell.tsx
@@ -119,21 +119,22 @@ export const SearchResultsCell: FC<SearchResultsProps> = ({
                                 <Button
                                     onClick={e => {
                                         e.preventDefault()
-                                        onFileLinkClicked(resultItem.uri)
+                                        const _uri = resultItem.uri
+                                        const _range = resultItem?.lineNumber
+                                            ? `:${Number.parseInt(resultItem.lineNumber) + 1}`
+                                            : ''
+                                        const uri = _uri.with({ path: `${_uri.path}${_range}` })
+                                        onFileLinkClicked(uri)
                                     }}
                                     variant="text"
                                     key={`${resultItem.fileName}-${index}`}
                                     className="tw-text-left tw-truncate tw-flex !tw-justify-start tw-py-1.5 tw-px-4 hover:tw-bg-zinc-900 tw-border-b tw-border-zinc-900 last:tw-border-b-0 tw-w-full !tw-items-center"
                                 >
-                                    <span className="tw-w-6 tw-text-right tw-text-zinc-500 tw-mr-3 tw-pt-0.5 tw-select-none">
-                                        {index + 1}
-                                    </span>
-
                                     <span className="tw-mr-2 tw-mt-0.5">{getIcon(resultItem.type)}</span>
                                     <div className="tw-flex tw-flex-col">
                                         <div className="tw-text-zinc-200">
                                             {resultItem.fileName}
-                                            {resultItem.lineNumber && (
+                                            {resultItem?.lineNumber && (
                                                 <span className="tw-text-zinc-500">
                                                     :{resultItem.lineNumber}
                                                 </span>

--- a/vscode/webviews/chat/cells/toolCell/SearchResultsCell.tsx
+++ b/vscode/webviews/chat/cells/toolCell/SearchResultsCell.tsx
@@ -112,7 +112,7 @@ export const SearchResultsCell: FC<SearchResultsProps> = ({
                             </div>
                         ))}
                     </div>
-                ) : (
+                ) : results?.length === 0 ? null : (
                     <div className="tw-overflow-x-auto tw-bg-zinc-950 tw-p-0">
                         <div className="tw-font-mono tw-text-xs tw-flex tw-flex-col tw-gap-1">
                             {generateSearchToolResults(results).map((resultItem, index) => (

--- a/vscode/webviews/chat/cells/toolCell/TerminalOutputCell.tsx
+++ b/vscode/webviews/chat/cells/toolCell/TerminalOutputCell.tsx
@@ -74,12 +74,8 @@ export const TerminalOutputCell: FC<TerminalOutputCellProps> = ({
     isLoading = false,
     defaultOpen = false,
 }) => {
-    const icon =
-        item.toolName === 'get_diagnostic'
-            ? item.status === UIToolStatus.Info
-                ? Bug
-                : BugOff
-            : Terminal
+    const isDiagnosticTool = item.toolName === 'get_diagnostic'
+    const icon = isDiagnosticTool ? (item.status === UIToolStatus.Info ? Bug : BugOff) : Terminal
     // Process content into lines if provided, otherwise use lines prop
     const lines = useMemo(() => {
         if (item?.content && item.content.trim() !== '') {
@@ -110,6 +106,7 @@ export const TerminalOutputCell: FC<TerminalOutputCellProps> = ({
     }
 
     const renderBodyContent = () => {
+        const isDiagnosticTool = item.toolName === 'get_diagnostic'
         if (isLoading || !lines?.length) {
             return (
                 <div className="tw-font-mono tw-text-xs tw-p-4 tw-bg-black tw-rounded-b-md tw-space-y-1">
@@ -143,7 +140,9 @@ export const TerminalOutputCell: FC<TerminalOutputCellProps> = ({
                             key={`${line.type}-${line.content}-${index}`}
                             className={cn(getLineClass(line.type))}
                         >
-                            {line.type === 'input' ? `$ ${line.content}` : line.content}
+                            {line.type === 'input' && !isDiagnosticTool
+                                ? `$ ${line.content}`
+                                : line.content}
                         </div>
                     )
                 })}
@@ -159,6 +158,7 @@ export const TerminalOutputCell: FC<TerminalOutputCellProps> = ({
             className={className}
             isLoading={isLoading}
             defaultOpen={defaultOpen}
+            status={item?.status}
         />
     )
 }

--- a/vscode/webviews/chat/cells/toolCell/TerminalOutputCell.tsx
+++ b/vscode/webviews/chat/cells/toolCell/TerminalOutputCell.tsx
@@ -127,6 +127,11 @@ export const TerminalOutputCell: FC<TerminalOutputCellProps> = ({
             )
         }
 
+        if (lines?.length < 2) {
+            // Since the first line is the name of the command, this means the result is empty.
+            return null
+        }
+
         return (
             <pre className="tw-font-mono tw-text-xs tw-p-4 tw-bg-black tw-rounded-b-md tw-overflow-x-auto">
                 {lines.map((line, index) => {

--- a/vscode/webviews/chat/cells/toolCell/ToolStatusCell.tsx
+++ b/vscode/webviews/chat/cells/toolCell/ToolStatusCell.tsx
@@ -40,7 +40,7 @@ export const ToolStatusCell: FC<ToolStatusProps> = ({ title, output }) => {
     if (output?.outputType === 'search-result' && output.searchResultItems) {
         return (
             <SearchResultsCell
-                query={output.title || ''}
+                query={output.title || 'Search result'}
                 results={output.searchResultItems}
                 onFileLinkClicked={onFileLinkClicked}
             />


### PR DESCRIPTION
This commit modifies the `PromptBuilder` class to exclude context items of type 'tool-state' when building context messages. These items are now handled as part of the chat messages.

The change filters the `this.contextItems` array to exclude items where `item.type === 'tool-state'` before processing them for inclusion in the prompt. This ensures that tool state information is not duplicated or misinterpreted within the prompt context.

Also fix UI bug where files are showing up with FileX icon

## Test Plan

1. Ask Cody in agent mode that requires opening a file
2. before this change, the file icon will show up with an X
3. After: show up with code file icon

After

<img width="657" alt="image" src="https://github.com/user-attachments/assets/34d28ee7-af36-40b5-a3e0-05e4666d705e" />

