### PR TITLE
fix/chat: Stop the Guardrails shimmer effect when checks are done

### DIFF
--- a/vscode/webviews/components/CodeBlockPlaceholder.module.css
+++ b/vscode/webviews/components/CodeBlockPlaceholder.module.css
@@ -20,13 +20,16 @@
 }
 
 .line {
-    /* This height is important so that the shimmer animation and the final code are the same height. */
+    /* This height is important so that the shimmer animation and the final code are similar height. */
     height: 1rem;
     border-radius: 2px;
-    will-change: transform, opacity;
+    will-change: opacity;
+    background-color: var(--vscode-editorInlayHint-background, var(--vscode-editor-selectionBackground, rgba(255 255 255 / 8%)));
+}
+
+.guardrails-checking .line {
     animation: shimmer 2s ease-in-out;
     animation-iteration-count: infinite;
-    background-color: var(--vscode-editorInlayHint-background, var(--vscode-editor-selectionBackground, rgba(255, 255, 255, 0.08)));
 }
 
 .line:nth-of-type(2n+1) {

--- a/vscode/webviews/components/CodeBlockPlaceholder.story.tsx
+++ b/vscode/webviews/components/CodeBlockPlaceholder.story.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
+import { GuardrailsCheckStatus } from '@sourcegraph/cody-shared'
 import React from 'react'
 import { CodeBlockPlaceholder } from './CodeBlockPlaceholder'
 
@@ -65,6 +66,6 @@ export const Animated: Story = {
             return () => clearInterval(timer)
         }, [index])
 
-        return <CodeBlockPlaceholder text={text} />
+        return <CodeBlockPlaceholder text={text} status={GuardrailsCheckStatus.Checking} />
     },
 }

--- a/vscode/webviews/components/CodeBlockPlaceholder.tsx
+++ b/vscode/webviews/components/CodeBlockPlaceholder.tsx
@@ -1,3 +1,4 @@
+import { GuardrailsCheckStatus } from '@sourcegraph/cody-shared'
 import { clsx } from 'clsx'
 import type React from 'react'
 import styles from '../chat/ChatMessageContent/ChatMessageContent.module.css'
@@ -5,6 +6,7 @@ import modulestyles from './CodeBlockPlaceholder.module.css'
 
 interface CodeBlockPlaceholderProps {
     text: string
+    status: GuardrailsCheckStatus
     className?: string
 }
 
@@ -14,11 +16,22 @@ interface CodeBlockPlaceholderProps {
  */
 export const CodeBlockPlaceholder: React.FC<CodeBlockPlaceholderProps> = ({
     text,
+    status,
     className,
 }: CodeBlockPlaceholderProps) => {
     const widths = text.split('\n').map(s => s.length)
     return (
-        <div className={clsx(styles.content, 'tw-overflow-hidden tw-p-4', className)}>
+        <div
+            className={clsx(
+                styles.content,
+                'tw-overflow-hidden tw-p-4',
+                className,
+                status === GuardrailsCheckStatus.GeneratingCode ||
+                    status === GuardrailsCheckStatus.Checking
+                    ? modulestyles.guardrailsChecking
+                    : modulestyles.guardrailsChecked
+            )}
+        >
             {widths.map((width, index) => (
                 <div
                     key={`${index}-${width}`}

--- a/vscode/webviews/components/GuardrailsApplicator.tsx
+++ b/vscode/webviews/components/GuardrailsApplicator.tsx
@@ -42,7 +42,8 @@ function parseAttributionResult(result: Attribution | Error): GuardrailsResult {
 export interface GuardrailsRenderProps {
     // TODO: This should instead be the thing to display
     showCode: boolean
-    guardrailsStatus: React.ReactNode
+    guardrailsStatus: GuardrailsCheckStatus
+    guardrailsStatusDisplay: React.ReactNode
 }
 
 // A cache of Guardrails attribution results. Because React over-rendering can
@@ -258,7 +259,8 @@ export const GuardrailsApplicator: React.FC<GuardrailsApplicatorProps> = ({
         <>
             {children({
                 showCode,
-                guardrailsStatus: statusDisplay,
+                guardrailsStatus: guardrailsResult.status,
+                guardrailsStatusDisplay: statusDisplay,
             })}
         </>
     )

--- a/vscode/webviews/components/RichCodeBlock.tsx
+++ b/vscode/webviews/components/RichCodeBlock.tsx
@@ -167,11 +167,11 @@ export const RichCodeBlock: React.FC<RichCodeBlockProps> = ({
             guardrails={guardrails}
             isCodeComplete={isCodeComplete}
         >
-            {({ showCode, guardrailsStatus }) => (
+            {({ showCode, guardrailsStatus, guardrailsStatusDisplay }) => (
                 <div className={clsx('tw-overflow-hidden', className)}>
                     {!showCode ? (
                         // When code shouldn't be show, display a placeholder
-                        <CodeBlockPlaceholder text={code} />
+                        <CodeBlockPlaceholder text={code} status={guardrailsStatus} />
                     ) : (
                         // Otherwise show the actual code with syntax highlighting
                         <pre className={styles.content}>{children}</pre>
@@ -182,7 +182,7 @@ export const RichCodeBlock: React.FC<RichCodeBlockProps> = ({
                     <div className={styles.buttonsContainer}>
                         <div className={styles.buttons}>
                             {showCode && actionButtons}
-                            {guardrailsStatus}
+                            {guardrailsStatusDisplay}
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
...not sure why pr-auditor/pre-merge does not think the following is a test plan:

# Test plan

1. Connect to an instance with `"attribution.enabled": true, "attribution.mode": "enforced"`
2. Prompt Cody to generate 10+ lines of code which matches code indexed by sourcegraph.com, in this example "generate hello world in INTERCAL"
3. Check that the shimmer effect appears on the lines as the code is being generated and checked, but stops when the attribution matches (or the API fails with a timeout.)

Subtle in a screenshot, but note how each line appears the same tone. The shimmering has stopped:

![Guardrails attribution match stops the shimmer](https://github.com/user-attachments/assets/098c331d-b478-4733-9bd3-b335ab42e1e9)