### PR TITLE
fix(autoedit): Skip automatically enrollment when running in other clients

### DIFF
--- a/vscode/src/autoedits/autoedit-onboarding.ts
+++ b/vscode/src/autoedits/autoedit-onboarding.ts
@@ -9,6 +9,7 @@ import {
     telemetryRecorder,
 } from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
+import { isRunningInsideAgent } from '../jsonrpc/isRunningInsideAgent'
 import { localStorage } from '../services/LocalStorageProvider'
 import { isUserEligibleForAutoeditsFeature } from './create-autoedits-provider'
 
@@ -18,6 +19,12 @@ export class AutoEditBetaOnboarding implements vscode.Disposable {
     )
 
     public async enrollUserToAutoEditBetaIfEligible(): Promise<void> {
+        if (isRunningInsideAgent()) {
+            // We do not currently automatically opt users into auto-edit if we are running inside Agent.
+            // This is because Agent support is still experimental and is only ready for dogfooding right now.
+            return
+        }
+
         const isUserEligibleForAutoeditBeta = await this.isUserEligibleForAutoeditBetaOverride()
         if (isUserEligibleForAutoeditBeta) {
             await this.enrollUserToAutoEditBeta()


### PR DESCRIPTION
## Description

Not 100% sure if this would be an issue or not (as we're directly modifying the VS Code workspace settings, unsure if that's propagated to Agent)... but to be on the safe side we should skip auto-enrollment when not running in VS Code

## Test plan

1. Run auto-edits in JetBrains but do not set `suggestionsMode`
2. Check that this setting is not automatically set

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
