### PR TITLE
chore(chat): Improve the feature flag evaluation process

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -272,11 +272,14 @@ export class FeatureFlagProviderImpl implements FeatureFlagProvider {
 
     /**
      * Observe the evaluated value of a feature flag.
+     * @param flagName - The feature flag to evaluate
+     * @param forceRefresh - When set to true, forces a refresh of the feature flag value. Useful for new feature flags that are frequently toggled.
+     * @returns An Observable that emits the current value of the feature flag
      */
-    public evaluateFeatureFlag(flagName: FeatureFlag): Observable<boolean> {
+    public evaluateFeatureFlag(flagName: FeatureFlag, forceRefresh = false): Observable<boolean> {
         let entry = this.featureFlagCache[flagName]
 
-        if (!entry) {
+        if (!entry || forceRefresh) {
             // Whenever the auth status changes, we need to call `evaluateFeatureFlags` on the GraphQL
             // endpoint, because our endpoint or authentication may have changed.
             entry = storeLastValue(

--- a/lib/shared/src/models/sync.test.ts
+++ b/lib/shared/src/models/sync.test.ts
@@ -497,15 +497,15 @@ describe('syncModels', () => {
             // set the feature flag
             if (featureFlagEnabled) {
                 vi.spyOn(featureFlagProvider, 'evaluateFeatureFlag').mockImplementation(
-                    (flag: FeatureFlag) =>
-                        flag === FeatureFlag.CodyChatDefaultToClaude35Haiku
+                    (flagName: FeatureFlag, _forceRefresh?: boolean) =>
+                        flagName === FeatureFlag.CodyChatDefaultToClaude35Haiku
                             ? Observable.of(featureFlagEnabled)
                             : Observable.of(false)
                 )
             } else {
                 vi.spyOn(featureFlagProvider, 'evaluateFeatureFlag').mockImplementation(
-                    (flag: FeatureFlag) =>
-                        flag === FeatureFlag.CodyChatDefaultToClaude35Haiku
+                    (flagName: FeatureFlag, _forceRefresh?: boolean) =>
+                        flagName === FeatureFlag.CodyChatDefaultToClaude35Haiku
                             ? Observable.of(featureFlagEnabled)
                             : Observable.of(true)
                 )


### PR DESCRIPTION
Add a forceRefresh param to evaluateFeatureFlag. This can be useful for new feature flags since we might toggle the value frequently and skip caching.

## Test plan
CI
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
