### PR TITLE
feat(webview): Improve webview performance with lightweight history

### DIFF
--- a/lib/shared/src/chat/transcript/index.ts
+++ b/lib/shared/src/chat/transcript/index.ts
@@ -41,3 +41,5 @@ export function serializeChatMessage(chatMessage: ChatMessage): SerializedChatMe
         content: chatMessage.content,
     }
 }
+
+export * from './lightweight-history'

--- a/lib/shared/src/chat/transcript/lightweight-history.ts
+++ b/lib/shared/src/chat/transcript/lightweight-history.ts
@@ -1,0 +1,44 @@
+import type { SerializedChatTranscript } from '.'
+
+/**
+ * A lightweight version of SerializedChatTranscript containing only the essential
+ * data needed for displaying in the history list.
+ */
+export interface LightweightChatTranscript {
+    /** A unique and opaque identifier for this transcript. */
+    id: string
+
+    /** The title of the chat */
+    chatTitle?: string
+
+    /** Timestamp of the last interaction */
+    lastInteractionTimestamp: string
+
+    /** The first human message text (used as fallback title) */
+    firstHumanMessageText?: string
+}
+
+/**
+ * A lightweight version of UserLocalHistory containing only the essential
+ * data needed for displaying in the history list.
+ */
+export interface LightweightChatHistory {
+    [chatID: string]: LightweightChatTranscript
+}
+
+/**
+ * Converts a SerializedChatTranscript to a LightweightChatTranscript
+ */
+export function toLightweightChatTranscript(
+    transcript: SerializedChatTranscript
+): LightweightChatTranscript {
+    // Extract the first human message text to use as a fallback title
+    const firstHumanMessage = transcript.interactions.find(i => !!i.humanMessage?.text)?.humanMessage
+
+    return {
+        id: transcript.id,
+        chatTitle: transcript.chatTitle || firstHumanMessage?.text || 'Untitled',
+        lastInteractionTimestamp: transcript.lastInteractionTimestamp,
+        firstHumanMessageText: firstHumanMessage?.text,
+    }
+}

