### PR TITLE
feat(tabs): Move "Open in Editor" button to secondary position

### DIFF
--- a/vscode/webviews/tabs/TabsBar.tsx
+++ b/vscode/webviews/tabs/TabsBar.tsx
@@ -129,8 +129,8 @@ export const TabsBar = memo<TabsBarProps>(props => {
                     <div className="tw-flex tw-ml-auto">
                         <TabButton
                             prominent
-                            Icon={showOpenInEditor ? ColumnsIcon : MessageSquarePlusIcon}
-                            title={showOpenInEditor ? 'Open in Editor' : 'New Chat'}
+                            Icon={MessageSquarePlusIcon}
+                            title={'New Chat'}
                             IDE={IDE}
                             tooltipExtra={IDE === CodyIDE.VSCode && '(⇧⌥/)'}
                             view={View.Chat}
@@ -138,18 +138,30 @@ export const TabsBar = memo<TabsBarProps>(props => {
                             onClick={() =>
                                 handleSubActionClick({
                                     changesView: View.Chat,
-                                    command: `${
-                                        showOpenInEditor
-                                            ? 'cody.chat.moveToEditor'
-                                            : getCreateNewChatCommand({
-                                                  IDE,
-                                                  webviewType,
-                                                  multipleWebviewsEnabled,
-                                              })
-                                    }`,
+                                    command: getCreateNewChatCommand({
+                                        IDE,
+                                        webviewType,
+                                        multipleWebviewsEnabled,
+                                    }),
                                 })
                             }
                         />
+                        {showOpenInEditor && (
+                            <TabButton
+                                prominent
+                                Icon={ColumnsIcon}
+                                title={'Open in Editor'}
+                                IDE={IDE}
+                                view={View.Chat}
+                                data-testid="open-in-editor-button"
+                                onClick={() =>
+                                    handleSubActionClick({
+                                        changesView: View.Chat,
+                                        command: 'cody.chat.moveToEditor',
+                                    })
+                                }
+                            />
+                        )}
                         {IDE !== CodyIDE.Web && (
                             <UserMenu
                                 authStatus={user.user as AuthenticatedAuthStatus}


### PR DESCRIPTION
This commit moves the "Open in Editor" button in the TabsBar to a secondary position, next to the "New Chat" button.

The "New Chat" button is now always visible as the primary action. The "Open in Editor" button is displayed conditionally based on the `showOpenInEditor` prop. This change improves the user experience by prioritizing the "New Chat" action while still providing easy access to the "Open in Editor" functionality.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Fix https://linear.app/sourcegraph/issue/CODY-5587/new-editor-and-new-chat-should-both-show-in-nav-bar

<img width="485" alt="image" src="https://github.com/user-attachments/assets/77facb21-54d9-4361-b801-6c7434ca5b61" />
