### PR TITLE
feat(telemetry): introduce opentelemetry metrics to cody #CODY-5585

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -515,6 +515,9 @@ importers:
       '@opentelemetry/core':
         specifier: ^1.18.1
         version: 1.18.1(@opentelemetry/api@1.7.0)
+      '@opentelemetry/exporter-metrics-otlp-http':
+        specifier: ^0.45.1
+        version: 0.45.1(@opentelemetry/api@1.7.0)
       '@opentelemetry/exporter-trace-otlp-http':
         specifier: ^0.45.1
         version: 0.45.1(@opentelemetry/api@1.7.0)
@@ -525,6 +528,9 @@ importers:
         specifier: ^0.45.1
         version: 0.45.1(@opentelemetry/api@1.7.0)
       '@opentelemetry/resources':
+        specifier: ^1.18.1
+        version: 1.18.1(@opentelemetry/api@1.7.0)
+      '@opentelemetry/sdk-metrics':
         specifier: ^1.18.1
         version: 1.18.1(@opentelemetry/api@1.7.0)
       '@opentelemetry/sdk-trace-base':
@@ -3723,6 +3729,20 @@ packages:
       '@opentelemetry/semantic-conventions': 1.27.0
     dev: false
 
+  /@opentelemetry/exporter-metrics-otlp-http@0.45.1(@opentelemetry/api@1.7.0):
+    resolution: {integrity: sha512-DvyXkjHIrnQ9ESj8tDrGFzRtVIGOzZpmi80YZdTlwr6TMQzvg4UgHQcGo6wj7ZGzdwAJ7057OgAcDUd+/O/Erg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.7.0
+      '@opentelemetry/core': 1.18.1(@opentelemetry/api@1.7.0)
+      '@opentelemetry/otlp-exporter-base': 0.45.1(@opentelemetry/api@1.7.0)
+      '@opentelemetry/otlp-transformer': 0.45.1(@opentelemetry/api@1.7.0)
+      '@opentelemetry/resources': 1.18.1(@opentelemetry/api@1.7.0)
+      '@opentelemetry/sdk-metrics': 1.18.1(@opentelemetry/api@1.7.0)
+    dev: false
+
   /@opentelemetry/exporter-trace-otlp-http@0.45.1(@opentelemetry/api@1.7.0):
     resolution: {integrity: sha512-a6CGqSG66n5R1mghzLMzyzn3iGap1b0v+0PjKFjfYuwLtpHQBxh2PHxItu+m2mXSwnM4R0GJlk9oUW5sQkCE0w==}
     engines: {node: '>=14'}
@@ -4310,7 +4330,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.26.0
       '@radix-ui/primitive': 1.0.1
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.37)(react@18.2.0)
       '@radix-ui/react-context': 1.0.1(@types/react@18.2.37)(react@18.2.0)

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -56,7 +56,14 @@
     "release-notes": "ts-node-transpile-only ./scripts/release-notes.ts",
     "measure-bundle-size": "cross-env LOG_BUNDLE_SIZE=true ts-node-transpile-only ./scripts/measure-bundle-size.ts"
   },
-  "categories": ["AI", "Chat", "Programming Languages", "Machine Learning", "Snippets", "Education"],
+  "categories": [
+    "AI",
+    "Chat",
+    "Programming Languages",
+    "Machine Learning",
+    "Snippets",
+    "Education"
+  ],
   "keywords": [
     "cody",
     "codey",
@@ -121,7 +128,11 @@
   },
   "main": "./dist/extension.node.js",
   "browser": "./dist/extension.web.js",
