### PR TITLE
Crash occurred when user tries to save new code file

### DIFF
--- a/jetbrains/src/main/kotlin/com/sourcegraph/utils/CodyEditorUtil.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/utils/CodyEditorUtil.kt
@@ -181,20 +181,19 @@ object CodyEditorUtil {
 
   @JvmStatic
   fun fixUriString(uriString: String): String {
-      if (uriString.startsWith("untitled://")) {
-          // IntelliJ does not support in-memory files so we are using scratch files instead
-          return uriString.substringAfterLast(':').trimStart('/', '\\')
-      }
-      else {
-          // Check `ProtocolTextDocumentExt.normalizeToVscUriFormat` for explanation
-          val patchedUri = uriString.replace("file://wsl.localhost/", "file:////wsl.localhost/")
-          return if (patchedUri.startsWith("file://")) patchedUri else "file://$patchedUri"
-      }
+    if (uriString.startsWith("untitled://")) {
+      // IntelliJ does not support in-memory files so we are using scratch files instead
+      return uriString.substringAfterLast(':').trimStart('/', '\\')
+    } else {
+      // Check `ProtocolTextDocumentExt.normalizeToVscUriFormat` for explanation
+      val patchedUri = uriString.replace("file://wsl.localhost/", "file:////wsl.localhost/")
+      return if (patchedUri.startsWith("file://")) patchedUri else "file://$patchedUri"
+    }
   }
 
   fun findFileOrScratch(project: Project, uriString: String): VirtualFile? {
     val fixedUri = fixUriString(uriString)
-    if (fixedUri.startsWith("untitled://")) {
+    if (uriString.startsWith("untitled://")) {
       return ScratchRootType.getInstance()
           .findFile(project, fixedUri, ScratchFileService.Option.existing_only)
     } else {

--- a/jetbrains/src/test/kotlin/utils/CodyEditorUtilTest.kt
+++ b/jetbrains/src/test/kotlin/utils/CodyEditorUtilTest.kt
@@ -1,0 +1,44 @@
+package utils
+
+import com.sourcegraph.utils.CodyEditorUtil
+import junit.framework.TestCase.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+class CodyEditorUtilTest(private val uri: String, private val expectedUri: String) {
+
+  @Test
+  fun canFixUriPath() {
+    val result = CodyEditorUtil.fixUriString(uri)
+
+    assertEquals(expectedUri, result)
+  }
+
+  companion object {
+    @JvmStatic
+    @Parameterized.Parameters
+    fun data(): Collection<Array<Any>> {
+      return listOf(
+          arrayOf(
+              "C:%5Cdev%5CJetbrainsTestsProjects%5CValidate.kt",
+              "file://C:%5Cdev%5CJetbrainsTestsProjects%5CValidate.kt"),
+          arrayOf(
+              "file://C:%5Cdev%5CJetbrainsTestsProjects%5Ckotlin%5CTestProject%5CValidate.kt",
+              "file://C:%5Cdev%5CJetbrainsTestsProjects%5Ckotlin%5CTestProject%5CValidate.kt"),
+          arrayOf(
+              "untitled://Whatever/path/it/has/MyScratchFile.kt",
+              "Whatever/path/it/has/MyScratchFile.kt"),
+          arrayOf(
+              "file://wsl.localhost/ubuntu/home/user/project/main.py",
+              "file:////wsl.localhost/ubuntu/home/user/project/main.py"),
+          arrayOf(
+              "file:////wsl.localhost/debian/etc/hosts", "file:////wsl.localhost/debian/etc/hosts"),
+          // Unix-like paths needing prefix
+          arrayOf("/home/user/my_code.go", "file:///home/user/my_code.go"),
+          arrayOf("file:///usr/local/bin/script.sh", "file:///usr/local/bin/script.sh"),
+      )
+    }
+  }
+}


### PR DESCRIPTION
`VfsUtil.toUri()` interpert the drive letter in the windows path as a scheme in the uri. This leads to a URI object which, when the `toPath()` method is called, causes an error. This prevents the creation of a new code file and spoils all "Save file" functionality. This PR tries to remedy the situation by conditionally adding a "file" prefix to the uri string. Using `withScheme()` does not fix the situation because the scheme is already mistakenly set when the URI is created. 

## Test plan
1. Use chat to generate some code
2. Under code block click on Save file icon
3. Add name for file
4. Click on 'OK'
5. Code file should be created and opened in the editor without errors
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
