### PR TITLE
feat(chat): update code search tool

### DIFF
--- a/vscode/src/chat/chat-view/tools/schema.ts
+++ b/vscode/src/chat/chat-view/tools/schema.ts
@@ -39,6 +39,22 @@ export const GetDiagnosticSchema = z.object({
 
 export const CodeSearchSchema = z.object({
     query: z.string().describe('Keyword query to search for.'),
+    include: z
+        .string()
+        .optional()
+        .describe('Glob pattern to include files in the search. Default is all files.'),
+    exclude: z
+        .string()
+        .optional()
+        .describe('Glob pattern to exclude files from the search. Default is no exclusions.'),
+    dir: z
+        .string()
+        .optional()
+        .describe('Directory to search in. Default to use the current codebase root.'),
+})
+
+export const SearchAgentSchema = z.object({
+    query: z.string().describe('Specific instruction for the agent to follow when searching for code.'),
 })
 
 // Define types based on schemas for type safety

--- a/vscode/src/chat/chat-view/tools/search.ts
+++ b/vscode/src/chat/chat-view/tools/search.ts
@@ -1,3 +1,5 @@
+import { exec } from 'node:child_process'
+import { promisify } from 'node:util'
 import type { Span } from '@opentelemetry/api'
 import {
     type ContextItem,
@@ -6,9 +8,11 @@ import {
     UIToolStatus,
     displayPath,
     firstValueFrom,
+    logDebug,
     pendingOperation,
 } from '@sourcegraph/cody-shared'
 import type { ContextItemToolState } from '@sourcegraph/cody-shared/src/codebase-context/messages'
+import * as vscode from 'vscode'
 import { URI } from 'vscode-uri'
 import type { AgentTool } from '.'
 import { getCorpusContextItemsForEditorState } from '../../initialContext'
@@ -39,6 +43,34 @@ export async function getCodebaseSearchTool(
                 const repo = corpusItems.find(i => i.type === 'tree' || i.type === 'repository')
                 const mentions = repo ? [repo] : []
 
+                try {
+                    // Local search using grep
+                    if (validInput.query) {
+                        logDebug('grep_search', `Searching for: ${validInput.query}`, {
+                            verbose: { mentions },
+                        })
+
+                        // Perform local search
+                        const searchResults = await grep(validInput.query, {
+                            dir: repo?.uri.fsPath,
+                        })
+
+                        if (searchResults.length > 0) {
+                            return createSearchToolStateItem(
+                                validInput.query,
+                                searchResults,
+                                UIToolStatus.Done,
+                                startTime
+                            )
+                        }
+                    }
+                } catch (error) {
+                    logDebug('grep_search', `Local search failed: ${error}`, {
+                        verbose: { mentions },
+                    })
+                }
+
+                // If local search fails or returns no results, fallback to remote search
                 try {
                     const searches = await contextRetriever.retrieveContext(
                         toStructuredMentions(mentions),
@@ -126,5 +158,188 @@ export function createSearchToolStateItem(
             `Status: ${status}`,
             ...(duration ? [`Duration: ${duration}ms`] : []),
         ],
+    }
+}
+
+let useRipGrep: boolean | undefined = undefined
+
+// Check if ripgrep can be used for searching.
+async function isRipGrepAvailabile(): Promise<boolean> {
+    if (useRipGrep === undefined) {
+        try {
+            const { stdout } = await promisify(exec)('rg --version')
+            useRipGrep = stdout.includes('ripgrep')
+        } catch {
+            useRipGrep = false
+        }
+        logDebug('grep_search', useRipGrep ? 'use ripgrep' : 'ripgrep not found')
+    }
+    return useRipGrep
+}
+
+const SEARCH_COMMAND_TEMPLATES = {
+    rg: 'rg "{{KEYWORD}}" {{DIR}} --line-number --heading --smart-case',
+    grep: 'grep "{{KEYWORD}}" {{DIR}} -r -n',
+}
+
+async function grep(
+    keyword: string,
+    options: {
+        dir?: string
+        includePattern?: string
+        excludePattern?: string
+    }
+): Promise<ContextItem[]> {
+    try {
+        logDebug('grep_search', `Searching for: ${keyword}`)
+        // Check if ripgrep availability has been determined
+        if (useRipGrep === undefined) {
+            await isRipGrepAvailabile()
+        }
+        // Use workspace root directory if not specified
+        const dir =
+            options.dir || vscode.workspace.workspaceFolders?.[0]?.uri?.toString() || process.cwd()
+        try {
+            const execPromise = promisify(exec)
+            const template = useRipGrep ? SEARCH_COMMAND_TEMPLATES.rg : SEARCH_COMMAND_TEMPLATES.grep
+            const command = template.replace('{{KEYWORD}}', keyword).replace('{{DIR}}', dir ?? '')
+            const { stdout, stderr } = await execPromise(command)
+            logDebug('grep_search', `Searched for ${keyword}`, { verbose: { stdout, stderr } })
+            // Break down the output into context items
+            const searches: ContextItem[] = []
+            const lines = stdout.split('\n')
+            for (const line of lines) {
+                if (!line.trim()) continue // Skip empty lines
+                // Extract file path and line number
+                const match = line.match(/^(.*?):(\d+):(.*)$/)
+                if (match) {
+                    const filePath = match[1]
+                    const lineNumber = Number.parseInt(match[2], 10)
+                    const lineText = match[3].trim()
+                    // Create a ContextItemToolState for each match
+                    searches.push({
+                        type: 'file',
+                        uri: URI.file(filePath),
+                        title: filePath,
+                        description: `Line ${lineNumber}`,
+                        content: lineText,
+                        source: ContextItemSource.Search,
+                        range: {
+                            start: { line: lineNumber - 1, character: 0 }, // 0-based index
+                            end: { line: lineNumber - 1, character: lineText.length },
+                        },
+                    } satisfies ContextItem)
+                }
+                return searches
+            }
+        } catch (error) {
+            throw new Error(`Grep search failed: ${error}`)
+        }
+    } catch (error) {
+        const errorMsg = error instanceof Error ? error : new Error('Unknown error')
+        throw new Error(`Grep search failed: ${errorMsg}`)
+    }
+    return []
+}
+
+/**
+ * Search for a term in the workspace files using VSCode's file search capabilities.
+ * This function searches for the term in all files that match the include pattern
+ * and are not excluded by the exclude pattern.
+ * @param term The search term to look for
+ * @param options Search options
+ * @returns Array of search results with file paths and matching lines
+ */
+export async function vscodeSearch(
+    term: string,
+    options: {
+        includePattern?: string
+        excludePattern?: string
+        directory?: string
+        caseSensitive?: boolean
+        maxResults?: number
+    } = {}
+): Promise<Array<{ uri: vscode.Uri; lineNumber: number; lineText: string }>> {
+    if (!term || term.trim() === '') {
+        throw new Error('Search term is required')
+    }
+    try {
+        logDebug('file_operations', `Searching for: ${term}`)
+        // Get workspace folder
+        const workspaceFolder = vscode.workspace.workspaceFolders?.[0]
+        if (!workspaceFolder) {
+            throw new Error('No workspace folder is open')
+        }
+        // Determine search directory
+        let searchDir = workspaceFolder
+        if (options.directory) {
+            const dirUri = vscode.Uri.joinPath(workspaceFolder.uri, options.directory)
+            try {
+                // Check if directory exists
+                await vscode.workspace.fs.stat(dirUri)
+                // Create a custom workspace folder for the search
+                searchDir = {
+                    uri: dirUri,
+                    name: options.directory.split('/').pop() || options.directory,
+                    index: 0,
+                }
+            } catch (error) {
+                throw new Error(`Directory not found: ${options.directory}`)
+            }
+        }
+        // Create search pattern
+        const searchPattern = new vscode.RelativePattern(searchDir, '**/*')
+        // Find all files that match the include pattern
+        const files = await vscode.workspace.findFiles(
+            options.includePattern ? options.includePattern : searchPattern,
+            options.excludePattern,
+            options.maxResults
+        )
+        logDebug('file_operations', `Found ${files.length} files to search in`)
+        // Search for the term in each file
+        const searchResults: Array<{ uri: vscode.Uri; lineNumber: number; lineText: string }> = []
+        for (const fileUri of files) {
+            try {
+                const document = await vscode.workspace.openTextDocument(fileUri)
+                const fileContent = document.getText()
+                // Create a regex for the search term
+                const regex = new RegExp(
+                    term.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&'), // Escape special characters
+                    options.caseSensitive ? 'g' : 'gi'
+                )
+                let match: RegExpExecArray | null
+                match = regex.exec(fileContent)
+                while (match !== null) {
+                    const position = document.positionAt(match.index)
+                    const lineNumber = position.line
+                    const lineText = document.lineAt(lineNumber).text
+
+                    searchResults.push({
+                        uri: fileUri,
+                        lineNumber,
+                        lineText,
+                    })
+                    // Limit results if maxResults is specified
+                    if (options.maxResults && searchResults.length >= options.maxResults) {
+                        break
+                    }
+
+                    match = regex.exec(fileContent)
+                }
+            } catch (error) {
+                // Skip files that can't be read
+                logDebug('file_operations', `Error reading file ${fileUri.toString()}: ${error}`)
+                continue
+            }
+            // Limit results if maxResults is specified
+            if (options.maxResults && searchResults.length >= options.maxResults) {
+                break
+            }
+        }
+        logDebug('file_operations', `Found ${searchResults.length} results for term: ${term}`)
+        return searchResults
+    } catch (error: any) {
+        logDebug('file_operations', `Error searching for term "${term}": ${error.message}`)
+        throw new Error(`Failed to search files: ${error.message}`)
     }
 }

--- a/vscode/src/chat/chat-view/tools/shell.ts
+++ b/vscode/src/chat/chat-view/tools/shell.ts
@@ -38,7 +38,7 @@ export const shellTool: AgentTool = {
     spec: {
         name: 'run_terminal_command',
         description:
-            'Run an arbitrary terminal command at the root of the users project. E.g. `ls -la` for listing files, or `find` for searching latest version of the codebase files locally.',
+            'Run an arbitrary terminal command at the root of the users project. E.g. `ls -la` for listing files. The command must not be interactive and must be shell escaped. The command will be run in the root of the current workspace folder.',
         input_schema: zodToolSchema(RunTerminalCommandSchema),
     },
     invoke: async (input: RunTerminalCommandInput) => {


### PR DESCRIPTION
This commit introduces several enhancements to the code search tool used in the chat interface:

- Implements local search using `grep` or `ripgrep` for faster results within the codebase. It falls back to remote search if local search fails or returns no results.
- Adds schema options for `include`, `exclude`, and `dir` to allow users to specify file patterns and directories for the search.
- Updates the shell tool description to clarify its usage and limitations, emphasizing non-interactive commands and shell escaping.

These changes improve the efficiency and flexibility of the code search tool, providing users with more control over their search queries.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Try asking Cody
