### PR TITLE
fix(agent mode): initial context not included as context

### DIFF
--- a/vscode/src/chat/chat-view/handlers/AgenticHandler.ts
+++ b/vscode/src/chat/chat-view/handlers/AgenticHandler.ts
@@ -10,7 +10,6 @@ import {
     UIToolStatus,
     isDefined,
     logDebug,
-    wrapInActiveSpan,
 } from '@sourcegraph/cody-shared'
 import type { ContextItemToolState } from '@sourcegraph/cody-shared/src/codebase-context/messages'
 import { URI } from 'vscode-uri'
@@ -163,9 +162,6 @@ export class AgenticHandler extends ChatHandler implements AgentHandler {
                 }
 
                 turnCount++
-
-                // Reset the context items for the next turn
-                contextItems = []
             } catch (error) {
                 this.handleError(chatBuilder.sessionID, error, delegate, signal)
                 break
@@ -183,13 +179,13 @@ export class AgenticHandler extends ChatHandler implements AgentHandler {
         span: Span,
         signal: AbortSignal,
         model: string,
-        contextItems: ContextItem[] = []
+        contextItems: ContextItem[]
     ): Promise<{ botResponse: ChatMessage; toolCalls: Map<string, ToolCallContentPart> }> {
         // Create prompt
         const prompter = new AgenticChatPrompter(this.SYSTEM_PROMPT)
         const prompt = await prompter.makePrompt(chatBuilder, contextItems)
-        recorder.recordChatQuestionExecuted([], { addMetadata: true, current: span })
-
+        recorder.recordChatQuestionExecuted(contextItems, { addMetadata: true, current: span })
+        logDebug('AgenticHandler', 'Prompt created', { verbose: prompt })
         // Prepare API call parameters
         const params = {
             maxTokensToSample: 8000,
@@ -419,43 +415,41 @@ class AgenticChatPrompter {
     }
 
     public async makePrompt(chat: ChatBuilder, context: ContextItem[] = []): Promise<Message[]> {
-        return wrapInActiveSpan('AgenticChat.prompter', async () => {
-            const promptBuilder = await PromptBuilder.create(contextWindow)
+        const builder = await PromptBuilder.create(contextWindow)
 
-            // Add preamble messages
-            if (!promptBuilder.tryAddToPrefix([this.preamble])) {
-                throw new Error(`Preamble length exceeded context window ${contextWindow.input}`)
-            }
-
-            // Add existing chat transcript messages
-            const transcript = chat.getDehydratedMessages()
-            const reversedTranscript = [...transcript].reverse()
-
-            promptBuilder.tryAddMessages(reversedTranscript)
-
-            await this.tryAddContext(promptBuilder, context)
-
-            const historyItems = reversedTranscript
-                .flatMap(m => (m.contextFiles ? [...m.contextFiles].reverse() : []))
-                .filter(isDefined)
-
-            await this.tryAddContext(promptBuilder, historyItems, 'history')
-
-            return promptBuilder.build()
-        })
-    }
-
-    private async tryAddContext(
-        builder: PromptBuilder,
-        context: ContextItem[],
-        type = 'user'
-    ): Promise<void> {
-        try {
-            const contextItems = context.filter(item => item.type !== 'tool-state')
-            builder.tryAddContext(type === 'history' ? 'history' : 'user', contextItems)
-        } catch {
-            logDebug('AgenticChatPrompter', 'Error adding context to prompt')
-            return
+        // Add preamble messages
+        if (!builder.tryAddToPrefix([this.preamble])) {
+            throw new Error(`Preamble length exceeded context window ${contextWindow.input}`)
         }
+
+        // Add existing chat transcript messages
+        const transcript = chat.getDehydratedMessages()
+        const reversedTranscript = [...transcript].reverse()
+
+        builder.tryAddMessages(reversedTranscript)
+
+        if (context.length) {
+            const { added } = await builder.tryAddContext('user', transformItems(context))
+            chat.setLastMessageContext(added)
+        }
+
+        const historyItems = reversedTranscript
+            .flatMap(m => (m.contextFiles ? [...m.contextFiles].reverse() : []))
+            .filter(isDefined)
+
+        if (historyItems.length) {
+            await builder.tryAddContext('history', transformItems(historyItems))
+        }
+        return builder.build()
     }
+}
+function transformItems(items: ContextItem[]): ContextItem[] {
+    return items
+        .filter(item => item.type !== 'tool-state')
+        ?.map(i => {
+            if (i.type === 'file' && !i.range) {
+                i.content = i.content?.concat('\n<<EOF>>')
+            }
+            return i
+        })
 }

--- a/vscode/src/chat/chat-view/tools/file.ts
+++ b/vscode/src/chat/chat-view/tools/file.ts
@@ -21,11 +21,10 @@ export const getFileTool: AgentTool = {
             if (context === undefined || !context?.content) {
                 throw new Error(`File ${validInput.name} not found or empty`)
             }
-
             // For successful file retrieval
             return createFileToolState(
                 validInput.name,
-                context.content + '\nEOF', // Keep the EOF marker which can be useful
+                context.content + '\n<<EOF>>', // Keep the EOF marker which can be useful
                 UIToolStatus.Done,
                 context.uri // Use the actual file URI if available
             )


### PR DESCRIPTION
This commit improves context handling in the agentic chat feature and enhances file content processing within the file tool.

- The AgenticChatPrompter now directly manages context items, removing the need to reset them after each turn. It also streamlines the process of adding context and history items to the prompt.
- The file tool now appends "<<EOF>>" to the end of file content to ensure the LLM knows the end of the file.
- Updated the transformItems function to add the EOF marker to the file content.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

1. At mention a file and ask Cody in agent mode about it
2. Cody should be able to answer the question without using tool to fetch the file

<img width="663" alt="image" src="https://github.com/user-attachments/assets/53d01f6a-f62e-4e16-8782-3fd02a415111" />


### Before

it would try to find the file to answer the question

<img width="710" alt="image" src="https://github.com/user-attachments/assets/e1f040df-2e86-4ebc-91fb-080ba7607e4e" />

