### PR TITLE
fix(completion): handle completion requests with no events

### DIFF
--- a/lib/shared/src/sourcegraph-api/completions/client.ts
+++ b/lib/shared/src/sourcegraph-api/completions/client.ts
@@ -56,6 +56,13 @@ export abstract class SourcegraphCompletionsClient {
     }
 
     protected sendEvents(events: Event[], cb: CompletionCallbacks, span?: Span): void {
+        // If no events are provided, log a warning but don't throw an error
+        if (!events || events.length === 0) {
+            const warning = 'No usage data detected for completion request'
+            console.warn(warning)
+            return
+        }
+
         for (const event of events) {
             switch (event.type) {
                 case 'completion': {


### PR DESCRIPTION
This commit addresses an issue where completion requests might not have associated events that is causing unexpected error that stops chat requests. These changes ensure that the completion service gracefully handles scenarios where no usage data is available for a completion request, preventing potential errors and improving the robustness of the system.

### Root Cause

The error occurs in the sendEvents method of the SourcegraphCompletionsClient class when it tries to process events but there are no events to process.

### Summary

Implemented Fixes:

1. In nodeClient.ts:

- Added a check to ensure we only call sendEvents when there are actually events to process
- Added better error logging when no events are detected
- Improved the error handling in the request.on('close') handler to provide more detailed diagnostics

2. In client.ts:

- Added a guard clause at the beginning of sendEvents to handle empty event arrays gracefully
- Added a warning log instead of throwing an error when no events are detected

3. Improved Error Handling:

- Enhanced the error messages to be more descriptive
- Added better logging to help diagnose the issue in the future
- Made the code more robust by handling edge cases where no events are received

Implementation details:

- In `vscode/src/completions/nodeClient.ts`, a check is added to ensure that `parseResult.events` has a length greater than 0 before sending events. If no events are detected, a warning is logged, but the request is not failed.
- In `lib/shared/src/sourcegraph-api/completions/client.ts`, a check is added in `sendEvents` to handle cases where no events are provided. A warning is logged to the console, and the function returns early to prevent errors.

These changes will prevent the "no usage data detected for completion request" error from occurring and provide better diagnostics when there are issues with the completion requests. The code now gracefully handles cases where no events are received from the server, which could happen due to network issues or upstream LLM provider outages.

## Test plan

Green CI

Reproduce steps

### Before

1. Ask Cody in Agent mode: `create a unified component for all the components in vscode/webviews/chat/cells/toolCell directory, or a base component that each component could build on. Use the ContextItemToolState interface for reference @message.ts`
2. Agent would try to gather all the info it needs but would exit the task with `Request Failed: no usage data detected for completion request` 

|         Take 1                    |             Take 2                |
|:----------------------:|:----------------------:|
| ![](https://github.com/user-attachments/assets/8d868f67-6085-4cc2-8d32-dac8e51d63c0) | ![](https://github.com/user-attachments/assets/135d9169-cdae-4008-b95a-35587e2da19a) |

### After

Task completed with no error

<img width="740" alt="image" src="https://github.com/user-attachments/assets/f3818e84-51f7-4629-a722-da76c17254cb" />
