### PR TITLE
Update tree-sitter to v0.24.5

### DIFF
--- a/agent/src/cli/command-bench/AutocompleteMatcher.ts
+++ b/agent/src/cli/command-bench/AutocompleteMatcher.ts
@@ -52,7 +52,7 @@ export class AutocompleteMatcher {
             return
         }
         this.originalTree = this.parser.parse(text)
-        this.originalTreeIsFreeOfErrrors = !this.originalTree.rootNode.hasError()
+        this.originalTreeIsFreeOfErrrors = !this.originalTree.rootNode.hasError
         const result: AutocompleteMatch[] = []
         const document = new EvaluationDocument(
             this.params,

--- a/agent/src/cli/command-bench/testParse.test.ts
+++ b/agent/src/cli/command-bench/testParse.test.ts
@@ -55,7 +55,7 @@ describe('testParse', () => {
             throw new TypeError(`parser is undefined for language ${language}`)
         }
         const originalTree = parser.parse(okText)
-        expect(originalTree.rootNode.hasError()).toBe(false)
+        expect(originalTree.rootNode.hasError).toBe(false)
         expect(testParses(errorText, parser)).toBe(false)
     })
 })

--- a/agent/src/cli/command-bench/testParse.ts
+++ b/agent/src/cli/command-bench/testParse.ts
@@ -6,7 +6,7 @@ export function testParses(newText: string, parser: WrappedParser): boolean | un
     // from performance improvements but it didn't work correctly,
     // parseTest.test.ts was failing until we removed `previousTree`.
     const newTree = parser.parse(newText)
-    const hasError = newTree.rootNode.hasError()
+    const hasError = newTree.rootNode.hasError
     newTree.delete()
     return !hasError
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "vscode-jsonrpc": "^8.2.0",
-        "web-tree-sitter": "^0.21.0",
+        "web-tree-sitter": "^0.24.5",
         "win-ca": "^3.5.1"
       },
       "devDependencies": {
@@ -8919,12 +8919,6 @@
       "dependencies": {
         "defaults": "^1.0.3"
       }
-    },
-    "node_modules/web-tree-sitter": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.21.0.tgz",
-      "integrity": "sha512-iJ+QJ6ikN9D9cG7Kh6q3KtAstYFUQbYZ8OjuPEJYWfj2kLrmp5I3C2n6WjE1Y3jvj7nJbkcrJytJGWUEhCxn+g==",
-      "license": "MIT"
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "vscode-jsonrpc": "^8.2.0",
-    "web-tree-sitter": "^0.21.0",
+    "web-tree-sitter": "^0.24.5",
     "win-ca": "^3.5.1",
     "ws": "^8.16.0",
     "zod-to-json-schema": "^3.24.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,8 +43,8 @@ importers:
         specifier: ^8.2.0
         version: 8.2.0
       web-tree-sitter:
-        specifier: ^0.21.0
-        version: 0.21.0
+        specifier: ^0.24.5
+        version: 0.24.5
       win-ca:
         specifier: ^3.5.1
         version: 3.5.1
@@ -17914,8 +17914,8 @@ packages:
     engines: {node: '>= 14'}
     dev: false
 
-  /web-tree-sitter@0.21.0:
-    resolution: {integrity: sha512-iJ+QJ6ikN9D9cG7Kh6q3KtAstYFUQbYZ8OjuPEJYWfj2kLrmp5I3C2n6WjE1Y3jvj7nJbkcrJytJGWUEhCxn+g==}
+  /web-tree-sitter@0.24.5:
+    resolution: {integrity: sha512-+J/2VSHN8J47gQUAvF8KDadrfz6uFYVjxoxbKWDoXVsH2u7yLdarCnIURnrMA6uSRkgX3SdmqM5BOoQjPdSh5w==}
     dev: false
 
   /webauthn4js@3.0.0:

--- a/vscode/src/completions/text-processing/parse-completion.ts
+++ b/vscode/src/completions/text-processing/parse-completion.ts
@@ -75,11 +75,10 @@ export function parseCompletion(context: CompletionContext): ParsedCompletion {
     // Search for ERROR nodes in the completion range.
     const query = parser.getLanguage().query('(ERROR) @error')
     // TODO(tree-sitter): query bigger range to catch higher scope syntactic errors caused by the completion.
-    const captures = query.captures(
-        treeWithCompletion.rootNode,
-        points?.trigger || points.start,
-        points.end
-    )
+    const captures = query.captures(treeWithCompletion.rootNode, {
+        startPosition: points?.trigger || points.start,
+        endPosition: points.end,
+    })
 
     return {
         ...completion,


### PR DESCRIPTION
Update tree sitter to version [v0.24.5](https://github.com/tree-sitter/tree-sitter/releases/tag/v0.24.5)
This is last version before breaking changes which would require some bigger code changes and probably more testing.

Notably this version contains this PR:
[When loading languages via WASM, gracefully handle memory errors and leaks in external scanners #3181
](https://github.com/tree-sitter/tree-sitter/pull/3181)
That should help mitigate a lot of problems we had in past with tree-sitter, and also - hopefully - help with tree-sitter memory usage.

## Test plan

Full QA, with different programming languages.

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