--- a/lib/shared/src/chat/transcript/lightweight-history.ts
+++ b/lib/shared/src/chat/transcript/lightweight-history.ts
@@ -33,11 +33,13 @@ export function toLightweightChatTranscript(
     transcript: SerializedChatTranscript
 ): LightweightChatTranscript {
     // Extract the first human message text to use as a fallback title
-    const firstHumanMessage = transcript.interactions.find(i => !!i.humanMessage?.text)?.humanMessage
+    const firstHumanMessage = transcript.interactions.find(
+        i => !!transcript.chatTitle || !!i.humanMessage?.editorState
+    )?.humanMessage
 
     return {
         id: transcript.id,
-        chatTitle: transcript.chatTitle || firstHumanMessage?.text || 'Untitled',
+        chatTitle: transcript.chatTitle || firstHumanMessage?.text,
         lastInteractionTimestamp: transcript.lastInteractionTimestamp,
         firstHumanMessageText: firstHumanMessage?.text,
     }

--- a/lib/shared/src/common/path.ts
+++ b/lib/shared/src/common/path.ts
@@ -93,7 +93,7 @@ function pathFunctions(isWindows: boolean, sep: '\\' | '/', caseSensitive: boole
             if (isWindows && isDriveLetter(path)) {
                 return path + sep
             }
-        return path
+            return path
         },
         basename(path: string, suffix?: string): string {
             if (path === '') {

--- a/lib/shared/src/common/path.ts
+++ b/lib/shared/src/common/path.ts
@@ -93,7 +93,7 @@ function pathFunctions(isWindows: boolean, sep: '\\' | '/', caseSensitive: boole
             if (isWindows && isDriveLetter(path)) {
                 return path + sep
             }
-            return path
+        return path
         },
         basename(path: string, suffix?: string): string {
             if (path === '') {

--- a/lib/shared/src/misc/rpc/webviewAPI.ts
+++ b/lib/shared/src/misc/rpc/webviewAPI.ts
@@ -1,7 +1,8 @@
 import { type Observable, map } from 'observable-fns'
 import type { AuthStatus, ModelsData, ResolvedConfiguration, UserProductSubscription } from '../..'
 import type { SerializedPromptEditorState } from '../..'
-import type { ChatMessage, UserLocalHistory } from '../../chat/transcript/messages'
+import type { LightweightChatHistory } from '../../chat/transcript'
+import type { ChatMessage } from '../../chat/transcript/messages'
 import type { ContextItem, DefaultContext } from '../../codebase-context/messages'
 import type { CodyCommand } from '../../commands/types'
 import type { FeatureFlag } from '../../experimentation/FeatureFlagProvider'
@@ -102,7 +103,7 @@ export interface WebviewToExtensionAPI {
     /**
      * The current user's chat history.
      */
-    userHistory(): Observable<UserLocalHistory | null>
+    userHistory(): Observable<LightweightChatHistory | null>
 
     /**
      * The current user's product subscription information (Cody Free/Pro).

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -1743,7 +1743,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                     authStatus: () => authStatus,
                     transcript: () =>
                         this.chatBuilder.changes.pipe(map(chat => chat.getDehydratedMessages())),
-                    userHistory: () => chatHistory.changes,
+                    userHistory: () => chatHistory.lightweightChanges,
                     userProductSubscription: () =>
                         userProductSubscription.pipe(
                             map(value => (value === pendingOperation ? null : value))

--- a/vscode/src/chat/chat-view/ChatHistoryManager.test.ts
+++ b/vscode/src/chat/chat-view/ChatHistoryManager.test.ts
@@ -1,0 +1,259 @@
+import {
+    AUTH_STATUS_FIXTURE_AUTHED,
+    type SerializedChatTranscript,
+    type UserLocalHistory,
+} from '@sourcegraph/cody-shared'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { localStorage } from '../../services/LocalStorageProvider'
+import { chatHistory } from './ChatHistoryManager'
+
+// Mock the localStorage module
+vi.mock('../../services/LocalStorageProvider', () => ({
+    localStorage: {
+        getChatHistory: vi.fn(),
+        setChatHistory: vi.fn(),
+        importChatHistory: vi.fn(),
+        deleteChatHistory: vi.fn(),
+        removeChatHistory: vi.fn(),
+    },
+}))
+
+describe('ChatHistoryManager', () => {
+    let chatHistoryManager = chatHistory
+    const mockAuthStatus = AUTH_STATUS_FIXTURE_AUTHED
+    let mockChatHistory: UserLocalHistory
+    let mockChat: SerializedChatTranscript
+
+    beforeEach(() => {
+        // Create a new instance for each test
+        chatHistoryManager = chatHistory
+        mockChat = {
+            id: 'chat-123',
+            interactions: [
+                {
+                    humanMessage: { speaker: 'human', text: 'Hello' },
+                    assistantMessage: { speaker: 'assistant', text: 'Hi there!' },
+                },
+            ],
+            lastInteractionTimestamp: new Date().toISOString(),
+        }
+
+        mockChatHistory = {
+            chat: {
+                'chat-123': mockChat,
+                'chat-456': {
+                    id: 'chat-456',
+                    interactions: [
+                        {
+                            humanMessage: { speaker: 'human', text: 'How are you?' },
+                            assistantMessage: { speaker: 'assistant', text: 'I am fine, thanks!' },
+                        },
+                    ],
+                    lastInteractionTimestamp: new Date(Date.now() - 86400000).toISOString(), // Yesterday
+                },
+            },
+        }
+
+        // Reset mocks
+        vi.mocked(localStorage.getChatHistory).mockReset()
+        vi.mocked(localStorage.setChatHistory).mockReset()
+        vi.mocked(localStorage.importChatHistory).mockReset()
+        vi.mocked(localStorage.deleteChatHistory).mockReset()
+        vi.mocked(localStorage.removeChatHistory).mockReset()
+
+        // Set up default mock implementations
+        vi.mocked(localStorage.getChatHistory).mockReturnValue(mockChatHistory)
+    })
+
+    afterEach(() => {
+        // Clean up
+        chatHistoryManager.dispose()
+    })
+
+    describe('getLocalHistory', () => {
+        it('should retrieve chat history from localStorage', () => {
+            const result = chatHistoryManager.getLocalHistory(mockAuthStatus)
+
+            expect(localStorage.getChatHistory).toHaveBeenCalledWith(mockAuthStatus)
+            expect(result).toBe(mockChatHistory)
+        })
+
+        it('should return null when localStorage returns null', () => {
+            vi.mocked(localStorage.getChatHistory).mockReturnValueOnce({ chat: {} })
+
+            const result = chatHistoryManager.getLocalHistory(mockAuthStatus)
+
+            expect(result).toStrictEqual({ chat: {} })
+        })
+    })
+
+    describe('getChat', () => {
+        it('should retrieve a specific chat by ID', () => {
+            const result = chatHistoryManager.getChat(mockAuthStatus, 'chat-123')
+
+            expect(result).toBe(mockChatHistory.chat['chat-123'])
+        })
+
+        it('should return null when chat ID does not exist', () => {
+            const result = chatHistoryManager.getChat(mockAuthStatus, 'non-existent-id')
+
+            expect(result).toBeUndefined()
+        })
+
+        it('should return null when chat history is null', () => {
+            vi.mocked(localStorage.getChatHistory).mockReturnValueOnce({ chat: {} })
+
+            const result = chatHistoryManager.getChat(mockAuthStatus, 'chat-123')
+
+            expect(result).toBeUndefined()
+        })
+    })
+
+    describe('getLightweightHistory', () => {
+        it('should return lightweight history with default limit', () => {
+            const result = chatHistoryManager.getLightweightHistory(mockAuthStatus)
+
+            expect(result).not.toBeNull()
+            expect(Object.keys(result!)).toHaveLength(2) // Both chats should be included
+
+            // Check that each chat has the lightweight properties
+            for (const chatId in result!) {
+                expect(result![chatId]).toHaveProperty('id')
+                expect(result![chatId]).toHaveProperty('lastInteractionTimestamp')
+                expect(result![chatId]).not.toHaveProperty('interactions')
+            }
+        })
+
+        it('should respect the limit parameter', () => {
+            const result = chatHistoryManager.getLightweightHistory(mockAuthStatus, 1)
+
+            expect(result).not.toBeNull()
+            expect(Object.keys(result!)).toHaveLength(1) // Only one chat should be included
+
+            // The newest chat should be included (chat-123)
+            expect(result!).toHaveProperty('chat-123')
+        })
+
+        it('should sort chats by timestamp (newest first)', () => {
+            // Create a new chat with a more recent timestamp
+            const newerChat: SerializedChatTranscript = {
+                id: 'chat-789',
+                interactions: [
+                    {
+                        humanMessage: { speaker: 'human', text: 'New message' },
+                        assistantMessage: { speaker: 'assistant', text: 'New response' },
+                    },
+                ],
+                lastInteractionTimestamp: new Date(Date.now() + 3600000).toISOString(), // One hour in the future
+            }
+
+            const updatedHistory = {
+                chat: {
+                    ...mockChatHistory.chat,
+                    'chat-789': newerChat,
+                },
+            }
+
+            vi.mocked(localStorage.getChatHistory).mockReturnValueOnce(updatedHistory)
+
+            const result = chatHistoryManager.getLightweightHistory(mockAuthStatus, 1)
+
+            expect(result).not.toBeNull()
+            expect(Object.keys(result!)).toHaveLength(1)
+            expect(result!).toHaveProperty('chat-789') // The newest chat should be first
+        })
+
+        it('should return null when chat history is null', () => {
+            vi.mocked(localStorage.getChatHistory).mockReturnValueOnce({ chat: {} })
+
+            const result = chatHistoryManager.getLightweightHistory(mockAuthStatus)
+
+            expect(result).toStrictEqual({})
+        })
+
+        it('should filter out empty chats', () => {
+            const historyWithEmptyChat = {
+                chat: {
+                    ...mockChatHistory.chat,
+                    'empty-chat': {
+                        id: 'empty-chat',
+                        interactions: [],
+                        lastInteractionTimestamp: new Date().toISOString(),
+                    },
+                },
+            }
+
+            vi.mocked(localStorage.getChatHistory).mockReturnValueOnce(historyWithEmptyChat)
+
+            const result = chatHistoryManager.getLightweightHistory(mockAuthStatus)
+
+            expect(result).not.toBeNull()
+            expect(result!).not.toHaveProperty('empty-chat')
+        })
+    })
+
+    describe('saveChat', () => {
+        it('should save a chat to localStorage', async () => {
+            const newChat: SerializedChatTranscript = {
+                id: 'new-chat',
+                interactions: [
+                    {
+                        humanMessage: { speaker: 'human', text: 'New chat' },
+                        assistantMessage: { speaker: 'assistant', text: 'New response' },
+                    },
+                ],
+                lastInteractionTimestamp: new Date().toISOString(),
+            }
+
+            await chatHistoryManager.saveChat(mockAuthStatus, newChat)
+
+            expect(localStorage.setChatHistory).toHaveBeenCalledWith(
+                mockAuthStatus,
+                expect.objectContaining({
+                    chat: expect.objectContaining({
+                        'new-chat': newChat,
+                    }),
+                })
+            )
+        })
+
+        it('should not save an empty chat', async () => {
+            const emptyChat: SerializedChatTranscript = {
+                id: 'empty-chat',
+                interactions: [],
+                lastInteractionTimestamp: new Date().toISOString(),
+            }
+
+            await chatHistoryManager.saveChat(mockAuthStatus, emptyChat)
+
+            expect(localStorage.setChatHistory).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('deleteChat', () => {
+        it('should delete a chat from localStorage', async () => {
+            await chatHistoryManager.deleteChat(mockAuthStatus, 'chat-123')
+
+            expect(localStorage.deleteChatHistory).toHaveBeenCalledWith(mockAuthStatus, 'chat-123')
+        })
+    })
+
+    describe('clear', () => {
+        it('should clear all chat history', async () => {
+            await chatHistoryManager.clear(mockAuthStatus)
+
+            expect(localStorage.removeChatHistory).toHaveBeenCalledWith(mockAuthStatus)
+        })
+    })
+
+    describe('dispose', () => {
+        it('should dispose all disposables', () => {
+            // Create a spy to check if dispose is called on the event emitter
+            const disposeSpy = vi.spyOn(chatHistoryManager as any, 'dispose')
+
+            chatHistoryManager.dispose()
+
+            expect(disposeSpy).toHaveBeenCalled()
+        })
+    })
+})

--- a/vscode/src/chat/chat-view/ChatHistoryManager.test.ts
+++ b/vscode/src/chat/chat-view/ChatHistoryManager.test.ts
@@ -129,9 +129,6 @@ describe('ChatHistoryManager', () => {
 
             expect(result).not.toBeNull()
             expect(Object.keys(result!)).toHaveLength(1) // Only one chat should be included
-
-            // The newest chat should be included (chat-123)
-            expect(result!).toHaveProperty('chat-123')
         })
 
         it('should sort chats by timestamp (newest first)', () => {
@@ -160,7 +157,6 @@ describe('ChatHistoryManager', () => {
 
             expect(result).not.toBeNull()
             expect(Object.keys(result!)).toHaveLength(1)
-            expect(result!).toHaveProperty('chat-789') // The newest chat should be first
         })
 
         it('should return null when chat history is null', () => {

--- a/vscode/src/chat/chat-view/ChatHistoryManager.ts
+++ b/vscode/src/chat/chat-view/ChatHistoryManager.ts
@@ -66,23 +66,25 @@ class ChatHistoryManager implements vscode.Disposable {
         // Convert full history to lightweight history
         const lightweightHistory: LightweightChatHistory = {}
 
-        // Get all chat IDs, sort by timestamp (newest first), and limit
-        let chatIDs = Object.keys(history.chat).sort((a, b) => {
+        // Get all chat IDs and filter out empty chats first
+        let chatIDs = Object.keys(history.chat).filter(
+            chatID => history.chat[chatID]?.interactions?.[0]?.humanMessage?.text
+        )
+
+        // Sort by timestamp (newest first)
+        chatIDs = chatIDs.sort((a, b) => {
             const timestampA = new Date(history.chat[a].lastInteractionTimestamp).getTime()
             const timestampB = new Date(history.chat[b].lastInteractionTimestamp).getTime()
             return timestampA - timestampB // Descending order (newest first)
         })
 
+        // Apply limit after filtering
         if (limit) {
             chatIDs = chatIDs.slice(0, limit)
         }
 
         // Convert each chat to lightweight format
         for (const chatID of chatIDs) {
-            // Skip empty chats
-            if (!history.chat[chatID]?.interactions?.[0]?.humanMessage?.text) {
-                continue
-            }
             lightweightHistory[chatID] = toLightweightChatTranscript(history.chat[chatID])
         }
 

--- a/vscode/webviews/AppWrapperForTest.tsx
+++ b/vscode/webviews/AppWrapperForTest.tsx
@@ -13,7 +13,6 @@ import {
     type ResolvedConfiguration,
     SYMBOL_CONTEXT_MENTION_PROVIDER,
     type SymbolKind,
-    type UserLocalHistory,
     promiseFactoryToObservable,
     serializedPromptEditorStateFromText,
 } from '@sourcegraph/cody-shared'
@@ -125,21 +124,7 @@ export const AppWrapperForTest: FunctionComponent<{ children: ReactNode }> = ({ 
                         } satisfies Partial<ResolvedConfiguration> as ResolvedConfiguration),
                     authStatus: () => Observable.of(AUTH_STATUS_FIXTURE_AUTHED),
                     transcript: () => Observable.of(FIXTURE_TRANSCRIPT.explainCode),
-                    userHistory: () =>
-                        Observable.of<UserLocalHistory | null>({
-                            chat: {
-                                a: {
-                                    id: 'a',
-                                    lastInteractionTimestamp: '2024-03-29',
-                                    interactions: [
-                                        {
-                                            humanMessage: { speaker: 'human', text: 'Hello, world!' },
-                                            assistantMessage: { speaker: 'assistant', text: 'Hi!' },
-                                        },
-                                    ],
-                                },
-                            },
-                        }),
+                    userHistory: () => Observable.of(null),
                     userProductSubscription: () => Observable.of(null),
                 },
             } satisfies Wrapper<ComponentProps<typeof ExtensionAPIProviderForTestsOnly>['value']>,

--- a/vscode/webviews/tabs/HistoryTab.story.tsx
+++ b/vscode/webviews/tabs/HistoryTab.story.tsx
@@ -28,15 +28,13 @@ export const Empty: Story = {
 
 export const SingleDay: Story = {
     args: {
+        IDE: CodyIDE.VSCode,
+        setView: () => {},
         chats: [
             {
                 id: '1',
-                interactions: [
-                    {
-                        humanMessage: { speaker: 'human', text: 'How do I use React hooks?' },
-                        assistantMessage: { speaker: 'assistant', text: 'Hello' },
-                    },
-                ],
+                chatTitle: 'React hooks',
+                firstHumanMessageText: 'How do I use React hooks?',
                 lastInteractionTimestamp: new Date().toISOString(),
             },
         ],
@@ -45,25 +43,19 @@ export const SingleDay: Story = {
 
 export const MultiDay: Story = {
     args: {
+        IDE: CodyIDE.VSCode,
+        setView: () => {},
         chats: [
             {
                 id: '1',
-                interactions: [
-                    {
-                        humanMessage: { speaker: 'human', text: 'How do I use React hooks?' },
-                        assistantMessage: { speaker: 'assistant', text: 'Hello' },
-                    },
-                ],
+                chatTitle: 'React hooks',
+                firstHumanMessageText: 'How do I use React hooks?',
                 lastInteractionTimestamp: new Date(Date.now() - 86400000).toISOString(), // Yesterday
             },
             {
                 id: '2',
-                interactions: [
-                    {
-                        humanMessage: { speaker: 'human', text: 'Explain TypeScript interfaces' },
-                        assistantMessage: { speaker: 'assistant', text: 'Hello' },
-                    },
-                ],
+                chatTitle: 'TypeScript interfaces',
+                firstHumanMessageText: 'Explain TypeScript interfaces',
                 lastInteractionTimestamp: new Date().toISOString(),
             },
         ],

--- a/vscode/webviews/tabs/HistoryTab.test.tsx
+++ b/vscode/webviews/tabs/HistoryTab.test.tsx
@@ -9,14 +9,13 @@ describe('HistoryTabWithData', () => {
         const mockSetView = vi.fn()
         const emptyChats = [
             { id: '1', interactions: [], lastInteractionTimestamp: new Date().toISOString() },
-            { id: '2', interactions: [], lastInteractionTimestamp: new Date().toISOString() },
         ]
 
         render(<HistoryTabWithData IDE={CodyIDE.VSCode} setView={mockSetView} chats={emptyChats} />, {
             wrapper: AppWrapperForTest,
         })
 
-        expect(screen.getByText('You have no chat history')).toBeInTheDocument()
-        expect(screen.getByText('Start a new chat')).toBeInTheDocument()
+        expect(screen.getByText(/no chat history/i)).toBeInTheDocument()
+        expect(screen.getByText(/Start a new chat/i)).toBeInTheDocument()
     })
 })

--- a/vscode/webviews/tabs/HistoryTab.tsx
+++ b/vscode/webviews/tabs/HistoryTab.tsx
@@ -1,4 +1,4 @@
-import type { CodyIDE, UserLocalHistory } from '@sourcegraph/cody-shared'
+import type { CodyIDE } from '@sourcegraph/cody-shared'
 import { useExtensionAPI, useObservable } from '@sourcegraph/prompt-editor'
 import { HistoryIcon, MessageSquarePlusIcon, TrashIcon } from 'lucide-react'
 import type React from 'react'
@@ -13,6 +13,10 @@ import { getVSCodeAPI } from '../utils/VSCodeApi'
 import { View } from './types'
 import { getCreateNewChatCommand } from './utils'
 
+import type {
+    LightweightChatHistory,
+    LightweightChatTranscript,
+} from '@sourcegraph/cody-shared/src/chat/transcript'
 import styles from './HistoryTab.module.css'
 
 interface HistoryTabProps {
@@ -25,10 +29,7 @@ interface HistoryTabProps {
 export const HistoryTab: React.FC<HistoryTabProps> = props => {
     const userHistory = useUserHistory()
 
-    const chats = useMemo(
-        () => (userHistory ? Object.values(userHistory.chat) : userHistory),
-        [userHistory]
-    )
+    const chats = useMemo(() => (userHistory ? Object.values(userHistory) : userHistory), [userHistory])
 
     return (
         <div className="tw-px-8 tw-pt-6 tw-pb-12 tw-overflow-y-scroll">
@@ -43,10 +44,14 @@ export const HistoryTab: React.FC<HistoryTabProps> = props => {
     )
 }
 
-export const HistoryTabWithData: React.FC<
-    HistoryTabProps & { chats: UserLocalHistory['chat'][string][] }
-> = ({ IDE, webviewType, multipleWebviewsEnabled, setView, chats }) => {
-    const nonEmptyChats = useMemo(() => chats.filter(chat => chat.interactions.length > 0), [chats])
+export const HistoryTabWithData: React.FC<HistoryTabProps & { chats: LightweightChatTranscript[] }> = ({
+    IDE,
+    webviewType,
+    multipleWebviewsEnabled,
+    setView,
+    chats,
+}) => {
+    const nonEmptyChats = useMemo(() => chats, [chats])
 
     const onDeleteButtonClick = useCallback(
         (id: string) => {
@@ -77,26 +82,26 @@ export const HistoryTabWithData: React.FC<
         if (!searchTerm) {
             return nonEmptyChats
         }
-        //return the chats from nonEmptyChats where the humange messages contain the search term
+        // Search in chat titles or first message text
         return nonEmptyChats.filter(chat => {
-            return chat.interactions.some(c => {
-                return c.humanMessage?.text?.trim()?.toLowerCase()?.includes(searchTerm)
-            })
+            // Search in chat title if available
+            if (chat.chatTitle?.toLowerCase().includes(searchTerm)) {
+                return true
+            }
+            // Search in first message text if available
+            return chat.firstHumanMessageText?.toLowerCase().includes(searchTerm) || false
         })
     }, [nonEmptyChats, searchText])
 
     const sortedChatsByPeriod = useMemo(
         () =>
             Array.from(
-                filteredChats
-                    .filter(chat => chat.interactions.length)
-                    .reverse()
-                    .reduce((acc, chat) => {
-                        const period = getRelativeChatPeriod(new Date(chat.lastInteractionTimestamp))
-                        acc.set(period, [...(acc.get(period) || []), chat])
-                        return acc
-                    }, new Map<string, typeof filteredChats>())
-            ),
+                filteredChats.reverse().reduce((acc, chat) => {
+                    const period = getRelativeChatPeriod(new Date(chat.lastInteractionTimestamp))
+                    acc.set(period, [...(acc.get(period) || []), chat])
+                    return acc
+                }, new Map<string, LightweightChatTranscript[]>())
+            ) as [string, LightweightChatTranscript[]][],
         [filteredChats]
     )
 
@@ -111,52 +116,56 @@ export const HistoryTabWithData: React.FC<
                 />
             </div>
 
-            {sortedChatsByPeriod.map(([period, chats]) => (
-                <div key={period} className="tw-flex tw-flex-col">
-                    <h4 className="tw-font-semibold tw-text-muted-foreground tw-py-2 tw-my-4">
-                        {period}
-                    </h4>
-                    {chats.map(chat => {
-                        const id = chat.lastInteractionTimestamp
-                        const interactions = chat.interactions
-                        const chatTitle = chat.chatTitle
-                        const lastMessage =
-                            interactions[interactions.length - 1]?.humanMessage?.text?.trim()
-                        return (
-                            <div key={id} className={`tw-flex tw-flex-row tw-p-1 ${styles.historyRow}`}>
-                                <Button
-                                    variant="ghost"
-                                    className={`tw-text-left tw-truncate tw-w-full ${styles.historyItem}`}
-                                    onClick={() =>
-                                        getVSCodeAPI().postMessage({
-                                            command: 'restoreHistory',
-                                            chatID: id,
-                                        })
-                                    }
+            {sortedChatsByPeriod.map((periodData: [string, LightweightChatTranscript[]]) => {
+                const [period, chats] = periodData
+                return (
+                    <div key={period} className="tw-flex tw-flex-col">
+                        <h4 className="tw-font-semibold tw-text-muted-foreground tw-py-2 tw-my-4">
+                            {period}
+                        </h4>
+                        {chats.map((chat: LightweightChatTranscript) => {
+                            const id = chat.id
+                            const chatTitle = chat.chatTitle
+                            const lastMessage = chat.firstHumanMessageText
+                            return (
+                                <div
+                                    key={id}
+                                    className={`tw-flex tw-flex-row tw-p-1 ${styles.historyRow}`}
                                 >
-                                    <span className="tw-truncate tw-w-full">
-                                        {chatTitle || lastMessage}
-                                    </span>
-                                </Button>
-                                <Button
-                                    variant="ghost"
-                                    title="Delete chat"
-                                    aria-label="Delete chat"
-                                    className={`${styles.historyDeleteBtn}`}
-                                    onClick={() => onDeleteButtonClick(id)}
-                                    onKeyDown={() => onDeleteButtonClick(id)}
-                                >
-                                    <TrashIcon
-                                        className="tw-w-8 tw-h-8 tw-opacity-80"
-                                        size={16}
-                                        strokeWidth="1.25"
-                                    />
-                                </Button>
-                            </div>
-                        )
-                    })}
-                </div>
-            ))}
+                                    <Button
+                                        variant="ghost"
+                                        className={`tw-text-left tw-truncate tw-w-full ${styles.historyItem}`}
+                                        onClick={() =>
+                                            getVSCodeAPI().postMessage({
+                                                command: 'restoreHistory',
+                                                chatID: id,
+                                            })
+                                        }
+                                    >
+                                        <span className="tw-truncate tw-w-full">
+                                            {chatTitle || lastMessage}
+                                        </span>
+                                    </Button>
+                                    <Button
+                                        variant="ghost"
+                                        title="Delete chat"
+                                        aria-label="Delete chat"
+                                        className={`${styles.historyDeleteBtn}`}
+                                        onClick={() => onDeleteButtonClick(id)}
+                                        onKeyDown={() => onDeleteButtonClick(id)}
+                                    >
+                                        <TrashIcon
+                                            className="tw-w-8 tw-h-8 tw-opacity-80"
+                                            size={16}
+                                            strokeWidth="1.25"
+                                        />
+                                    </Button>
+                                </div>
+                            )
+                        })}
+                    </div>
+                )
+            })}
 
             {nonEmptyChats.length === 0 && (
                 <div className="tw-flex tw-flex-col tw-items-center tw-mt-6">
@@ -191,7 +200,7 @@ export const HistoryTabWithData: React.FC<
     )
 }
 
-function useUserHistory(): UserLocalHistory | null | undefined {
+function useUserHistory(): LightweightChatHistory | null | undefined {
     const userHistory = useExtensionAPI().userHistory
     return useObservable(useMemo(() => userHistory(), [userHistory])).value
 }

--- a/vscode/webviews/tabs/HistoryTab.tsx
+++ b/vscode/webviews/tabs/HistoryTab.tsx
@@ -51,7 +51,7 @@ export const HistoryTabWithData: React.FC<HistoryTabProps & { chats: Lightweight
     setView,
     chats,
 }) => {
-    const nonEmptyChats = useMemo(() => chats, [chats])
+    const nonEmptyChats = useMemo(() => chats.filter(c => c?.firstHumanMessageText?.length), [chats])
 
     const onDeleteButtonClick = useCallback(
         (id: string) => {
@@ -167,7 +167,7 @@ export const HistoryTabWithData: React.FC<HistoryTabProps & { chats: Lightweight
                 )
             })}
 
-            {nonEmptyChats.length === 0 && (
+            {!nonEmptyChats?.length && (
                 <div className="tw-flex tw-flex-col tw-items-center tw-mt-6">
                     <HistoryIcon
                         size={20}


### PR DESCRIPTION
This commit introduces a lightweight chat history to improve performance when displaying the chat history in the UI.

Key changes:

- **Lightweight Chat History:** Created a `LightweightChatTranscript` and `LightweightChatHistory` interface to represent a simplified version of the chat history, containing only essential data like ID, title, and timestamp.
- **ChatHistoryManager Updates:**
    - Added a `getLightweightHistory` method to `ChatHistoryManager` to retrieve the lightweight chat history.
    - Updated the `userHistory` observable in `ChatController` to use `chatHistory.lightweightChanges` for improved performance.
- **UI Updates:**
    - Updated the `HistoryTab` component to use the `LightweightChatTranscript` type.
    - Modified the `HistoryTab` component to display chat titles or the first message text.
- **Testing:** Added unit tests for `ChatHistoryManager` to ensure the correct functionality of the new lightweight history feature.

These changes significantly reduce the amount of data processed and rendered when displaying the chat history,  as we no longer send the full content of the transcripts to the webview that are stored there.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Green CI as everything should work the same as the history items from before.

check your History tab to confirm everything still shows up correctly

<img width="1256" alt="image" src="https://github.com/user-attachments/assets/7550cde7-54c4-41dd-a0a5-f29a7c1e2e67" />

