### PR TITLE
feat(agent): Update node binaries used by agent to v22.14.0

### DIFF
--- a/jetbrains/build.gradle.kts
+++ b/jetbrains/build.gradle.kts
@@ -413,7 +413,8 @@ tasks {
       println("Unzipped main archive, created $destination")
 
       destination.listFiles()?.forEach { fileInDestination ->
-        if (fileInDestination.isFile && fileInDestination.name.endsWith(".zip", ignoreCase = true)) {
+        if (fileInDestination.isFile &&
+            fileInDestination.name.endsWith(".zip", ignoreCase = true)) {
           println("Found inner zip file: ${fileInDestination.name}. Unzipping...")
           try {
             project.copy {
@@ -423,10 +424,12 @@ tasks {
             println("Successfully unzipped ${fileInDestination.name}")
 
             if (!fileInDestination.delete()) {
-              project.logger.warn("Failed to delete inner zip file: ${fileInDestination.absolutePath}")
+              project.logger.warn(
+                  "Failed to delete inner zip file: ${fileInDestination.absolutePath}")
             }
           } catch (e: Exception) {
-            project.logger.error("Failed to unzip inner file ${fileInDestination.name}: ${e.message}", e)
+            project.logger.error(
+                "Failed to unzip inner file ${fileInDestination.name}: ${e.message}", e)
           }
         }
       }
@@ -436,7 +439,8 @@ tasks {
 
     val nodeVersionDir = destination.resolve(nodeVersion)
     if (!nodeVersionDir.exists()) {
-      project.logger.warn("Expected Node version directory not found after unzipping: $nodeVersionDir")
+      project.logger.warn(
+          "Expected Node version directory not found after unzipping: $nodeVersionDir")
     }
     return nodeVersionDir
   }

--- a/jetbrains/build.gradle.kts
+++ b/jetbrains/build.gradle.kts
@@ -403,6 +403,8 @@ tasks {
     download(url, zipFile)
 
     val destination = githubArchiveCache.resolve("node").resolve("node-binaries-$nodeVersion")
+    val nodeVersionDir = destination.resolve(branch)
+
     if (!destination.exists()) {
       val extractTargetDir = destination.parentFile
       println("Unzipping $zipFile to $extractTargetDir...")
@@ -413,24 +415,24 @@ tasks {
       }
       println("Unzipped main archive, created $destination")
 
-      destination.listFiles()?.forEach { fileInDestination ->
-        if (fileInDestination.isFile &&
-            fileInDestination.name.endsWith(".zip", ignoreCase = true)) {
-          println("Found inner zip file: ${fileInDestination.name}. Unzipping...")
+      nodeVersionDir.listFiles()?.forEach { fileInNodeVersionDir ->
+        if (fileInNodeVersionDir.isFile &&
+            fileInNodeVersionDir.name.endsWith(".zip", ignoreCase = true)) {
+          println("Found inner zip file: ${fileInNodeVersionDir.name}. Unzipping...")
           try {
             project.copy {
-              from(project.zipTree(fileInDestination))
-              into(destination)
+              from(project.zipTree(fileInNodeVersionDir))
+              into(nodeVersionDir)
             }
-            println("Successfully unzipped ${fileInDestination.name}")
+            println("Successfully unzipped ${fileInNodeVersionDir.name}")
 
-            if (!fileInDestination.delete()) {
+            if (!fileInNodeVersionDir.delete()) {
               project.logger.warn(
-                  "Failed to delete inner zip file: ${fileInDestination.absolutePath}")
+                  "Failed to delete inner zip file: ${fileInNodeVersionDir.absolutePath}")
             }
           } catch (e: Exception) {
             project.logger.error(
-                "Failed to unzip inner file ${fileInDestination.name}: ${e.message}", e)
+                "Failed to unzip inner file ${fileInNodeVersionDir.name}: ${e.message}", e)
           }
         }
       }
@@ -438,7 +440,6 @@ tasks {
       println("Using existing unzipped directory: $destination")
     }
 
-    val nodeVersionDir = destination.resolve(branch)
     if (!nodeVersionDir.exists()) {
       project.logger.error(
           "Expected Node version directory not found after unzipping: $nodeVersionDir")

--- a/jetbrains/build.gradle.kts
+++ b/jetbrains/build.gradle.kts
@@ -397,8 +397,9 @@ tasks {
 
   fun downloadNodeBinaries(): File {
     val nodeVersion = properties("nodeBinaries.version")!!
-    val url = "https://github.com/sourcegraph/node-binaries/archive/refs/heads/${nodeVersion}.zip"
-    val zipFile = githubArchiveCache.resolve("$nodeVersion.zip")
+    val branch = "v${nodeVersion}"
+    val url = "https://github.com/sourcegraph/node-binaries/archive/refs/heads/$branch.zip"
+    val zipFile = githubArchiveCache.resolve("$branch.zip")
     download(url, zipFile)
 
     val destination = githubArchiveCache.resolve("node").resolve("node-binaries-$nodeVersion")
@@ -437,9 +438,9 @@ tasks {
       println("Using existing unzipped directory: $destination")
     }
 
-    val nodeVersionDir = destination.resolve(nodeVersion)
+    val nodeVersionDir = destination.resolve(branch)
     if (!nodeVersionDir.exists()) {
-      project.logger.warn(
+      project.logger.error(
           "Expected Node version directory not found after unzipping: $nodeVersionDir")
     }
     return nodeVersionDir

--- a/jetbrains/gradle.properties
+++ b/jetbrains/gradle.properties
@@ -22,6 +22,5 @@ kotlin.stdlib.default.dependency=false
 kotlin.daemon.jvmargs=-Xmx2g -Xms500m
 org.gradle.jvmargs=-Xmx4g -Xms500m
 # See https://docs.gradle.org/current/userguide/build_cache.html#sec:build_cache_configure
-nodeBinaries.commit=8755ae4c05fd476cd23f2972049111ba436c86d4
-nodeBinaries.version=v20.12.2
+nodeBinaries.version=v22.14.0
 cody.autocomplete.enableFormatting=true

--- a/jetbrains/gradle.properties
+++ b/jetbrains/gradle.properties
@@ -22,5 +22,5 @@ kotlin.stdlib.default.dependency=false
 kotlin.daemon.jvmargs=-Xmx2g -Xms500m
 org.gradle.jvmargs=-Xmx4g -Xms500m
 # See https://docs.gradle.org/current/userguide/build_cache.html#sec:build_cache_configure
-nodeBinaries.version=v22.14.0
+nodeBinaries.version=22.14.0
 cody.autocomplete.enableFormatting=true


### PR DESCRIPTION
## Changes

Update node binaries used by agent to v22.14.0.
It seems to have a bit better memory management/gc, and definitely gives us huge boost when doing heap snapshots for memory profiling (5 sec vs 3 min).

## Test plan

Full QA on possibly all platforms is needed.