### PR TITLE
Revert "[JetBrains] Update plugins  (#7626)"

### DIFF
--- a/jetbrains/build.gradle.kts
+++ b/jetbrains/build.gradle.kts
@@ -59,8 +59,8 @@ val skippedFailureLevels =
 plugins {
   id("java")
   id("jvm-test-suite")
-  id("org.jetbrains.kotlin.jvm") version "2.1.20"
-  id("org.jetbrains.intellij.platform") version "2.5.0"
+  id("org.jetbrains.kotlin.jvm") version "2.1.10"
+  id("org.jetbrains.intellij.platform") version "2.2.1"
   id("org.jetbrains.changelog") version "2.2.1"
   id("com.diffplug.spotless") version "7.0.2"
   id("io.sentry.jvm.gradle") version "5.2.0"


### PR DESCRIPTION
This reverts commit ba7b0deb5633bb66633341018d6aa393a2d9b92c.

Reason: looks like it fails during release publishing.

## Test plan

N/A