### PR TITLE
Add head dump command to Cody debug options

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/CodyAgentServer.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/CodyAgentServer.kt
@@ -102,6 +102,8 @@ interface CodyAgentServer {
   fun testing_closestPostData(params: Testing_ClosestPostDataParams): CompletableFuture<Testing_ClosestPostDataResult>
   @JsonRequest("testing/memoryUsage")
   fun testing_memoryUsage(params: Null?): CompletableFuture<Testing_MemoryUsageResult>
+  @JsonRequest("testing/heapdump")
+  fun testing_heapdump(params: Null?): CompletableFuture<Null?>
   @JsonRequest("testing/awaitPendingPromises")
   fun testing_awaitPendingPromises(params: Null?): CompletableFuture<Null?>
   @JsonRequest("testing/workspaceDocuments")

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/ModelTag.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/ModelTag.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
 package com.sourcegraph.cody.agent.protocol_generated;
 
-typealias ModelTag = String // One of: power, speed, balanced, other, recommended, deprecated, experimental, waitlist, on-waitlist, early-access, internal, pro, free, enterprise, gateway, byok, local, ollama, dev, stream-disabled, vision, reasoning, tools
+typealias ModelTag = String // One of: power, speed, balanced, other, recommended, deprecated, experimental, waitlist, on-waitlist, early-access, internal, pro, free, enterprise, gateway, byok, local, ollama, dev, stream-disabled, vision, reasoning, tools, default
 

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -745,6 +745,10 @@ export class Agent extends MessageHandler implements ExtensionClient {
             return { usage: process.memoryUsage() }
         })
 
