### PR TITLE
fix(agentic chat): Update Sonnet model ID check in syncModels

### DIFF
--- a/lib/shared/src/models/sync.ts
+++ b/lib/shared/src/models/sync.ts
@@ -275,8 +275,9 @@ export function syncModels({
                                                 const haikuModel = data.primaryModels.find(m =>
                                                     m.id.includes('5-haiku')
                                                 )
+                                                // Look for any sonnet model to add Deep Cody.
                                                 const sonnetModel = data.primaryModels.find(m =>
-                                                    m.id.includes('5-sonnet')
+                                                    m.id.includes('sonnet')
                                                 )
                                                 const hasDeepCody = data.primaryModels.some(m =>
                                                     m.id.includes('deep-cody')


### PR DESCRIPTION
The `syncModels` function was incorrectly checking for the presence of '5-sonnet' in the model ID. This commit updates the check to look for 'sonnet' instead, which is the correct identifier for the Sonnet model regardless of their version number.

This is a temporary solution until we make agentic chat available to all models

https://linear.app/sourcegraph/issue/CODY-5598


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

1. Open cody and connect to demo
2. Confirm Agentic Chat is showing up in model drop down