### PR TITLE
Refreshing icon after enabling autocomplete

### DIFF
--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyEnableAutocompleteAction.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyEnableAutocompleteAction.kt
@@ -8,6 +8,7 @@ import com.sourcegraph.config.ConfigUtil
 class CodyEnableAutocompleteAction : DumbAwareEDTAction("Enable Cody Autocomplete") {
   override fun actionPerformed(e: AnActionEvent) {
     CodyApplicationSettings.instance.isCodyAutocompleteEnabled = true
+    e.project?.let { CodyStatusService.resetApplication(it) }
   }
 
   override fun update(e: AnActionEvent) {


### PR DESCRIPTION
This PR add refreshing status icon to `CodyEnableAutocompleteAction`
## Test plan
1. Try to enable/disable autocomplete in status bar button and see if icon is changing.
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
