### PR TITLE
Show current selection mention in initial context

### DIFF
--- a/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
@@ -1,5 +1,6 @@
 import {
     type ChatMessage,
+    type ContextItem,
     type ContextItemMedia,
     FAST_CHAT_INPUT_TOKEN_BUDGET,
     type Model,
@@ -361,13 +362,21 @@ export const HumanMessageEditor: FunctionComponent<{
         // Remove tree type if streaming is not supported.
         const excludedTypes = new Set([
             'open-link',
-            'current-selection',
             ...(currentChatModel?.tags?.includes(ModelTag.StreamDisabled) ? ['tree'] : []),
         ])
 
-        const filteredItems = defaultContext?.initialContext.filter(
-            item => !excludedTypes.has(item.type)
-        )
+        const filteredItems = defaultContext?.initialContext
+            .filter(item => !excludedTypes.has(item.type))
+            .map((item): ContextItem => {
+                if (item.type === 'current-selection') {
+                    return {
+                        ...item,
+                        type: 'file',
+                    }
+                }
+                return item
+            })
+
         void editor.setInitialContextMentions(filteredItems)
     }, [defaultContext?.initialContext, isSent, isFirstMessage, currentChatModel])
 


### PR DESCRIPTION
Enable showing current selection automatically as initial context when the user selects code in a file.

## Test plan

- Start new chat
- Select code in open tab
- File mention item with the selected range should be added automatically to the input.