+        this.registerAuthenticatedRequest('testing/heapdump', async () => {
+            return await vscode.commands.executeCommand('cody.debug.heapDump')
+        })
+
         this.registerAuthenticatedRequest('testing/networkRequests', async () => {
             const requests = this.params.networkRequests ?? []
             return {

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowFactory.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowFactory.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.wm.ToolWindowFactory
 import com.intellij.ui.content.ContentFactory
 import com.sourcegraph.cody.CodyToolWindowContent.Companion.executeOnInstanceIfNotDisposed
 import com.sourcegraph.cody.config.actions.OpenCodySettingsEditorAction
+import com.sourcegraph.cody.debugging.OpenWebviewDevToolsAction
 import com.sourcegraph.cody.ui.web.WebUIService.Companion.getInstance
 import com.sourcegraph.config.ConfigUtil.isCodyEnabled
 import com.sourcegraph.config.ConfigUtil.isFeatureFlagEnabled

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/debugging/AgentHeapDumpAction.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/debugging/AgentHeapDumpAction.kt
@@ -1,0 +1,11 @@
+package com.sourcegraph.cody.debugging
+
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.sourcegraph.cody.agent.CodyAgentService
+import com.sourcegraph.common.ui.DumbAwareEDTAction
+
+class AgentHeapDumpAction : DumbAwareEDTAction("Agent Heap Dump") {
+  override fun actionPerformed(e: AnActionEvent) {
+    CodyAgentService.withAgent(e.project ?: return) { agent -> agent.server.testing_heapdump(null) }
+  }
+}

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/debugging/OpenWebviewDevToolsAction.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/debugging/OpenWebviewDevToolsAction.kt
@@ -1,6 +1,7 @@
-package com.sourcegraph.cody
+package com.sourcegraph.cody.debugging
 
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.sourcegraph.cody.CodyToolWindowContent
 import com.sourcegraph.common.ui.DumbAwareEDTAction
 
 class OpenWebviewDevToolsAction : DumbAwareEDTAction("Open WebView DevTools") {

--- a/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -400,10 +400,16 @@
                     <override-text place="GoToAction" text="Cody: Enable OffScreen Rendering"/>
                 </action>
                 <action id="cody.openWebviewDevToolsAction"
-                        class="com.sourcegraph.cody.OpenWebviewDevToolsAction"
+                        class="com.sourcegraph.cody.debugging.OpenWebviewDevToolsAction"
                         text="Open DevTools"
                         description="Open DevTools to debug Cody webview">
                     <override-text place="GoToAction" text="Cody: Open DevTools"/>
+                </action>
+                <action id="cody.agentHeapDumpAction"
+                        class="com.sourcegraph.cody.debugging.AgentHeapDumpAction"
+                        text="Agent Heap Dump"
+                        description="Do a heap dump of the Cody agent process">
+                    <override-text place="GoToAction" text="Cody: Agent Heap Dump"/>
                 </action>
             </group>
         </group>

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -558,6 +558,12 @@
         "title": "Report Issue"
       },
       {
+        "command": "cody.debug.heapDump",
+        "category": "Cody Debug",
+        "group": "Debug",
+        "title": "Heap Dump"
+      },
+      {
         "command": "cody.copy.version",
         "category": "Cody Debug",
         "group": "Debug",

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -200,6 +200,7 @@ export type ClientRequests = {
     'testing/requestErrors': [null, { errors: NetworkRequest[] }]
     'testing/closestPostData': [{ url: string; postData: string }, { closestBody: string }]
     'testing/memoryUsage': [null, { usage: MemoryUsage }]
+    'testing/heapdump': [null, null]
     'testing/awaitPendingPromises': [null, null]
     // Retrieve the Agent's copy of workspace documents, for testing/validation.
     'testing/workspaceDocuments': [GetDocumentsParams, GetDocumentsResult]

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -117,6 +117,7 @@ import {
     exportOutputLog,
     openCodyOutputChannel,
 } from './services/utils/export-logs'
+import { dumpCodyHeapSnapshot } from './services/utils/heap-dump'
 import { openCodyIssueReporter } from './services/utils/issue-reporter'
 import { SupercompletionProvider } from './supercompletions/supercompletion-provider'
 import { parseAllVisibleDocuments, updateParseTreeOnEdit } from './tree-sitter/parse-tree-cache'
@@ -707,7 +708,8 @@ async function registerDebugCommands(
         vscode.commands.registerCommand('cody.debug.export.logs', () => exportOutputLog(context.logUri)),
         vscode.commands.registerCommand('cody.debug.outputChannel', () => openCodyOutputChannel()),
         vscode.commands.registerCommand('cody.debug.enable.all', () => enableVerboseDebugMode()),
-        vscode.commands.registerCommand('cody.debug.reportIssue', () => openCodyIssueReporter())
+        vscode.commands.registerCommand('cody.debug.reportIssue', () => openCodyIssueReporter()),
+        vscode.commands.registerCommand('cody.debug.heapDump', () => dumpCodyHeapSnapshot())
     )
 }
 

--- a/vscode/src/services/utils/heap-dump.ts
+++ b/vscode/src/services/utils/heap-dump.ts
@@ -1,0 +1,45 @@
+import * as os from 'node:os'
+import * as path from 'node:path'
+import * as vscode from 'vscode'
+
+export async function dumpCodyHeapSnapshot() {
+    const isNode = typeof process !== 'undefined'
+    if (!isNode) {
+        throw new Error('Heap dump is not supported in web')
+    }
+
+    try {
+        const defaultPath = path.join(
+            os.tmpdir(),
+            `cody-heap-${new Date().toISOString().replace(/[:.]/g, '-')}.heapsnapshot`
+        )
+
+        const fileUri = await vscode.window.showSaveDialog({
+            defaultUri: vscode.Uri.file(defaultPath),
+            filters: {
+                'Heap Snapshots': ['heapsnapshot'],
+            },
+            title: 'Save Cody Heap Snapshot',
+        })
+
+        if (!fileUri) {
+            // User cancelled the save dialog
+            return
+        }
+
+        // biome-ignore lint/style/useNodejsImportProtocol: node:v8 would not work for web compilation
+        const v8 = require('v8')
+        const filename = v8.writeHeapSnapshot(fileUri.path)
+        const msg = `Cody heap dump written to: ${filename}`
+        console.log(msg)
+        vscode.window.showInformationMessage(msg, 'Open containing folder').then(answer => {
+            if (answer === 'Open containing folder') {
+                vscode.env.openExternal(vscode.Uri.file(path.parse(filename).dir))
+            }
+        })
+    } catch (error) {
+        const errorMessage = `Failed to create heap snapshot: ${error}`
+        console.error(errorMessage)
+        vscode.window.showErrorMessage(errorMessage)
+    }
+}


### PR DESCRIPTION
## Changes

This PR adds Heap Dump action for both VSC and JetBrains.
It can be used for debugging memory leaks and general memory performance.

**Interesting fact:**
Doing a heap dump takes few seconds in VSC but few minutes in JetBrains.
We definitely should explain why that happens (and hopefully fix it).

## Test plan

1. Open JetBrains IDE
2. Click `Shift shift` and type "cody heap"
3. Hit enter to confirm running "Cody: Agent Heap Dump" action
4. Select location where you want to save a dump
 
After few minutes IDE should display notification about dump being ready.

The same can be done with VSC. To find the action hit `Ctrl+Shift+P`.

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
