### PR TITLE
chore(release): fix release notes step

### DIFF
--- a/.github/workflows/release-vscode-stable.yml
+++ b/.github/workflows/release-vscode-stable.yml
@@ -53,6 +53,8 @@ jobs:
           VSCODE_MARKETPLACE_TOKEN: ${{ secrets.VSCODE_MARKETPLACE_TOKEN }}
           VSCODE_OPENVSX_TOKEN: ${{ secrets.VSCODE_OPENVSX_TOKEN }}
       - run: pnpm -C vscode run release-notes
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       - name: create release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/release-vscode-stable.yml
+++ b/.github/workflows/release-vscode-stable.yml
@@ -60,7 +60,6 @@ jobs:
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
           tag_name: ${{ github.ref }}
           release_name: Cody for VS Code ${{ env.EXT_VERSION }}


### PR DESCRIPTION
Previously release notes were not being generated because of a missing anthropic key, this PR moves the env var to the right step in the workflow


## Test plan
tested release-notes.ts working locally with the key
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
