### PR TITLE
fix(ci): Update SCIP upload command in GitHub Actions

### DIFF
--- a/.github/workflows/scip-typescript.yml
+++ b/.github/workflows/scip-typescript.yml
@@ -41,19 +41,19 @@ jobs:
       - run: pnpm dlx @sourcegraph/scip-typescript index --pnpm-workspaces --no-global-caches
 
       - name: Upload SCIP to Cloud
-        run: pnpm dlx @sourcegraph/src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress
+        run: pnpm dlx @sourcegraph/src code-intel upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress
         env:
           SRC_ENDPOINT: https://sourcegraph.com/
           SRC_ACCESS_TOKEN: ${{ secrets.SRC_ACCESS_TOKEN_DOTCOM }}
 
       - name: Upload SCIP to S2
-        run: pnpm dlx @sourcegraph/src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress
+        run: pnpm dlx @sourcegraph/src code-intel upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress
         env:
           SRC_ENDPOINT: https://sourcegraph.sourcegraph.com/
           SRC_ACCESS_TOKEN: ${{ secrets.SRC_ACCESS_TOKEN_S2 }}
 
       - name: Upload lsif to Demo
-        run: pnpm dlx @sourcegraph/src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress || true
+        run: pnpm dlx @sourcegraph/src code-intel upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress || true
         env:
           SRC_ENDPOINT: https://demo.sourcegraph.com/
           SRC_ACCESS_TOKEN: ${{ secrets.SRC_ACCESS_TOKEN_DEMO }}


### PR DESCRIPTION
The `lsif upload` command in the SCIP TypeScript workflow has been replaced with `code-intel upload`. This change aligns with the updated command structure in `@sourcegraph/src`. The environment variables and other configurations remain the same. This ensures that SCIP data is correctly uploaded to Sourcegraph Cloud, S2, and Demo instances.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

[scip-typescript / scip-typescript (pull_request)](https://github.com/sourcegraph/cody/actions/runs/14120690080/job/39560246951?pr=7593) job to be green. it's been failing for a month