### PR TITLE
chore: Skip flaky integration test

### DIFF
--- a/vscode/test/integration/single-root/chat.test.ts
+++ b/vscode/test/integration/single-root/chat.test.ts
@@ -29,7 +29,10 @@ suite('Chat', function () {
     this.beforeEach(() => beforeIntegrationTest())
     this.afterEach(() => afterIntegrationTest())
 
-    test('sends and receives a message', async () => {
+    // TODO: This test is flaky and occasionally throws an uncaught AbortError.
+    // Example failure: https://github.com/sourcegraph/cody/actions/runs/14273152078/job/40010754961#step:11:108
+    // Issue to fix: https://github.com/sourcegraph/cody/issues/7673
+    test.skip('sends and receives a message', async () => {
         await vscode.commands.executeCommand('cody.chat.newEditorPanel')
         const chatView = await getChatViewProvider()
         await chatView.handleUserMessage({


### PR DESCRIPTION
## Description

This test regularly fails in CI.

Example failures on `main`: 
1. https://github.com/sourcegraph/cody/actions/runs/14302985167/job/40080668100#step:12:127
2. https://github.com/sourcegraph/cody/actions/runs/14273152078/job/40010756130#step:13:109
3. https://github.com/sourcegraph/cody/actions/runs/14273152078/job/40010755491#step:12:126

## Test plan

Integration tests pass

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