-  "activationEvents": ["onLanguage", "onStartupFinished", "onWebviewPanel:cody.editorPanel"],
+  "activationEvents": [
+    "onLanguage",
+    "onStartupFinished",
+    "onWebviewPanel:cody.editorPanel"
+  ],
   "contributes": {
     "walkthroughs": [
       {
@@ -691,13 +702,17 @@
       },
       {
         "command": "cody.supercompletion.jumpTo",
-        "args": ["next"],
+        "args": [
+          "next"
+        ],
         "key": "shift+ctrl+down",
         "when": "cody.activated && !editorReadonly && cody.hasActionableSupercompletion"
       },
       {
         "command": "cody.supercompletion.jumpTo",
-        "args": ["previous"],
+        "args": [
+          "previous"
+        ],
         "key": "shift+ctrl+up",
         "when": "cody.activated && !editorReadonly && cody.hasActionableSupercompletion"
       },
@@ -941,7 +956,10 @@
           "order": 2,
           "type": "string",
           "markdownDescription": "A Git repository URL to use instead of allowing Cody to infer the Git repository from the workspace.",
-          "examples": ["https://github.com/sourcegraph/cody", "ssh://git@github.com/sourcegraph/cody"]
+          "examples": [
+            "https://github.com/sourcegraph/cody",
+            "ssh://git@github.com/sourcegraph/cody"
+          ]
         },
         "cody.customHeaders": {
           "order": 4,
@@ -957,7 +975,11 @@
         },
         "cody.suggestions.mode": {
           "type": "string",
-          "enum": ["autocomplete", "auto-edit (Beta)", "off"],
+          "enum": [
+            "autocomplete",
+            "auto-edit (Beta)",
+            "off"
+          ],
           "enumDescriptions": [
             "Suggests standard code completions as you type.",
             "Suggests advanced context-aware code edits as you navigate the codebase. Experimental feature for Pro and Enterprise users.",
@@ -996,12 +1018,18 @@
           "order": 6,
           "type": "string",
           "markdownDescription": "A custom instruction to be included at the start of all chat messages (e.g. \"Answer all my questions in Spanish.\")",
-          "examples": ["Answer all my questions in Spanish."]
+          "examples": [
+            "Answer all my questions in Spanish."
+          ]
         },
         "cody.chat.defaultLocation": {
           "order": 6,
           "type": "string",
-          "enum": ["sticky", "sidebar", "editor"],
+          "enum": [
+            "sticky",
+            "sidebar",
+            "editor"
+          ],
           "markdownDescription": "Controls where the Cody chat view opens when the user invokes the `Cody: New Chat` command, or the Alt+L and Alt+/ shortcuts.",
           "enumDescriptions": [
             "Opens in the last-activated view location, which is set whenever the user explicitly chooses to open chat in a given location",
@@ -1014,7 +1042,9 @@
           "order": 7,
           "type": "string",
           "markdownDescription": "A custom instruction to be included at the end of all instructions for edit commands (e.g. \"Write all unit tests with Jest instead of detected framework.\")",
-          "examples": ["Write all unit tests with Jest instead of detected framework."]
+          "examples": [
+            "Write all unit tests with Jest instead of detected framework."
+          ]
         },
         "cody.codeActions.enabled": {
           "order": 11,
@@ -1059,7 +1089,10 @@
         "cody.telemetry.level": {
           "order": 99,
           "type": "string",
-          "enum": ["all", "off"],
+          "enum": [
+            "all",
+            "off"
+          ],
           "enumDescriptions": [
             "Sends usage data and errors.",
             "[Enterprise-only] Disables all extension telemetry."
@@ -1070,7 +1103,10 @@
         "cody.autocomplete.advanced.provider": {
           "type": "string",
           "default": "default",
-          "enum": ["default", "experimental-ollama"],
+          "enum": [
+            "default",
+            "experimental-ollama"
+          ],
           "enumDescriptions": [
             "Our recommended setup with the best balance of quality and latency. We continuously update this for optimal performance.",
             "Experimental support for Ollama users. Use `cody.autocomplete.experimental.ollamaOptions` to configure requests to Ollama server."
@@ -1094,7 +1130,10 @@
         },
         "cody.experimental.foldingRanges": {
           "type": "string",
-          "enum": ["lsp", "indentation-based"],
+          "enum": [
+            "lsp",
+            "indentation-based"
+          ],
           "enumDescriptions": [
             "Use folding ranges that are enabled by default in VS Code, and are usually powered by LSP",
             "Use custom implementation of folding ranges that is indentation based. This is the implementation that is used by other Cody clients like the JetBrains plugin"
@@ -1105,7 +1144,11 @@
         "cody.autocomplete.experimental.graphContext": {
           "type": "string",
           "default": null,
-          "enum": [null, "tsc", "tsc-mixed"],
+          "enum": [
+            null,
+            "tsc",
+            "tsc-mixed"
+          ],
           "markdownDescription": "Use the code graph to retrieve context for autocomplete requests."
         },
         "cody.autocomplete.experimental.fireworksOptions": {
@@ -1203,7 +1246,11 @@
         },
         "cody.net.mode": {
           "type": "string",
-          "enum": ["auto", "bypass", "vscode"],
+          "enum": [
+            "auto",
+            "bypass",
+            "vscode"
+          ],
           "enumDescriptions": [
             "Default behavior. If `cody.net.proxy.endpoint` is configured, bypassing is automatically enabled, otherwise direct is used.",
             "Bypass VSCode's network stack, using Cody's instead.",
@@ -1217,7 +1264,11 @@
           "type": "string",
           "default": "",
           "pattern": "^((http|https|socks|socks4|socks4a|socks5|socks5h)://[^:]+:\\d+|unix://(~|/|[a-zA-Z]:\\\\).+)?$",
-          "examples": ["https://localhost:7080", "socks5://1.2.3.4:1080", "unix://~/cody-proxy.sock"]
+          "examples": [
+            "https://localhost:7080",
+            "socks5://1.2.3.4:1080",
+            "unix://~/cody-proxy.sock"
+          ]
         },
         "cody.net.proxy.skipCertValidation": {
           "description": "Whether to skip proxy server CA cert validation. Useful if the proxy server uses a self-signed certificate.",
@@ -1248,8 +1299,16 @@
           "examples": [
             {
               "shell": {
-                "allow": ["git", "ls", "find"],
-                "block": ["history", "sudo", "rm"]
+                "allow": [
+                  "git",
+                  "ls",
+                  "find"
+                ],
+                "block": [
+                  "history",
+                  "sudo",
+                  "rm"
+                ]
               }
             }
           ],
@@ -1269,7 +1328,10 @@
           "markdownDescription": "Configure external authentication providers for Cody requests. Each provider consists of a command that generates HTTP headers used for authentication for a given endpoint.\n\n**How it works:**\n1. The specified command outputs a JSON object with header-value pairs\n2. These headers are included in authenticated Cody requests to the specified endpoint\n3. HTTP authentication proxy need to be used to enable custom authentication flows (e.g. JWT tokens, Oath2, etc)\n\nSee [HTTP Authentication Proxies](https://sourcegraph.com/docs/admin/auth#http-authentication-proxies) for proxy configuration.",
           "items": {
             "type": "object",
-            "required": ["endpoint", "executable"],
+            "required": [
+              "endpoint",
+              "executable"
+            ],
             "properties": {
               "endpoint": {
                 "type": "string",
@@ -1277,7 +1339,9 @@
               },
               "executable": {
                 "type": "object",
-                "required": ["commandLine"],
+                "required": [
+                  "commandLine"
+                ],
                 "properties": {
                   "commandLine": {
                     "type": "array",
@@ -1390,7 +1454,9 @@
     "untrustedWorkspaces": {
       "supported": "limited",
       "description": "Cody only uses providers (configured in `openctx.providers`) from trusted workspaces because providers may execute arbitrary code.",
-      "restrictedConfigurations": ["openctx.providers"]
+      "restrictedConfigurations": [
+        "openctx.providers"
+      ]
     }
   },
   "dependencies": {
@@ -1400,10 +1466,12 @@
     "@openctx/vscode-lib": "^0.0.26",
     "@opentelemetry/api": "^1.7.0",
     "@opentelemetry/core": "^1.18.1",
+    "@opentelemetry/exporter-metrics-otlp-http": "^0.45.1",
     "@opentelemetry/exporter-trace-otlp-http": "^0.45.1",
     "@opentelemetry/instrumentation": "^0.45.1",
     "@opentelemetry/instrumentation-http": "^0.45.1",
     "@opentelemetry/resources": "^1.18.1",
+    "@opentelemetry/sdk-metrics": "^1.18.1",
     "@opentelemetry/sdk-trace-base": "^1.18.1",
     "@opentelemetry/sdk-trace-node": "^1.18.1",
     "@opentelemetry/semantic-conventions": "^1.18.1",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -56,14 +56,7 @@
     "release-notes": "ts-node-transpile-only ./scripts/release-notes.ts",
     "measure-bundle-size": "cross-env LOG_BUNDLE_SIZE=true ts-node-transpile-only ./scripts/measure-bundle-size.ts"
   },
-  "categories": [
-    "AI",
-    "Chat",
-    "Programming Languages",
-    "Machine Learning",
-    "Snippets",
-    "Education"
-  ],
+  "categories": ["AI", "Chat", "Programming Languages", "Machine Learning", "Snippets", "Education"],
   "keywords": [
     "cody",
     "codey",
@@ -128,11 +121,7 @@
   },
   "main": "./dist/extension.node.js",
   "browser": "./dist/extension.web.js",
-  "activationEvents": [
-    "onLanguage",
-    "onStartupFinished",
-    "onWebviewPanel:cody.editorPanel"
-  ],
+  "activationEvents": ["onLanguage", "onStartupFinished", "onWebviewPanel:cody.editorPanel"],
   "contributes": {
     "walkthroughs": [
       {
@@ -702,17 +691,13 @@
       },
       {
         "command": "cody.supercompletion.jumpTo",
-        "args": [
-          "next"
-        ],
+        "args": ["next"],
         "key": "shift+ctrl+down",
         "when": "cody.activated && !editorReadonly && cody.hasActionableSupercompletion"
       },
       {
         "command": "cody.supercompletion.jumpTo",
-        "args": [
-          "previous"
-        ],
+        "args": ["previous"],
         "key": "shift+ctrl+up",
         "when": "cody.activated && !editorReadonly && cody.hasActionableSupercompletion"
       },
@@ -956,10 +941,7 @@
           "order": 2,
           "type": "string",
           "markdownDescription": "A Git repository URL to use instead of allowing Cody to infer the Git repository from the workspace.",
-          "examples": [
-            "https://github.com/sourcegraph/cody",
-            "ssh://git@github.com/sourcegraph/cody"
-          ]
+          "examples": ["https://github.com/sourcegraph/cody", "ssh://git@github.com/sourcegraph/cody"]
         },
         "cody.customHeaders": {
           "order": 4,
@@ -975,11 +957,7 @@
         },
         "cody.suggestions.mode": {
           "type": "string",
-          "enum": [
-            "autocomplete",
-            "auto-edit (Beta)",
-            "off"
-          ],
+          "enum": ["autocomplete", "auto-edit (Beta)", "off"],
           "enumDescriptions": [
             "Suggests standard code completions as you type.",
             "Suggests advanced context-aware code edits as you navigate the codebase. Experimental feature for Pro and Enterprise users.",
@@ -1018,18 +996,12 @@
           "order": 6,
           "type": "string",
           "markdownDescription": "A custom instruction to be included at the start of all chat messages (e.g. \"Answer all my questions in Spanish.\")",
-          "examples": [
-            "Answer all my questions in Spanish."
-          ]
+          "examples": ["Answer all my questions in Spanish."]
         },
         "cody.chat.defaultLocation": {
           "order": 6,
           "type": "string",
-          "enum": [
-            "sticky",
-            "sidebar",
-            "editor"
-          ],
+          "enum": ["sticky", "sidebar", "editor"],
           "markdownDescription": "Controls where the Cody chat view opens when the user invokes the `Cody: New Chat` command, or the Alt+L and Alt+/ shortcuts.",
           "enumDescriptions": [
             "Opens in the last-activated view location, which is set whenever the user explicitly chooses to open chat in a given location",
@@ -1042,9 +1014,7 @@
           "order": 7,
           "type": "string",
           "markdownDescription": "A custom instruction to be included at the end of all instructions for edit commands (e.g. \"Write all unit tests with Jest instead of detected framework.\")",
-          "examples": [
-            "Write all unit tests with Jest instead of detected framework."
-          ]
+          "examples": ["Write all unit tests with Jest instead of detected framework."]
         },
         "cody.codeActions.enabled": {
           "order": 11,
@@ -1089,10 +1059,7 @@
         "cody.telemetry.level": {
           "order": 99,
           "type": "string",
-          "enum": [
-            "all",
-            "off"
-          ],
+          "enum": ["all", "off"],
           "enumDescriptions": [
             "Sends usage data and errors.",
             "[Enterprise-only] Disables all extension telemetry."
@@ -1103,10 +1070,7 @@
         "cody.autocomplete.advanced.provider": {
           "type": "string",
           "default": "default",
-          "enum": [
-            "default",
-            "experimental-ollama"
-          ],
+          "enum": ["default", "experimental-ollama"],
           "enumDescriptions": [
             "Our recommended setup with the best balance of quality and latency. We continuously update this for optimal performance.",
             "Experimental support for Ollama users. Use `cody.autocomplete.experimental.ollamaOptions` to configure requests to Ollama server."
@@ -1130,10 +1094,7 @@
         },
         "cody.experimental.foldingRanges": {
           "type": "string",
-          "enum": [
-            "lsp",
-            "indentation-based"
-          ],
+          "enum": ["lsp", "indentation-based"],
           "enumDescriptions": [
             "Use folding ranges that are enabled by default in VS Code, and are usually powered by LSP",
             "Use custom implementation of folding ranges that is indentation based. This is the implementation that is used by other Cody clients like the JetBrains plugin"
@@ -1144,11 +1105,7 @@
         "cody.autocomplete.experimental.graphContext": {
           "type": "string",
           "default": null,
-          "enum": [
-            null,
-            "tsc",
-            "tsc-mixed"
-          ],
+          "enum": [null, "tsc", "tsc-mixed"],
           "markdownDescription": "Use the code graph to retrieve context for autocomplete requests."
         },
         "cody.autocomplete.experimental.fireworksOptions": {
@@ -1246,11 +1203,7 @@
         },
         "cody.net.mode": {
           "type": "string",
-          "enum": [
-            "auto",
-            "bypass",
-            "vscode"
-          ],
+          "enum": ["auto", "bypass", "vscode"],
           "enumDescriptions": [
             "Default behavior. If `cody.net.proxy.endpoint` is configured, bypassing is automatically enabled, otherwise direct is used.",
             "Bypass VSCode's network stack, using Cody's instead.",
@@ -1264,11 +1217,7 @@
           "type": "string",
           "default": "",
           "pattern": "^((http|https|socks|socks4|socks4a|socks5|socks5h)://[^:]+:\\d+|unix://(~|/|[a-zA-Z]:\\\\).+)?$",
-          "examples": [
-            "https://localhost:7080",
-            "socks5://1.2.3.4:1080",
-            "unix://~/cody-proxy.sock"
-          ]
+          "examples": ["https://localhost:7080", "socks5://1.2.3.4:1080", "unix://~/cody-proxy.sock"]
         },
         "cody.net.proxy.skipCertValidation": {
           "description": "Whether to skip proxy server CA cert validation. Useful if the proxy server uses a self-signed certificate.",
@@ -1299,16 +1248,8 @@
           "examples": [
             {
               "shell": {
-                "allow": [
-                  "git",
-                  "ls",
-                  "find"
-                ],
-                "block": [
-                  "history",
-                  "sudo",
-                  "rm"
-                ]
+                "allow": ["git", "ls", "find"],
+                "block": ["history", "sudo", "rm"]
               }
             }
           ],
@@ -1328,10 +1269,7 @@
           "markdownDescription": "Configure external authentication providers for Cody requests. Each provider consists of a command that generates HTTP headers used for authentication for a given endpoint.\n\n**How it works:**\n1. The specified command outputs a JSON object with header-value pairs\n2. These headers are included in authenticated Cody requests to the specified endpoint\n3. HTTP authentication proxy need to be used to enable custom authentication flows (e.g. JWT tokens, Oath2, etc)\n\nSee [HTTP Authentication Proxies](https://sourcegraph.com/docs/admin/auth#http-authentication-proxies) for proxy configuration.",
           "items": {
             "type": "object",
-            "required": [
-              "endpoint",
-              "executable"
-            ],
+            "required": ["endpoint", "executable"],
             "properties": {
               "endpoint": {
                 "type": "string",
@@ -1339,9 +1277,7 @@
               },
               "executable": {
                 "type": "object",
-                "required": [
-                  "commandLine"
-                ],
+                "required": ["commandLine"],
                 "properties": {
                   "commandLine": {
                     "type": "array",
@@ -1454,9 +1390,7 @@
     "untrustedWorkspaces": {
       "supported": "limited",
       "description": "Cody only uses providers (configured in `openctx.providers`) from trusted workspaces because providers may execute arbitrary code.",
-      "restrictedConfigurations": [
-        "openctx.providers"
-      ]
+      "restrictedConfigurations": ["openctx.providers"]
     }
   },
   "dependencies": {

--- a/vscode/src/autoedits/adapters/base.ts
+++ b/vscode/src/autoedits/adapters/base.ts
@@ -16,6 +16,8 @@ export type ModelResponseShared = {
      * TODO: update to proper types from different adapters.
      */
     requestBody?: AutoeditsRequestBody | CodeCompletionsParams
+    responseStatusCode: number
+    responseBody: string
 }
 
 export interface SuccessModelResponse extends ModelResponseShared {

--- a/vscode/src/autoedits/adapters/base.ts
+++ b/vscode/src/autoedits/adapters/base.ts
@@ -16,8 +16,6 @@ export type ModelResponseShared = {
      * TODO: update to proper types from different adapters.
      */
     requestBody?: AutoeditsRequestBody | CodeCompletionsParams
-    responseStatusCode: number
-    responseBody: string
 }
 
 export interface SuccessModelResponse extends ModelResponseShared {

--- a/vscode/src/autoedits/autoedits-provider.ts
+++ b/vscode/src/autoedits/autoedits-provider.ts
@@ -17,6 +17,7 @@ import { ContextRankingStrategy } from '../completions/context/completions-conte
 import { ContextMixer } from '../completions/context/context-mixer'
 import { DefaultContextStrategyFactory } from '../completions/context/context-strategy'
 import { getCurrentDocContext } from '../completions/get-current-doc-context'
+import { defaultVSCodeExtensionClient } from '../extension-client'
 import type { AutocompleteEditItem, AutoeditChanges } from '../jsonrpc/agent-protocol'
 import { isRunningInsideAgent } from '../jsonrpc/isRunningInsideAgent'
 import type { FixupController } from '../non-stop/FixupController'
@@ -171,7 +172,7 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
             })
         )
 
-        const meter = metrics.getMeter('autoedit')
+        const meter = metrics.getMeter('autoedit', defaultVSCodeExtensionClient().clientVersion)
 
         this.completionLatencyMetric = meter.createHistogram<CompletionLatencyMetricAttributes>(
             'autoedits.inlinecompletions.latency',


### PR DESCRIPTION
Introduces OpenTelemetry's metrics support to cody client. This allows cody client to send real-time metrics (currently every minute) for observability, monitoring. The metrics can be queried with prometheus or GCP's metric explorer. For example:

<img width="1586" alt="Screenshot 2025-04-01 at 10 42 38 AM" src="https://github.com/user-attachments/assets/60f8dbcb-441f-486f-b8e9-0cfe58230743" />

No additional configuration is required. New metrics will automatically appear in GCP's metric explorer.

In addition, with the version field (attached to the meter), the metrics can be used for release gating before rolling out to all populations.
<img width="1583" alt="Screenshot 2025-04-01 at 11 01 34 AM" src="https://github.com/user-attachments/assets/97fbff5a-48dc-4a91-b6a3-81f1b7101649" />


## Test plan

- manual testing
