### PR TITLE
[JetBrains] Fix issue with completions matching existing prefix and suffix with a common character

### DIFF
--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
@@ -407,6 +407,7 @@ class CodyAutocompleteManager {
       while (endIndex > 0 &&
           endIndex > startIndex &&
           original.length - (completion.length - endIndex) > 0 &&
+          original.length - (completion.length - endIndex) > startIndex &&
           completion[endIndex - 1] ==
               original[original.length - (completion.length - endIndex) - 1]) {
         endIndex--

--- a/jetbrains/src/test/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManagerTest.kt
+++ b/jetbrains/src/test/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManagerTest.kt
@@ -49,50 +49,58 @@ class CodyAutocompleteManagerTest : BasePlatformTestCase() {
   }
 
   fun testTrimCommonPrefixAndSuffix_NoCommonParts() {
-    val formatted = "Hello, World!"
+    val completion = "Hello, World!"
     val original = "Goodbye, Universe?"
-    val (startIndex, result) = trimCommonPrefixAndSuffix(formatted, original)
+    val (startIndex, result) = trimCommonPrefixAndSuffix(completion, original)
     assertEquals(0, startIndex)
     assertEquals("Hello, World!", result)
   }
 
   fun testTrimCommonPrefixAndSuffix_CommonPrefix() {
-    val formatted = "Hello, World!"
+    val completion = "Hello, World!"
     val original = "Hello, Universe?"
-    val (startIndex, result) = trimCommonPrefixAndSuffix(formatted, original)
+    val (startIndex, result) = trimCommonPrefixAndSuffix(completion, original)
     assertEquals(7, startIndex)
     assertEquals("World!", result)
   }
 
   fun testTrimCommonPrefixAndSuffix_CommonSuffix() {
-    val formatted = "Hello, World!"
+    val completion = "Hello, World!"
     val original = "Goodbye, World!"
-    val (startIndex, result) = trimCommonPrefixAndSuffix(formatted, original)
+    val (startIndex, result) = trimCommonPrefixAndSuffix(completion, original)
     assertEquals(0, startIndex)
     assertEquals("Hello", result)
   }
 
   fun testTrimCommonPrefixAndSuffix_CommonPrefixAndSuffix() {
-    val formatted = "Hello, beautiful World!"
+    val completion = "Hello, beautiful World!"
     val original = "Hello, amazing World!"
-    val (startIndex, result) = trimCommonPrefixAndSuffix(formatted, original)
+    val (startIndex, result) = trimCommonPrefixAndSuffix(completion, original)
     assertEquals(7, startIndex)
     assertEquals("beautiful", result)
   }
 
   fun testTrimCommonPrefixAndSuffix_EmptyStrings() {
-    val formatted = ""
+    val completion = ""
     val original = ""
-    val (startIndex, result) = trimCommonPrefixAndSuffix(formatted, original)
+    val (startIndex, result) = trimCommonPrefixAndSuffix(completion, original)
     assertEquals(0, startIndex)
     assertEquals("", result)
   }
 
-  fun testTrimCommonPrefixAndSuffix_FormattedShorterThanOriginal() {
-    val formatted = "Hello"
+  fun testTrimCommonPrefixAndSuffix_CompletionShorterThanOriginal() {
+    val completion = "Hello"
     val original = "Hello, World!"
-    val (startIndex, result) = trimCommonPrefixAndSuffix(formatted, original)
+    val (startIndex, result) = trimCommonPrefixAndSuffix(completion, original)
     assertEquals(5, startIndex)
     assertEquals("", result)
+  }
+
+  fun testTrimCommonPrefixAndSuffix_sameCommonPrefixAndSuffix() {
+    val completion = "      <input type=\"text\" value={message} onChange={onInputChange} />"
+    val original = "      <input type=\"text\" value={message} />"
+    val (startIndex, result) = trimCommonPrefixAndSuffix(completion, original)
+    assertEquals(41, startIndex)
+    assertEquals("onChange={onInputChange} ", result)
   }
 }


### PR DESCRIPTION
We had an issue with calculations of the text that is the actual insertion (does not match either prefix or suffix). 
- issue fixed
- unit test added

## Test plan
- green ci (a test case covering the issue has been added)
- completion should work in a case like this one: https://sourcegraph.sourcegraph.com/github.com/sourcegraph/cody-chat-eval/-/blob/src/autoedit_debug/examples/renderer-testing-examples/codium-js-rewrite-autoedits.js?L29-31

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
