### PR TITLE
chore(cody): fix failing scip-typescript CI workflow

### DIFF
--- a/.github/workflows/scip-typescript.yml
+++ b/.github/workflows/scip-typescript.yml
@@ -41,19 +41,19 @@ jobs:
       - run: pnpm dlx @sourcegraph/scip-typescript index --pnpm-workspaces --no-global-caches
 
       - name: Upload SCIP to Cloud
-        run: pnpm dlx @sourcegraph/src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress
+        run: pnpm dlx @sourcegraph/src code-intel upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress
         env:
           SRC_ENDPOINT: https://sourcegraph.com/
           SRC_ACCESS_TOKEN: ${{ secrets.SRC_ACCESS_TOKEN_DOTCOM }}
 
       - name: Upload SCIP to S2
-        run: pnpm dlx @sourcegraph/src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress
+        run: pnpm dlx @sourcegraph/src code-intel upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress
         env:
           SRC_ENDPOINT: https://sourcegraph.sourcegraph.com/
           SRC_ACCESS_TOKEN: ${{ secrets.SRC_ACCESS_TOKEN_S2 }}
 
-      - name: Upload lsif to Demo
-        run: pnpm dlx @sourcegraph/src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress || true
+      - name: Upload SCIP to Demo
+        run: pnpm dlx @sourcegraph/src code-intel upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress || true
         env:
           SRC_ENDPOINT: https://demo.sourcegraph.com/
           SRC_ACCESS_TOKEN: ${{ secrets.SRC_ACCESS_TOKEN_DEMO }}


### PR DESCRIPTION
## Test plan
Green CI. This job should succeed now
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
