### PR TITLE
fix(agent mode): select mode at start up

### DIFF
--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -743,7 +743,6 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
             command,
             manuallySelectedIntent,
             model,
-            chatAgent,
         }: Parameters<typeof this.handleUserMessage>[0],
         span: Span
     ): Promise<void> {
@@ -762,7 +761,6 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
             sessionID: this.chatBuilder.sessionID,
             traceId: span.spanContext().traceId,
             promptText: inputText,
-            chatAgent,
         })
         recorder.recordChatQuestionSubmitted(mentions)
 
@@ -770,7 +768,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
 
         this.postEmptyMessageInProgress(model)
 
-        const agent = getAgent(model, chatAgent ?? model, {
+        const agent = getAgent(model, manuallySelectedIntent, {
             contextRetriever: this.contextRetriever,
             editor: this.editor,
             chatClient: this.chatClient,
@@ -861,7 +859,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                         // In future work, we should remove this special-casing and unify
                         // how new messages are posted to the transcript.
 
-                        if (chatAgent === 'agentic') {
+                        if (manuallySelectedIntent === 'agentic') {
                             this.saveSession()
                         } else if (
                             messageInProgress &&

--- a/vscode/src/chat/chat-view/handlers/registry.ts
+++ b/vscode/src/chat/chat-view/handlers/registry.ts
@@ -1,10 +1,6 @@
 import Anthropic from '@anthropic-ai/sdk'
-import type { ChatMessage } from '@sourcegraph/cody-shared'
-import {
-    DeepCodyAgentID,
-    DeepCodyModelRef,
-    ToolCodyModelRef,
-} from '@sourcegraph/cody-shared/src/models/client'
+import type { ChatMessage, ChatModel } from '@sourcegraph/cody-shared'
+import { DeepCodyAgentID, ToolCodyModelRef } from '@sourcegraph/cody-shared/src/models/client'
 import { getConfiguration } from '../../../configuration'
 import { AgenticHandler } from './AgenticHandler'
 import { ChatHandler } from './ChatHandler'
@@ -45,25 +41,41 @@ const agentRegistry = new Map<string, (id: string, tools: AgentTools) => AgentHa
 /**
  * Gets an agent handler for the specified agent and model ID
  */
-export function getAgent(model: string, agentName: string, tools: AgentTools): AgentHandler {
+export function getAgent(model: string, intent: ChatMessage['intent'], tools: AgentTools): AgentHandler {
     const { contextRetriever, editor, chatClient } = tools
-    if (agentName === 'agentic') {
+
+    // Special case for agentic intent
+    if (intent === 'agentic') {
         return new AgenticHandler(contextRetriever, editor, chatClient)
     }
 
-    // Use registered agent or fall back to basic chat handler
-    const handlerFactory = agentRegistry.get(model) ?? agentRegistry.get(agentName)
-    if (handlerFactory) {
-        return handlerFactory(agentName, tools)
-    }
+    // Return appropriate handler or fallback to chat handler
+    const intentHandler = intent && agentRegistry.get(intent)
+    if (intentHandler) return intentHandler(intent, tools)
 
-    // Default to basic chat handler for unknown agents
+    // Try to get handler from registry based on model or intent
+    const modelHandler = agentRegistry.get(model)
+    if (modelHandler) return modelHandler(model, tools)
+
     return new ChatHandler(contextRetriever, editor, chatClient)
 }
 
-export function getAgentName(intent: ChatMessage['intent'], model?: string): string | undefined {
-    if (model === DeepCodyModelRef) {
+/**
+ * Gets the agent name based on the intent and model
+ * @param intent The intent of the chat message
+ * @param model The model of the chat message
+ * @returns The agent name or undefined if not applicable
+ */
+export function getAgentName(intent: ChatMessage['intent'], model?: ChatModel): string | undefined {
+    // Special case for agentic intent
+    if (intent === 'agentic') {
+        return 'agent-mode'
+    }
+    if (model === ToolCodyModelRef) {
+        return ToolCodyModelRef
+    }
+    if (model === DeepCodyAgentID) {
         return DeepCodyAgentID
     }
-    return (intent !== 'chat' && intent) || undefined
+    return undefined
 }

--- a/vscode/webviews/chat/Transcript.test.tsx
+++ b/vscode/webviews/chat/Transcript.test.tsx
@@ -424,7 +424,13 @@ describe('transcriptToInteractionPairs', () => {
     test('empty transcript', () => {
         expect(transcriptToInteractionPairs([], null, null)).toEqual<Interaction[]>([
             {
-                humanMessage: { index: 0, speaker: 'human', isUnsentFollowup: true, intent: undefined },
+                humanMessage: {
+                    index: 0,
+                    speaker: 'human',
+                    isUnsentFollowup: true,
+                    intent: undefined,
+                    manuallySelectedIntent: null,
+                },
                 assistantMessage: null,
             },
         ])
@@ -474,7 +480,13 @@ describe('transcriptToInteractionPairs', () => {
                 },
             },
             {
-                humanMessage: { index: 4, speaker: 'human', isUnsentFollowup: true, intent: null },
+                humanMessage: {
+                    index: 4,
+                    speaker: 'human',
+                    isUnsentFollowup: true,
+                    intent: null,
+                    manuallySelectedIntent: null,
+                },
                 assistantMessage: null,
             },
         ])
@@ -507,7 +519,13 @@ describe('transcriptToInteractionPairs', () => {
                 },
             },
             {
-                humanMessage: { index: 2, speaker: 'human', isUnsentFollowup: true, intent: null },
+                humanMessage: {
+                    index: 2,
+                    speaker: 'human',
+                    isUnsentFollowup: true,
+                    intent: null,
+                    manuallySelectedIntent: null,
+                },
                 assistantMessage: null,
             },
         ])

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -554,7 +554,7 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
                 manuallySelectedIntent,
             })
         },
-        [humanMessage]
+        [humanMessage, manuallySelectedIntent, setManuallySelectedIntent]
     )
 
     const isAgenticMode = useMemo(


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-5582/when-agent-mode-is-selected-it-doesnt-always-run-in-this-mode

This commit fixes an issue where the manually selected intent was not being correctly passed to the agent retrieval and submission functions. This resulted in incorrect agent selection and behavior, especially for the 'agentic' intent.

The following changes were made:

- In `Transcript.tsx`, removed the `intentFromSubmit` parameter from the `onUserAction` callback and related functions (`onEditSubmit`, `onFollowupSubmit`, `onHumanMessageSubmit`). The manually selected intent is now directly used.
- In `Transcript.tsx`, set manuallySelectedIntent to 'search' when editAndSubmitSearch is called
- In `registry.ts`, updated the `getAgent` function to use the `manuallySelectedIntent` parameter to determine the agent to use.
- In `registry.ts`, updated the `getAgentName` function to handle the 'agentic' intent correctly.
- In `ChatController.ts`, updated the `handleUserMessage` function to pass the `manuallySelectedIntent` to the `getAgent` function.
- In `ChatController.ts`, updated the `handleUserMessage` function to check for `manuallySelectedIntent === 'agentic'` instead of `chatAgent === 'agentic'` when saving the session.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Test Cases
1. Agent Selection Logic
Test Case 1.1: Verify that agent selection works correctly with the new intent-based approach

Submit a chat message with intent: 'agentic'
Confirm that Agent mode is used

Test Case 1.2: Verify fallback to ChatHandler works correctly

Submit a chat message with an 'chat' intent and model
Confirm that the default ChatHandler is used

Test Case 1.3: Test agentic chat model selection

Submit messages with 'agentic chat' model
Verify the agentic chat handler is used