### PR TITLE
fix(path): handle empty path in basename function

### DIFF
--- a/lib/shared/src/common/path.test.ts
+++ b/lib/shared/src/common/path.test.ts
@@ -55,6 +55,8 @@ describe('pathFunctions', () => {
                 expect(posixFileUris.dirname('file:///a/b/')).toBe('file:///a')
             })
             test('basename', () => {
+                expect(posixFileUris.basename('')).toBe('')
+                expect(posixFileUris.basename('file:///')).toBe('')
                 expect(posixFileUris.basename('file:///a/b/c')).toBe('c')
                 expect(posixFileUris.basename('file:///a/b')).toBe('b')
                 expect(posixFileUris.basename('file:///a/b/')).toBe('b')
@@ -96,6 +98,7 @@ describe('pathFunctions', () => {
                 expect(windowsFilePaths.dirname('\\a')).toBe('\\')
             })
             test('basename', () => {
+                expect(windowsFilePaths.basename('C:\\')).toBe('')
                 expect(windowsFilePaths.basename('C:\\a\\b\\c')).toBe('c')
                 expect(windowsFilePaths.basename('C:\\a\\b')).toBe('b')
                 expect(windowsFilePaths.basename('C:\\a')).toBe('a')
@@ -134,6 +137,7 @@ describe('pathFunctions', () => {
                 expect(windowsFileUris.dirname('file:///C:/a/')).toBe('file:///C:')
             })
             test('basename', () => {
+                expect(windowsFilePaths.basename('')).toBe('')
                 expect(windowsFileUris.basename('file:///C:/a/b/c')).toBe('c')
                 expect(windowsFileUris.basename('file:///C:/a/b')).toBe('b')
                 expect(windowsFileUris.basename('file:///C:/a')).toBe('a')

--- a/lib/shared/src/common/path.ts
+++ b/lib/shared/src/common/path.ts
@@ -96,6 +96,9 @@ function pathFunctions(isWindows: boolean, sep: '\\' | '/', caseSensitive: boole
             return path
         },
         basename(path: string, suffix?: string): string {
+            if (path === '') {
+                return ''
+            }
             if (path.endsWith(sep)) {
                 path = path.slice(0, -1)
             }


### PR DESCRIPTION
The `basename` function was not handling empty paths correctly, leading to unexpected behavior. This commit adds a check for an empty path and returns an empty string in that case, ensuring consistent and correct behavior.

## Test Plan

Tests updated. Green CI.