### PR TITLE
fix/guardrails: In enforced mode, hide smart apply, etc. actions until attribution complete

### DIFF
--- a/lib/shared/src/guardrails/client.ts
+++ b/lib/shared/src/guardrails/client.ts
@@ -5,10 +5,10 @@ import { ClientConfigSingleton } from '../sourcegraph-api/clientConfig'
 import { graphqlClient } from '../sourcegraph-api/graphql/client'
 import { isError } from '../utils'
 
-// 10s timeout is enough to serve most attribution requests.
-// It's a better user experience for chat attribution to wait
-// a few seconds more and get attribution result.
-const defaultTimeoutSeconds = 10
+// This is a long timeout because attribution requests can be quite slow, and
+// loading one chat can generate multiple requests--one per generated code
+// block.
+const defaultTimeoutSeconds = 45
 
 /**
  * This defines the user controllable configuration. Note: enablement is

--- a/vscode/webviews/components/RichCodeBlock.tsx
+++ b/vscode/webviews/components/RichCodeBlock.tsx
@@ -170,7 +170,7 @@ export const RichCodeBlock: React.FC<RichCodeBlockProps> = ({
                     {/* Actions bar */}
                     <div className={styles.buttonsContainer}>
                         <div className={styles.buttons}>
-                            {actionButtons}
+                            {showCode && actionButtons}
                             <div className={styles.metadataContainer}>{guardrailsStatus}</div>
                         </div>
                     </div>


### PR DESCRIPTION
When Guardrails is in "enforced" mode, we want to prevent the user from using code until an attribution check is complete. Hide the action buttons until it is OK to show the code.

For Guardrails "permissive" mode, or no Guardrails, `showCode` is always `true` and we will show the action buttons as soon as the code is complete.

This also bumps the timeout for Guardrails attribution requests. These requests can easily take 20s+ for long code blocks.

Fixes CODY-5552, CODY-5551

## Test plan

Tested manually:

1. Set up an instance with `"attribution.enabled": true, "attribution.mode": "enforced"` and connect to it.
2. Generate more than 10 lines of code.
3. Check that the action buttons do not appear while "Checking Guardrails"