### PR TITLE
chore(ci): add gcloud auth that was removed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,9 @@ jobs:
         runner: ${{ fromJson(needs.fast_tests_matrix_prep.outputs.matrix) }}
     runs-on: ${{ matrix.runner }}-latest
     timeout-minutes: 15
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,10 +128,33 @@ jobs:
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-      - run: xvfb-run -a pnpm -C vscode run test:integration
+        # commands before `xvfb-run -a pnpm run test` avoid these ERROR messages:
+        # - Failed to connect to the bus: Could not parse server address: Unknown address type (examples of valid types are "tcp" and on UNIX "unix")
+        # - Exiting GPU process due to errors during initialization
+      - run: |
+          export XDG_RUNTIME_DIR=/run/user/$(id -u)
+          export DBUS_SESSION_BUS_ADDRESS=unix:path=$XDG_RUNTIME_DIR/bus
+          dbus-daemon --session --address=$DBUS_SESSION_BUS_ADDRESS --nofork --nopidfile --syslog-only &
+          mkdir ~/.vscode && echo '{ "disable-hardware-acceleration": true }' > ~/.vscode/argv.json
+          xvfb-run -a pnpm -C vscode run test:integration
         if: matrix.runner == 'ubuntu'
-      - run: pnpm -C vscode run test:integration
-        if: matrix.runner == 'windows' || matrix.runner == 'macos'
+      - name: Disable hardware acceleration in VS Code (Windows only)
+        if: matrix.runner == 'windows'
+        shell: powershell
+        run: |
+          $vscodeDir = "$env:USERPROFILE\.vscode"
+          New-Item -ItemType Directory -Path $vscodeDir -Force | Out-Null
+          $json = @'
+          {
+            "disable-hardware-acceleration": true
+          }
+          '@
+          $json | Set-Content -Path "$vscodeDir\argv.json" -Encoding UTF8
+          pnpm -C vscode run test:integration
+      - run: |
+          mkdir ~/.vscode && echo '{ "disable-hardware-acceleration": true }' > ~/.vscode/argv.json
+          pnpm -C vscode run test:integration
+        if: matrix.runner == 'macos'
 
   # Sets a variable that is used to determine the matrix to run slow tests (e2e) on.
   # Everything runs on ubuntu, only commits to main run on macos and windows.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,14 @@ jobs:
         with:
           node-version-file: .tool-versions
       - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # SECURITY: pin third-party action hashes
+      - id: auth
+        uses: google-github-actions/auth@v2
+        # Skip auth if PR is from a fork
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        with:
+          workload_identity_provider: ${{ secrets.DATA_TEAM_PROVIDER_NAME }}
+          service_account: ${{ secrets.DATA_TEAM_SA_EMAIL }}
+      - uses: google-github-actions/setup-gcloud@v2
       - run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
         shell: bash
         id: pnpm-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,14 +131,15 @@ jobs:
         # commands before `xvfb-run -a pnpm run test` avoid these ERROR messages:
         # - Failed to connect to the bus: Could not parse server address: Unknown address type (examples of valid types are "tcp" and on UNIX "unix")
         # - Exiting GPU process due to errors during initialization
-      - run: |
+      - name: Run tests (ubuntu)
+        run: |
           export XDG_RUNTIME_DIR=/run/user/$(id -u)
           export DBUS_SESSION_BUS_ADDRESS=unix:path=$XDG_RUNTIME_DIR/bus
           dbus-daemon --session --address=$DBUS_SESSION_BUS_ADDRESS --nofork --nopidfile --syslog-only &
           mkdir ~/.vscode && echo '{ "disable-hardware-acceleration": true }' > ~/.vscode/argv.json
           xvfb-run -a pnpm -C vscode run test:integration
         if: matrix.runner == 'ubuntu'
-      - name: Disable hardware acceleration in VS Code (Windows only)
+      - name: Run tests (windows)
         if: matrix.runner == 'windows'
         shell: powershell
         run: |
@@ -151,7 +152,8 @@ jobs:
           '@
           $json | Set-Content -Path "$vscodeDir\argv.json" -Encoding UTF8
           pnpm -C vscode run test:integration
-      - run: |
+      - name: Run tests (mac)
+        run: |
           mkdir ~/.vscode && echo '{ "disable-hardware-acceleration": true }' > ~/.vscode/argv.json
           pnpm -C vscode run test:integration
         if: matrix.runner == 'macos'


### PR DESCRIPTION
I mistakenly skipped this step when I re-added the gcloud auth

Closes DINF-909
## Test plan
CI
