### PR TITLE
fix(agentic-chat): Improve the UI for pinning the model when Agentic mode is selected (CODY-5449)

### DIFF
--- a/lib/shared/src/models/sync.ts
+++ b/lib/shared/src/models/sync.ts
@@ -327,6 +327,22 @@ export function syncModels({
                                                     data.preferences!.defaults.chat = haikuModel.id
                                                 }
 
+                                                // Add special tag to Claude 3.7 Sonnet for agentic mode
+                                                data.primaryModels = data.primaryModels.map(model => {
+                                                    if (
+                                                        model.title?.toLowerCase() ===
+                                                        'claude 3.7 sonnet'
+                                                    ) {
+                                                        return {
+                                                            ...model,
+                                                            tags: [
+                                                                ...model.tags,
+                                                                ModelTag.AgenticCompatible,
+                                                            ],
+                                                        }
+                                                    }
+                                                    return model
+                                                })
                                                 return Observable.of(data)
                                             }
                                         )

--- a/lib/shared/src/models/sync.ts
+++ b/lib/shared/src/models/sync.ts
@@ -326,19 +326,14 @@ export function syncModels({
                                                 ) {
                                                     data.preferences!.defaults.chat = haikuModel.id
                                                 }
-
-                                                // Add special tag to Claude 3.7 Sonnet for agentic mode
                                                 data.primaryModels = data.primaryModels.map(model => {
                                                     if (
-                                                        model.title?.toLowerCase() ===
-                                                        'claude 3.7 sonnet'
+                                                        model.modelRef ===
+                                                        data.preferences!.defaults.chat
                                                     ) {
                                                         return {
                                                             ...model,
-                                                            tags: [
-                                                                ...model.tags,
-                                                                ModelTag.AgenticCompatible,
-                                                            ],
+                                                            tags: [...model.tags, ModelTag.Default],
                                                         }
                                                     }
                                                     return model

--- a/lib/shared/src/models/tags.ts
+++ b/lib/shared/src/models/tags.ts
@@ -36,5 +36,5 @@ export enum ModelTag {
     Vision = 'vision', // Model supports vision capabilities
     Reasoning = 'reasoning', // Model supports reasoning capabilities
     Tools = 'tools', // Model supports tools capabilities
-    AgenticCompatible = 'agentic-compatible', // Model is compatible with agentic mode
+    Default = 'default', // Default Model
 }

--- a/lib/shared/src/models/tags.ts
+++ b/lib/shared/src/models/tags.ts
@@ -36,4 +36,5 @@ export enum ModelTag {
     Vision = 'vision', // Model supports vision capabilities
     Reasoning = 'reasoning', // Model supports reasoning capabilities
     Tools = 'tools', // Model supports tools capabilities
+    AgenticCompatible = 'agentic-compatible', // Model is compatible with agentic mode
 }

--- a/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/Toolbar.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/Toolbar.tsx
@@ -155,6 +155,7 @@ export const Toolbar: FunctionComponent<{
                     modelSelectorRef={modelSelectorRef}
                     className="tw-mr-1"
                     extensionAPI={extensionAPI}
+                    intent={intent}
                 />
             </div>
             <div className="tw-flex-1 tw-flex tw-justify-end">
@@ -188,9 +189,24 @@ const ModelSelectFieldToolbarItem: FunctionComponent<{
     className?: string
     extensionAPI: WebviewToExtensionAPI
     modelSelectorRef: React.MutableRefObject<{ open: () => void; close: () => void } | null>
-}> = ({ userInfo, focusEditor, className, models, extensionAPI, modelSelectorRef }) => {
+    intent?: ChatMessage['intent']
+}> = ({ userInfo, focusEditor, className, models, extensionAPI, modelSelectorRef, intent }) => {
     const clientConfig = useClientConfig()
     const serverSentModelsEnabled = !!clientConfig?.modelsAPIEnabled
+
+    const agenticModel = useMemo(
+        () => models.find(m => m.tags.includes(ModelTag.AgenticCompatible)),
+        [models]
+    )
+
+    // If in agentic mode, ensure the agentic model is selected
+    useEffect(() => {
+        if (intent === 'agentic' && agenticModel && models[0]?.id !== agenticModel.id) {
+            extensionAPI.setChatModel(agenticModel.id).subscribe({
+                error: error => console.error('Failed to set chat model:', error),
+            })
+        }
+    }, [intent, agenticModel, models, extensionAPI.setChatModel])
 
     const onModelSelect = useCallback(
         (model: Model) => {
@@ -214,6 +230,7 @@ const ModelSelectFieldToolbarItem: FunctionComponent<{
                 data-testid="chat-model-selector"
                 modelSelectorRef={modelSelectorRef}
                 onCloseByEscape={() => modelSelectorRef?.current?.close()}
+                intent={intent}
             />
         )
     )

--- a/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/Toolbar.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/Toolbar.tsx
@@ -155,7 +155,6 @@ export const Toolbar: FunctionComponent<{
                     modelSelectorRef={modelSelectorRef}
                     className="tw-mr-1"
                     extensionAPI={extensionAPI}
-                    intent={intent}
                 />
             </div>
             <div className="tw-flex-1 tw-flex tw-justify-end">
@@ -189,8 +188,7 @@ const ModelSelectFieldToolbarItem: FunctionComponent<{
     className?: string
     extensionAPI: WebviewToExtensionAPI
     modelSelectorRef: React.MutableRefObject<{ open: () => void; close: () => void } | null>
-    intent?: ChatMessage['intent']
-}> = ({ userInfo, focusEditor, className, models, extensionAPI, modelSelectorRef, intent }) => {
+}> = ({ userInfo, focusEditor, className, models, extensionAPI, modelSelectorRef }) => {
     const clientConfig = useClientConfig()
     const serverSentModelsEnabled = !!clientConfig?.modelsAPIEnabled
 
@@ -216,7 +214,6 @@ const ModelSelectFieldToolbarItem: FunctionComponent<{
                 data-testid="chat-model-selector"
                 modelSelectorRef={modelSelectorRef}
                 onCloseByEscape={() => modelSelectorRef?.current?.close()}
-                intent={intent}
             />
         )
     )

--- a/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/Toolbar.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/Toolbar.tsx
@@ -194,10 +194,7 @@ const ModelSelectFieldToolbarItem: FunctionComponent<{
     const clientConfig = useClientConfig()
     const serverSentModelsEnabled = !!clientConfig?.modelsAPIEnabled
 
-    const agenticModel = useMemo(
-        () => models.find(m => m.tags.includes(ModelTag.AgenticCompatible)),
-        [models]
-    )
+    const agenticModel = useMemo(() => models.find(m => m.tags.includes(ModelTag.Default)), [models])
 
     // If in agentic mode, ensure the agentic model is selected
     useEffect(() => {

--- a/vscode/webviews/components/modelSelectField/ModelSelectField.story.tsx
+++ b/vscode/webviews/components/modelSelectField/ModelSelectField.story.tsx
@@ -25,6 +25,14 @@ const MODELS: Model[] = [
         usage: [ModelUsage.Chat],
         tags: [ModelTag.Pro, ModelTag.Experimental],
     },
+    {
+        title: 'Claude 3.7 Sonnet',
+        provider: 'anthropic',
+        id: 'anthropic/claude-3-7-sonnet',
+        contextWindow: { input: 175000, output: 8000 },
+        usage: [ModelUsage.Chat],
+        tags: [ModelTag.Power],
+    },
 ]
 
 const meta: Meta<typeof ModelSelectField> = {
@@ -82,5 +90,16 @@ export const EnterpriseUser: Story = {
             isCodyProUser: false,
         },
         serverSentModelsEnabled: true,
+    },
+}
+
+// The model selector's value is always Claude 3.7 Sonnet in agentic mode
+export const AgenticMode: Story = {
+    args: {
+        userInfo: {
+            isDotComUser: true,
+            isCodyProUser: true,
+        },
+        intent: 'agentic',
     },
 }

--- a/vscode/webviews/components/modelSelectField/ModelSelectField.story.tsx
+++ b/vscode/webviews/components/modelSelectField/ModelSelectField.story.tsx
@@ -25,14 +25,6 @@ const MODELS: Model[] = [
         usage: [ModelUsage.Chat],
         tags: [ModelTag.Pro, ModelTag.Experimental],
     },
-    {
-        title: 'Claude 3.7 Sonnet',
-        provider: 'anthropic',
-        id: 'anthropic/claude-3-7-sonnet',
-        contextWindow: { input: 175000, output: 8000 },
-        usage: [ModelUsage.Chat],
-        tags: [ModelTag.Power],
-    },
 ]
 
 const meta: Meta<typeof ModelSelectField> = {
@@ -90,16 +82,5 @@ export const EnterpriseUser: Story = {
             isCodyProUser: false,
         },
         serverSentModelsEnabled: true,
-    },
-}
-
-// The model selector's value is always Claude 3.7 Sonnet in agentic mode
-export const AgenticMode: Story = {
-    args: {
-        userInfo: {
-            isDotComUser: true,
-            isCodyProUser: true,
-        },
-        intent: 'agentic',
     },
 }

--- a/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
+++ b/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
@@ -1,8 +1,8 @@
-import { type Model, ModelTag, isCodyProModel } from '@sourcegraph/cody-shared'
+import { type ChatMessage, type Model, ModelTag, isCodyProModel } from '@sourcegraph/cody-shared'
 import { isMacOS } from '@sourcegraph/cody-shared'
 import { DeepCodyAgentID, ToolCodyModelName } from '@sourcegraph/cody-shared/src/models/client'
 import { clsx } from 'clsx'
-import { BookOpenIcon, BrainIcon, BuildingIcon, ExternalLinkIcon } from 'lucide-react'
+import { AlertTriangleIcon, BookOpenIcon, BrainIcon, BuildingIcon, ExternalLinkIcon } from 'lucide-react'
 import { type FunctionComponent, type ReactNode, useCallback, useMemo } from 'react'
 import type { UserAccountInfo } from '../../Chat'
 import { getVSCodeAPI } from '../../utils/VSCodeApi'
@@ -35,6 +35,8 @@ export const ModelSelectField: React.FunctionComponent<{
     onCloseByEscape?: () => void
     className?: string
 
+    intent?: ChatMessage['intent']
+
     /** For storybooks only. */
     __storybook__open?: boolean
     modelSelectorRef?: React.MutableRefObject<{ open: () => void; close: () => void } | null>
@@ -45,6 +47,7 @@ export const ModelSelectField: React.FunctionComponent<{
     userInfo,
     onCloseByEscape,
     className,
+    intent,
     __storybook__open,
     modelSelectorRef,
 }) => {
@@ -91,6 +94,7 @@ export const ModelSelectField: React.FunctionComponent<{
             showCodyProBadge,
             parentOnModelSelect,
             isCodyProUser,
+            intent,
         ]
     )
 
@@ -119,7 +123,7 @@ export const ModelSelectField: React.FunctionComponent<{
     const options = useMemo<SelectListOption[]>(
         () =>
             models.map(m => {
-                const availability = modelAvailability(userInfo, serverSentModelsEnabled, m)
+                const availability = modelAvailability(userInfo, serverSentModelsEnabled, m, intent)
                 return {
                     value: m.id,
                     title: (
@@ -137,7 +141,7 @@ export const ModelSelectField: React.FunctionComponent<{
                     tooltip: getTooltip(m, availability),
                 } satisfies SelectListOption
             }),
-        [models, userInfo, serverSentModelsEnabled]
+        [models, userInfo, serverSentModelsEnabled, intent]
     )
     const optionsByGroup: { group: string; options: SelectListOption[] }[] = useMemo(() => {
         return optionByGroup(options)
@@ -183,6 +187,14 @@ export const ModelSelectField: React.FunctionComponent<{
                     className={`focus:tw-outline-none ${styles.chatModelPopover}`}
                     data-testid="chat-model-popover"
                 >
+                    {intent === 'agentic' && (
+                        <div className="tw-pl-5 tw-pr-3 tw-py-1.5 tw-text-sm tw-text-foreground tw-flex tw-justify-center">
+                            <div className="tw-flex tw-items-start tw-gap-2 tw-bg-muted tw-px-2 tw-py-0.5 tw-rounded">
+                                <AlertTriangleIcon className="tw-w-[16px] tw-h-[16px] tw-mt-[2px]" />
+                                <span className="tw-leading-4 tw-font-semibold">Only Claude 3.7 Sonnet is currently available in Agent Mode</span>
+                            </div>
+                        </div>
+                    )}
                     <CommandList
                         className="model-selector-popover tw-max-h-[80vh] tw-overflow-y-auto"
                         data-testid="chat-model-popover-option"
@@ -290,13 +302,18 @@ type ModelAvailability = 'available' | 'needs-cody-pro' | 'not-selectable-on-ent
 function modelAvailability(
     userInfo: Pick<UserAccountInfo, 'isCodyProUser' | 'isDotComUser'>,
     serverSentModelsEnabled: boolean,
-    model: Model
+    model: Model,
+    intent?: ChatMessage['intent']
 ): ModelAvailability {
     if (!userInfo.isDotComUser && !serverSentModelsEnabled) {
         return 'not-selectable-on-enterprise'
     }
     if (isCodyProModel(model) && userInfo.isDotComUser && !userInfo.isCodyProUser) {
         return 'needs-cody-pro'
+    }
+    // For agentic mode, only allow models with the AgenticCompatible tag (Claude 3.7 Sonnet)
+    if (intent === 'agentic' && !model.tags.includes(ModelTag.AgenticCompatible)) {
+        return 'not-selectable-on-enterprise'
     }
     return 'available'
 }

--- a/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
+++ b/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
@@ -313,7 +313,7 @@ function modelAvailability(
         return 'needs-cody-pro'
     }
     // For agentic mode, only allow models with the AgenticCompatible tag (Claude 3.7 Sonnet)
-    if (intent === 'agentic' && !model.tags.includes(ModelTag.AgenticCompatible)) {
+    if (intent === 'agentic' && !model.tags.includes(ModelTag.Default)) {
         return 'not-selectable-on-enterprise'
     }
     return 'available'

--- a/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
+++ b/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
@@ -1,4 +1,4 @@
-import { type ChatMessage, type Model, ModelTag, isCodyProModel } from '@sourcegraph/cody-shared'
+import { type Model, ModelTag, isCodyProModel } from '@sourcegraph/cody-shared'
 import { isMacOS } from '@sourcegraph/cody-shared'
 import { DeepCodyAgentID, ToolCodyModelName } from '@sourcegraph/cody-shared/src/models/client'
 import { clsx } from 'clsx'
@@ -35,8 +35,6 @@ export const ModelSelectField: React.FunctionComponent<{
     onCloseByEscape?: () => void
     className?: string
 
-    intent?: ChatMessage['intent']
-
     /** For storybooks only. */
     __storybook__open?: boolean
     modelSelectorRef?: React.MutableRefObject<{ open: () => void; close: () => void } | null>
@@ -47,7 +45,6 @@ export const ModelSelectField: React.FunctionComponent<{
     userInfo,
     onCloseByEscape,
     className,
-    intent,
     __storybook__open,
     modelSelectorRef,
 }) => {
@@ -97,8 +94,8 @@ export const ModelSelectField: React.FunctionComponent<{
         ]
     )
 
-    // Readonly if the intent is agentic or they are an enterprise user that does not support server-sent models
-    const readOnly = intent === 'agentic' || !(userInfo.isDotComUser || serverSentModelsEnabled)
+    // Readonly if they are an enterprise user that does not support server-sent models
+    const readOnly = !(userInfo.isDotComUser || serverSentModelsEnabled)
 
     const onOpenChange = useCallback(
         (open: boolean): void => {
@@ -280,11 +277,7 @@ export const ModelSelectField: React.FunctionComponent<{
                 },
             }}
         >
-            {intent === 'agentic'
-                ? 'Claude 3.7 Sonnet'
-                : value !== undefined
-                  ? options.find(option => option.value === value)?.title
-                  : 'Select...'}
+            {value !== undefined ? options.find(option => option.value === value)?.title : 'Select...'}
         </ToolbarPopoverItem>
     )
 }

--- a/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
+++ b/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
@@ -94,7 +94,6 @@ export const ModelSelectField: React.FunctionComponent<{
             showCodyProBadge,
             parentOnModelSelect,
             isCodyProUser,
-            intent,
         ]
     )
 
@@ -191,7 +190,9 @@ export const ModelSelectField: React.FunctionComponent<{
                         <div className="tw-pl-5 tw-pr-3 tw-py-1.5 tw-text-sm tw-text-foreground tw-flex tw-justify-center">
                             <div className="tw-flex tw-items-start tw-gap-2 tw-bg-muted tw-px-2 tw-py-0.5 tw-rounded">
                                 <AlertTriangleIcon className="tw-w-[16px] tw-h-[16px] tw-mt-[2px]" />
-                                <span className="tw-leading-4 tw-font-semibold">Only Claude 3.7 Sonnet is currently available in Agent Mode</span>
+                                <span className="tw-leading-4 tw-font-semibold">
+                                    Only Claude 3.7 Sonnet is currently available in Agent Mode
+                                </span>
                             </div>
                         </div>
                     )}


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-5449/better-ui-for-pinning-the-model-when-agentic-mode-is-selected#comment-115188f6

In agent mode
- enable the model dropdown button
- when user opens the menu, all other models are disabled. a call out is shown at the drop of the dropdown: "Only Claude 3.7 Sonnet is currently available in Agent Mode"

## Test plan
<img width="428" alt="Screenshot 2025-03-27 at 4 42 01 PM" src="https://github.com/user-attachments/assets/4a4e99d4-9e6b-417a-bbc0-517bf5127a02" />


Loom: https://www.loom.com/share/5dc7f3e75c4f48cab44e5351a58fa2ee
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
