### PR TITLE
fix(telemetry): remove telemetry level setting from VS Code config

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1062,17 +1062,6 @@
           "type": "string",
           "markdownDescription": "Regular expression to filter debug output. If empty, defaults to '.*', which prints all messages."
         },
-        "cody.telemetry.level": {
-          "order": 99,
-          "type": "string",
-          "enum": ["all", "off"],
-          "enumDescriptions": [
-            "Sends usage data and errors.",
-            "[Enterprise-only] Disables all extension telemetry."
-          ],
-          "markdownDescription": "Controls the telemetry about Cody usage and errors for users connected to Enterprise instances. This setting only takes effect for Sourcegraph Enterprise users. For users connected to sourcegraph.com, this option is always enabled. See [Cody usage and privacy notice](https://about.sourcegraph.com/terms/cody-notice).",
-          "default": "all"
-        },
         "cody.autocomplete.advanced.provider": {
           "type": "string",
           "default": "default",

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -50,7 +50,7 @@ describe('getConfiguration', () => {
                     case 'cody.debug.filter':
                         return /.*/
                     case 'cody.telemetry.level':
-                        return 'off'
+                        return 'all'
                     case 'cody.telemetry.clientName':
                         return undefined
                     case 'cody.chat.preInstruction':
@@ -187,7 +187,7 @@ describe('getConfiguration', () => {
             internalDebugState: false,
             debugVerbose: true,
             debugFilter: /.*/,
-            telemetryLevel: 'off',
+            telemetryLevel: 'all',
             agentHasPersistentStorage: false,
             autocompleteAdvancedProvider: 'default',
             autocompleteAdvancedModel: 'starcoder-16b',

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -89,7 +89,7 @@ export function getConfiguration(
         customHeaders: config.get<Record<string, string>>(CONFIG_KEY.customHeaders),
         debugVerbose: config.get<boolean>(CONFIG_KEY.debugVerbose, false),
         debugFilter: debugRegex,
-        telemetryLevel: config.get<'all' | 'off'>(CONFIG_KEY.telemetryLevel, 'all'),
+        telemetryLevel: getHiddenSetting<'all' | 'off'>('telemetry.level', 'all'),
         autocomplete: codyAutoSuggestionsMode === CodyAutoSuggestionMode.Autocomplete,
         autocompleteLanguages: config.get(CONFIG_KEY.autocompleteLanguages, {
             '*': true,

--- a/vscode/src/services/telemetry-v2.ts
+++ b/vscode/src/services/telemetry-v2.ts
@@ -4,6 +4,7 @@ import {
     TelemetryRecorderProvider,
     clientCapabilities,
     isDotCom,
+    isWorkspaceInstance,
     resolvedConfig,
     subscriptionDisposable,
     telemetryRecorder,
@@ -38,7 +39,10 @@ export function createOrUpdateTelemetryRecorderProvider(
             ])
             // Telemetry can only be disabled for Non-Sourcegraph.com instances.
             if (configuration.telemetryLevel === 'off') {
-                if (auth.serverEndpoint && !isDotCom(auth.serverEndpoint)) {
+                if (
+                    auth.serverEndpoint &&
+                    !(isDotCom(auth.serverEndpoint) || isWorkspaceInstance(auth.serverEndpoint))
+                ) {
                     updateGlobalTelemetryInstances(defaultNoOpProvider)
                     logDebug('TelemetryRecorderProvider', 'telemetry has been disabled.', {
                         verbose: `telemetry is disabled for ${auth.serverEndpoint}`,


### PR DESCRIPTION
The `cody.telemetry.level` setting is removed from the VS Code configuration. Telemetry is now enabled by default for all users, except for those on enterprise


## Test plan
Check that telemetry is on when using a dot.com or ES account 
