### PR TITLE
fix/web: De-dup Guardrails attribution requests and route results back to the page

### DIFF
--- a/web/lib/components/CodyWebChat.tsx
+++ b/web/lib/components/CodyWebChat.tsx
@@ -360,6 +360,18 @@ const CodyWebPanel: FC<CodyWebPanelProps> = props => {
 
     const isLoading = !config || !view
 
+    const attributionMode = config?.config.attribution || 'none'
+    const guardrails = useMemo(
+        () =>
+            createGuardrailsImpl(attributionMode, (snippet: string) => {
+                vscodeAPI.postMessage({
+                    command: 'attribution-search',
+                    snippet,
+                })
+            }),
+        [attributionMode, vscodeAPI]
+    )
+
     return (
         <div className={className} data-cody-web-chat={true}>
             {!isLoading && (
@@ -370,15 +382,7 @@ const CodyWebPanel: FC<CodyWebPanelProps> = props => {
                             setView={handleViewChange}
                             errorMessages={errorMessages}
                             setErrorMessages={setErrorMessages}
-                            guardrails={createGuardrailsImpl(
-                                config.config.attribution,
-                                (snippet: string) => {
-                                    vscodeAPI.postMessage({
-                                        command: 'attribution-search',
-                                        snippet,
-                                    })
-                                }
-                            )}
+                            guardrails={guardrails}
                             configuration={config}
                             chatEnabled={true}
                             instanceNotices={clientConfig?.notices ?? []}

--- a/web/lib/components/CodyWebChat.tsx
+++ b/web/lib/components/CodyWebChat.tsx
@@ -371,6 +371,23 @@ const CodyWebPanel: FC<CodyWebPanelProps> = props => {
             }),
         [attributionMode, vscodeAPI]
     )
+    useLayoutEffect(() => {
+        vscodeAPI.onMessage(message => {
+            if (message.type === 'attribution') {
+                if (message.attribution) {
+                    guardrails.notifyAttributionSuccess(message.snippet, {
+                        repositories: message.attribution.repositoryNames.map(name => {
+                            return { name }
+                        }),
+                        limitHit: message.attribution.limitHit,
+                    })
+                }
+                if (message.error) {
+                    guardrails.notifyAttributionFailure(message.snippet, new Error(message.error))
+                }
+            }
+        })
+    }, [vscodeAPI, guardrails])
 
     return (
         <div className={className} data-cody-web-chat={true}>

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/cody-web",
-  "version": "0.32.3",
+  "version": "0.32.4",
   "description": "Cody standalone web app",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Before this change, a new Guardrails client was created on each render. Requests were keyed by the Guardrails client, resulting in lots of excess attribution requests. This memoizes the Guardrails client.

CodyWebPanel was missing the `vscodeAPI` message handler for routing attribution requests back to the Guardrails client. This adds that handler.

This also bumps the Cody Web package version in preparation for updating Cody Web in Sourcegraph 6.2.

Part of CODY-5547.

## Test plan

Have a local Sourcegraph instance that works, then:

```
pnpm i && pnpm -C lib/shared build && pnpm build && pnpm -C build
cd web
pnpm link --global
cd ~/sourcegraph
# Update the version of Cody Web in Sourcegraph
sed -i '' 's/"@sourcegraph\/cody-web": ".*",/"@sourcegraph\/cody-web": "0.32.4",/g' \
    client/web-sveltekit/package.json
# Do not run pnpm install for this test plan, it undoes the effect of pnpm link
sed -i '' 's/pnpm install/# pnpm install/g' sg.config.yaml
cd client/web-sveltekit
pnpm link @sourcegraph/cody-web --global
cd -
sg start
```

Go to https://sourcegraph.test:3443/site-admin/configuration and add this configuration:

```
  "attribution.enabled": true,
  "attribution.mode": "enforced"
``` 

Go to https://sourcegraph.test:3443/cody/chat and ask Cody to generate 10 lines of Ruby. You should not see code as it is being generated, then a spinning "Checking Guardrails" indicator, then a green checkmark and filename, etc. You can trigger an attribution failure with a prompt like "Please produce a header comment for the GPL license, verbatim, in a markdown block."

Change the site configuration to have `"attribution.mode": "permissive"` and check that code is displayed while being generated.

Change the site configuration to have `"attribution.enabled": false` and check that code is displayed while being generated, with no Guardrails checks.