### PR TITLE
fix/chat: Label the button that runs shell commands "Execute" instead of "Execute in Terminal"

### DIFF
--- a/vscode/webviews/chat/ChatMessageContent/ChatMessageContent.tsx
+++ b/vscode/webviews/chat/ChatMessageContent/ChatMessageContent.tsx
@@ -3,6 +3,7 @@ import { clsx } from 'clsx'
 import type React from 'react'
 import { useCallback, useMemo } from 'react'
 import { RichMarkdown } from '../../components/RichMarkdown'
+import { getVSCodeAPI } from '../../utils/VSCodeApi'
 import { useConfig } from '../../utils/useConfig'
 import type { PriorHumanMessageInfo } from '../cells/messageCell/assistant/AssistantMessageCell'
 import styles from './ChatMessageContent.module.css'
@@ -66,15 +67,19 @@ export const ChatMessageContent: React.FunctionComponent<ChatMessageContentProps
 
     const onInsert = config.config.hasEditCapability ? insertButtonOnSubmit : undefined
 
-    const onExecute = useCallback((command: string) => {
+    let onExecute: ((command: string) => void) | undefined = useCallback((command: string) => {
         // Execute command in terminal
-        const vscodeApi = (window as any).acquireVsCodeApi?.()
-        vscodeApi?.postMessage({
+        const vscodeAPI = getVSCodeAPI()
+        vscodeAPI.postMessage({
             command: 'command',
             id: 'cody.terminal.execute',
             arg: command.trim(),
         })
     }, [])
+
+    // TODO: Replace this isVSCode check with a client capability check for
+    // terminal execution when agent/src/vscode-shim.ts implements `terminal()`
+    onExecute = config.clientCapabilities.isVSCode ? onExecute : undefined
 
     const onCopy = useCallback(
         (code: string) => copyButtonOnSubmit?.(code, 'Button'),

--- a/vscode/webviews/chat/ChatMessageContent/EditButtons.tsx
+++ b/vscode/webviews/chat/ChatMessageContent/EditButtons.tsx
@@ -333,7 +333,7 @@ export function createExecuteButton(command: string): React.ReactElement {
             <div className={styles.iconContainer}>
                 <i className="codicon codicon-terminal tw-align-middle" />
             </div>
-            Send command to Terminal
+            Run
         </button>
     )
 }

--- a/vscode/webviews/components/GuardrailsApplicator.tsx
+++ b/vscode/webviews/components/GuardrailsApplicator.tsx
@@ -212,6 +212,8 @@ export const GuardrailsApplicator: React.FC<GuardrailsApplicatorProps> = ({
                     .join(', ')}…`
             case GuardrailsCheckStatus.Error:
                 return `Guardrails API error: ${guardrailsResult.error?.message || 'Unknown error'}`
+            case GuardrailsCheckStatus.Skipped:
+                return 'Guardrails check skipped'
             default:
                 return 'Guardrails status unknown'
         }
@@ -229,8 +231,12 @@ export const GuardrailsApplicator: React.FC<GuardrailsApplicatorProps> = ({
     }
 
     const statusDisplay = (
-        <>
-            <GuardrailsStatus status={guardrailsResult.status} filename={fileName} tooltip={tooltip} />
+        <GuardrailsStatus
+            status={guardrailsResult.status}
+            filename={fileName}
+            tooltip={tooltip}
+            className={styles.metadataContainer}
+        >
             {guardrailsResult.status === GuardrailsCheckStatus.Error && (
                 <button
                     className={styles.button}
@@ -244,7 +250,7 @@ export const GuardrailsApplicator: React.FC<GuardrailsApplicatorProps> = ({
                     <span className="tw-hidden xs:tw-block">Retry</span>
                 </button>
             )}
-        </>
+        </GuardrailsStatus>
     )
 
     // Render function that provides check status and UI state to children

--- a/vscode/webviews/components/GuardrailsStatus.tsx
+++ b/vscode/webviews/components/GuardrailsStatus.tsx
@@ -5,6 +5,7 @@ import type React from 'react'
 import styles from '../chat/ChatMessageContent/ChatMessageContent.module.css'
 
 interface GuardrailsStatusProps {
+    children?: React.ReactNode
     status: GuardrailsCheckStatus
     filename?: string
     tooltip?: string
@@ -17,6 +18,7 @@ interface GuardrailsStatusProps {
  * It shows different icons and optional retry button based on the check status.
  */
 export const GuardrailsStatus: React.FC<GuardrailsStatusProps> = ({
+    children,
     status,
     filename,
     tooltip,
@@ -101,6 +103,7 @@ export const GuardrailsStatus: React.FC<GuardrailsStatusProps> = ({
                     )}
                 </div>
             )}
+            {children}
         </div>
     )
 }

--- a/vscode/webviews/components/RichCodeBlock.tsx
+++ b/vscode/webviews/components/RichCodeBlock.tsx
@@ -6,7 +6,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { CodyTaskState } from '../../src/non-stop/state'
 import type { CodeBlockActionsProps } from '../chat/ChatMessageContent/ChatMessageContent'
 import styles from '../chat/ChatMessageContent/ChatMessageContent.module.css'
-import { createEditButtons, createExecuteButton } from '../chat/ChatMessageContent/EditButtons'
+import { createEditButtons } from '../chat/ChatMessageContent/EditButtons'
 import { getCodeBlockId } from '../chat/ChatMessageContent/utils'
 import { type ClientActionListener, useClientActionListener } from '../client/clientState'
 import { useConfig } from '../utils/useConfig'
@@ -127,6 +127,10 @@ export const RichCodeBlock: React.FC<RichCodeBlockProps> = ({
         )
     )
 
+    const onExecuteThisScript = useCallback(() => {
+        onExecute?.(code)
+    }, [onExecute, code])
+
     const actionButtons = (
         <div className={styles.actionButtons}>
             {isCodeComplete &&
@@ -137,15 +141,13 @@ export const RichCodeBlock: React.FC<RichCodeBlockProps> = ({
                     copyButtonOnSubmit: onCopy,
                     onInsert,
                     onSmartApply,
+                    onExecute: onExecute && onExecuteThisScript,
                     smartApply,
                     smartApplyId: thisTaskId,
                     smartApplyState,
                     isCodeComplete,
                     fileName,
-                    isShellCommand,
                 })}
-
-            {isCodeComplete && isShellCommand && onExecute && createExecuteButton(code)}
         </div>
     )
 

--- a/vscode/webviews/components/RichCodeBlock.tsx
+++ b/vscode/webviews/components/RichCodeBlock.tsx
@@ -6,7 +6,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { CodyTaskState } from '../../src/non-stop/state'
 import type { CodeBlockActionsProps } from '../chat/ChatMessageContent/ChatMessageContent'
 import styles from '../chat/ChatMessageContent/ChatMessageContent.module.css'
-import { createEditButtons } from '../chat/ChatMessageContent/EditButtons'
+import { createAdditionsDeletions, createEditButtons } from '../chat/ChatMessageContent/EditButtons'
 import { getCodeBlockId } from '../chat/ChatMessageContent/utils'
 import { type ClientActionListener, useClientActionListener } from '../client/clientState'
 import { useConfig } from '../utils/useConfig'
@@ -131,11 +131,19 @@ export const RichCodeBlock: React.FC<RichCodeBlockProps> = ({
         onExecute?.(code)
     }, [onExecute, code])
 
+    const additionsDeletions = smartApply ? (
+        <div className={styles.buttonContainer}>
+            {createAdditionsDeletions({
+                hasEditIntent,
+                preText: code,
+            })}
+        </div>
+    ) : undefined
+
     const actionButtons = (
         <div className={styles.actionButtons}>
             {isCodeComplete &&
                 createEditButtons({
-                    hasEditIntent,
                     isVSCode: config.clientCapabilities.isVSCode,
                     preText: code,
                     copyButtonOnSubmit: onCopy,
@@ -170,10 +178,11 @@ export const RichCodeBlock: React.FC<RichCodeBlockProps> = ({
                     )}
 
                     {/* Actions bar */}
+                    {additionsDeletions}
                     <div className={styles.buttonsContainer}>
                         <div className={styles.buttons}>
                             {showCode && actionButtons}
-                            <div className={styles.metadataContainer}>{guardrailsStatus}</div>
+                            {guardrailsStatus}
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Also move the ... overflow menu to be the last menu item on the left.

## Test plan

Tested manually: Ask Cody to generate a 10 line shell script, and verify that the button is labelled "Execute."

Check that the Copy and Execute icons are aligned, both in cases where there are filenames/Guardrails, and where there is no metadata.

![Screenshot 2025-03-28 at 16 55 11](https://github.com/user-attachments/assets/171ca72a-2bf6-4fda-98be-7ec7da0d7235)