### PR TITLE
fix(chat): Completely disable Swift tree-sitter parsing due to VS Code 1.98+ crash

### DIFF
--- a/vscode/src/tree-sitter/grammars.test.ts
+++ b/vscode/src/tree-sitter/grammars.test.ts
@@ -144,12 +144,12 @@ describe('tree-sitter grammars', { timeout: 5000 }, () => {
             query: '(command_name) @identifier',
             expectedCapture: 'echo',
         },
-        {
-            language: SupportedLanguage.swift,
-            code: 'func helloWorld() { print("Hello, world!") }',
-            query: '(simple_identifier) @identifier',
-            expectedCapture: 'helloWorld',
-        },
+        // {
+        //     language: SupportedLanguage.swift,
+        //     code: 'func helloWorld() { print("Hello, world!") }',
+        //     query: '(simple_identifier) @identifier',
+        //     expectedCapture: 'helloWorld',
+        // },
         {
             language: SupportedLanguage.typescript,
             code: 'function helloWorld() { console.log("Hello, world!") }',

--- a/vscode/src/tree-sitter/grammars.ts
+++ b/vscode/src/tree-sitter/grammars.ts
@@ -32,7 +32,7 @@ export enum SupportedLanguage {
     rust = 'rust',
     scala = 'scala',
     shellscript = 'bash',
-    swift = 'swift',
+    // swift = 'swift',
     typescript = 'typescript',
     typescriptreact = 'typescriptreact',
 }
@@ -63,7 +63,9 @@ export const DOCUMENT_LANGUAGE_TO_GRAMMAR: Record<SupportedLanguage, string> = {
     [SupportedLanguage.rust]: 'tree-sitter-rust.wasm',
     [SupportedLanguage.scala]: 'tree-sitter-scala.wasm',
     [SupportedLanguage.shellscript]: 'tree-sitter-bash.wasm',
-    [SupportedLanguage.swift]: 'tree-sitter-swift.wasm',
+    // CODY-5459: Swift grammar is not working with VSCode 1.98+
+    // TODO: Fix Swift grammar crash of extension host
+    // [SupportedLanguage.swift]: 'tree-sitter-swift.wasm',
     [SupportedLanguage.typescript]: 'tree-sitter-typescript.wasm',
     [SupportedLanguage.typescriptreact]: 'tree-sitter-tsx.wasm',
 } as const

--- a/vscode/src/tree-sitter/parse-tree-cache.ts
+++ b/vscode/src/tree-sitter/parse-tree-cache.ts
@@ -60,12 +60,6 @@ export function updateParseTreeCache(document: TextDocument, parser: WrappedPars
 function getLanguageIfTreeSitterEnabled(document: TextDocument): SupportedLanguage | null {
     const { languageId } = document
 
-    // CODY-5459: Swift grammar is not working with VSCode 1.98+
-    // TODO: Fix Swift grammar crash of extension host
-    if (languageId === 'swift') {
-        return null
-    }
-
     /**
      * 1. Do not use tree-sitter for unsupported languages.
      * 2. Do not use tree-sitter for files with more than N lines to avoid performance issues.


### PR DESCRIPTION
This commit disables the Swift grammar in the tree-sitter implementation due to compatibility issues with VS Code versions 1.98 and later. The Swift grammar was causing the extension host to crash.

Previous pull request https://github.com/sourcegraph/cody/pull/7520 disabled the parser language loading
when going through parseDocument but you could also call directly `parse` and `updateParseTreeOnEdit`

## Test plan
Check that Cody no longer crashes with VSCode 1.98+
