### PR TITLE
Add CTA for auto-edits for pro users

### DIFF
--- a/jetbrains/src/main/java/com/sourcegraph/config/CodyAuthNotificationActivity.java
+++ b/jetbrains/src/main/java/com/sourcegraph/config/CodyAuthNotificationActivity.java
@@ -51,17 +51,8 @@ public class CodyAuthNotificationActivity implements Activity {
           }
         };
 
-    AnAction neverShowAgainAction =
-        new DumbAwareEDTAction("Never Show Again") {
-          @Override
-          public void actionPerformed(@NotNull AnActionEvent anActionEvent) {
-            notification.expire();
-            CodyApplicationSettings.getInstance().setGetStartedNotificationDismissed(true);
-          }
-        };
     notification.setIcon(Icons.CodyLogo);
     notification.addAction(openCodySidebar);
-    notification.addAction(neverShowAgainAction);
     Notifications.Bus.notify(notification);
   }
 }

--- a/jetbrains/src/main/java/com/sourcegraph/config/CodyAuthNotificationActivity.java
+++ b/jetbrains/src/main/java/com/sourcegraph/config/CodyAuthNotificationActivity.java
@@ -11,7 +11,6 @@ import com.intellij.openapi.wm.ToolWindowManager;
 import com.sourcegraph.Icons;
 import com.sourcegraph.cody.CodyToolWindowFactory;
 import com.sourcegraph.cody.auth.CodyAuthService;
-import com.sourcegraph.cody.config.CodyApplicationSettings;
 import com.sourcegraph.cody.initialization.Activity;
 import com.sourcegraph.common.NotificationGroups;
 import com.sourcegraph.common.ui.DumbAwareEDTAction;
@@ -21,8 +20,7 @@ public class CodyAuthNotificationActivity implements Activity {
 
   @Override
   public void runActivity(@NotNull Project project) {
-    if (!CodyApplicationSettings.getInstance().isGetStartedNotificationDismissed()
-        && !CodyAuthService.getInstance(project).isActivated()) {
+    if (!CodyAuthService.getInstance(project).isActivated()) {
       showOpenCodySidebarNotification(project);
     }
   }

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentClient.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentClient.kt
@@ -29,12 +29,14 @@ import com.sourcegraph.cody.edit.lenses.LensesService
 import com.sourcegraph.cody.error.CodyConsole
 import com.sourcegraph.cody.error.SentryService
 import com.sourcegraph.cody.ignore.IgnoreOracle
+import com.sourcegraph.cody.initialization.SuggestAutoedit
 import com.sourcegraph.cody.statusbar.CodyStatusService
 import com.sourcegraph.cody.ui.web.NativeWebviewProvider
 import com.sourcegraph.cody.vscode.InlineCompletionTriggerKind
 import com.sourcegraph.common.BrowserOpener
 import com.sourcegraph.common.NotificationGroups
 import com.sourcegraph.common.ui.SimpleDumbAwareEDTAction
+import com.sourcegraph.config.ConfigUtil
 import com.sourcegraph.utils.CodyEditorUtil
 import java.nio.file.Paths
 import java.util.concurrent.CompletableFuture
@@ -196,6 +198,8 @@ class CodyAgentClient(private val project: Project, private val webview: NativeW
         SentryService.getInstance().setUser(params.primaryEmail, params.username)
         authService.setActivated(true)
         authService.setEndpoint(SourcegraphServerPath(params.endpoint))
+        val isDotcom = params.endpoint.lowercase().startsWith(ConfigUtil.DOTCOM_URL)
+        SuggestAutoedit(isDotcom).runActivity(project)
       } else if (params is ProtocolUnauthenticatedAuthStatus) {
         SentryService.getInstance().setUser(null, null)
         authService.setActivated(false)

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/protocol/GetFeatureFlag.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/protocol/GetFeatureFlag.kt
@@ -5,4 +5,6 @@ import com.sourcegraph.cody.agent.protocol_generated.FeatureFlags_GetFeatureFlag
 object GetFeatureFlag {
   val UseSscForCodySubscription = FeatureFlags_GetFeatureFlagParams("UseSscForCodySubscription")
   val CodyProTrialEnded = FeatureFlags_GetFeatureFlagParams("CodyProTrialEnded")
+  val CodyAutoeditExperimentEnabledFeatureFlag =
+      FeatureFlags_GetFeatureFlagParams("CodyAutoeditExperimentEnabledFeatureFlag")
 }

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/protocol/GetFeatureFlag.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/protocol/GetFeatureFlag.kt
@@ -5,6 +5,6 @@ import com.sourcegraph.cody.agent.protocol_generated.FeatureFlags_GetFeatureFlag
 object GetFeatureFlag {
   val UseSscForCodySubscription = FeatureFlags_GetFeatureFlagParams("UseSscForCodySubscription")
   val CodyProTrialEnded = FeatureFlags_GetFeatureFlagParams("CodyProTrialEnded")
-  val CodyAutoeditExperimentEnabledFeatureFlag =
-      FeatureFlags_GetFeatureFlagParams("CodyAutoeditExperimentEnabledFeatureFlag")
+  val CodyAutoeditJetBrainsExperimentEnabledFeatureFlag =
+      FeatureFlags_GetFeatureFlagParams("CodyAutoeditJetBrainsExperimentEnabledFeatureFlag")
 }

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyApplicationSettings.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyApplicationSettings.kt
@@ -11,8 +11,6 @@ data class CodyApplicationSettings(
     var isCodyAutocompleteEnabled: Boolean = true,
     var isCodyDebugEnabled: Boolean = false,
     var isCodyVerboseDebugEnabled: Boolean = false,
-    var isGetStartedNotificationDismissed: Boolean = false,
-    var isNotLoggedInNotificationDismissed: Boolean = false,
     var anonymousUserId: String? = null,
     var isInstallEventLogged: Boolean = false,
     var isCustomAutocompleteColorEnabled: Boolean = false,
@@ -20,7 +18,6 @@ data class CodyApplicationSettings(
     var isLookupAutocompleteEnabled: Boolean = true,
     var isCodyUIHintsEnabled: Boolean = false,
     var blacklistedLanguageIds: List<String> = listOf(),
-    var isOnboardingGuidanceDismissed: Boolean = false,
     var shouldAcceptNonTrustedCertificatesAutomatically: Boolean = false,
     var shouldCheckForUpdates: Boolean = true,
     var isOffScreenRenderingEnabled: Boolean = true,
@@ -32,8 +29,6 @@ data class CodyApplicationSettings(
     this.isCodyAutocompleteEnabled = state.isCodyAutocompleteEnabled
     this.isCodyDebugEnabled = state.isCodyDebugEnabled
     this.isCodyVerboseDebugEnabled = state.isCodyVerboseDebugEnabled
-    this.isGetStartedNotificationDismissed = state.isGetStartedNotificationDismissed
-    this.isNotLoggedInNotificationDismissed = state.isNotLoggedInNotificationDismissed
     this.anonymousUserId = state.anonymousUserId
     this.isInstallEventLogged = state.isInstallEventLogged
     this.isCustomAutocompleteColorEnabled = state.isCustomAutocompleteColorEnabled
@@ -41,7 +36,6 @@ data class CodyApplicationSettings(
     this.isLookupAutocompleteEnabled = state.isLookupAutocompleteEnabled
     this.isCodyUIHintsEnabled = state.isCodyUIHintsEnabled
     this.blacklistedLanguageIds = state.blacklistedLanguageIds
-    this.isOnboardingGuidanceDismissed = state.isOnboardingGuidanceDismissed
     this.shouldAcceptNonTrustedCertificatesAutomatically =
         state.shouldAcceptNonTrustedCertificatesAutomatically
     this.shouldCheckForUpdates = state.shouldCheckForUpdates

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodySettingsFileChangeListener.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodySettingsFileChangeListener.kt
@@ -20,8 +20,7 @@ class CodySettingsFileChangeListener(private val project: Project) : FileDocumen
         LocalFileSystem.getInstance()
             .refreshAndFindFileByNioFile(ConfigUtil.getSettingsFile(project))
     if (currentFile == configFile) {
-      // TODO: it seams that some of the settings changes (like enabling/disabling autocomplete)
-      //       requires agent restart to take effect.
+      // TODO(CODY-5682): Adjust the agent to handle config changes without requiring a restart.
       CodyAgentService.withAgentRestartIfNeeded(project) {
         it.server.extensionConfiguration_change(ConfigUtil.getAgentConfiguration(project))
       }

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodySettingsFileChangeListener.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodySettingsFileChangeListener.kt
@@ -20,12 +20,10 @@ class CodySettingsFileChangeListener(private val project: Project) : FileDocumen
         LocalFileSystem.getInstance()
             .refreshAndFindFileByNioFile(ConfigUtil.getSettingsFile(project))
     if (currentFile == configFile) {
-      // TODO: it seams that some of the settings changes (like enabling/disabling
-      // autocomplete)
-      // requires agent restart to take effect.
+      // TODO: it seams that some of the settings changes (like enabling/disabling autocomplete)
+      //       requires agent restart to take effect.
       CodyAgentService.withAgentRestartIfNeeded(project) {
-        it.server.extensionConfiguration_change(
-            ConfigUtil.getAgentConfiguration(project, customConfigContent = document.text))
+        it.server.extensionConfiguration_change(ConfigUtil.getAgentConfiguration(project))
       }
     }
   }

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/initialization/SuggestAutoedit.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/initialization/SuggestAutoedit.kt
@@ -22,7 +22,13 @@ import java.util.concurrent.CompletableFuture
 
 class SuggestAutoedit(private val isDotcom: Boolean) : Activity {
 
+  companion object {
+    val autoeditSetting = "cody.suggestions.mode" to "auto-edit (Beta)"
+  }
+
   override fun runActivity(project: Project) {
+    if (ConfigUtil.getSetting(project, autoeditSetting.first) == autoeditSetting.second) return
+
     CodyAgentService.withAgent(project) {
       val isProOrEnterpriseFuture =
           if (isDotcom) {
@@ -34,7 +40,7 @@ class SuggestAutoedit(private val isDotcom: Boolean) : Activity {
         it.server
             .featureFlags_getFeatureFlag(CodyAutoeditJetBrainsExperimentEnabledFeatureFlag)
             .thenAccept { featureFlag ->
-              if (featureFlag == true || true) {
+              if (featureFlag == true) {
                 SuggestAutoeditNotification(project).notify(project)
               }
             }
@@ -57,7 +63,7 @@ class SuggestAutoeditNotification(project: Project) :
     addAction(
         NotificationAction.createExpiring(
             CodyBundle.getString("AutoeditSuggestionNotification.configure")) { _, _ ->
-              ConfigUtil.addSettings(project, mapOf("cody.suggestions.mode" to "auto-edit (Beta)"))
+              ConfigUtil.addSettings(project, mapOf(SuggestAutoedit.autoeditSetting))
               ApplicationManager.getApplication().restart()
             })
 

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/initialization/SuggestAutoedit.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/initialization/SuggestAutoedit.kt
@@ -4,10 +4,16 @@ import com.intellij.notification.Notification
 import com.intellij.notification.NotificationAction
 import com.intellij.notification.NotificationType
 import com.intellij.notification.impl.NotificationFullContent
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.actionSystem.ActionPlaces
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.Presentation
+import com.intellij.openapi.actionSystem.impl.SimpleDataContext
 import com.intellij.openapi.project.Project
 import com.sourcegraph.Icons
 import com.sourcegraph.cody.agent.CodyAgentService
 import com.sourcegraph.cody.agent.protocol.GetFeatureFlag.CodyAutoeditJetBrainsExperimentEnabledFeatureFlag
+import com.sourcegraph.cody.config.actions.OpenCodySettingsEditorAction
 import com.sourcegraph.common.CodyBundle
 import com.sourcegraph.common.NotificationGroups
 import java.util.concurrent.CompletableFuture
@@ -27,7 +33,7 @@ class SuggestAutoedit(private val isDotcom: Boolean) : Activity {
             .featureFlags_getFeatureFlag(CodyAutoeditJetBrainsExperimentEnabledFeatureFlag)
             .thenAccept { featureFlag ->
               if (featureFlag == true || true) {
-                SuggestAutoeditNotification().notify(project)
+                SuggestAutoeditNotification(project).notify(project)
               }
             }
       }
@@ -35,7 +41,7 @@ class SuggestAutoedit(private val isDotcom: Boolean) : Activity {
   }
 }
 
-class SuggestAutoeditNotification :
+class SuggestAutoeditNotification(project: Project) :
     Notification(
         NotificationGroups.CODY_AUTH,
         CodyBundle.getString("AutoeditSuggestionNotification.title"),
@@ -48,8 +54,21 @@ class SuggestAutoeditNotification :
 
     addAction(
         NotificationAction.createExpiring(
-            CodyBundle.getString("AutoeditSuggestionNotification.button")) { _, _ ->
+            CodyBundle.getString("AutoeditSuggestionNotification.configure")) { _, _ ->
+            })
 
+    addAction(
+        NotificationAction.createSimple(
+            CodyBundle.getString("AutoeditSuggestionNotification.openFile")) {
+              val anActionEvent =
+                  AnActionEvent(
+                      null,
+                      SimpleDataContext.getProjectContext(project),
+                      ActionPlaces.UNKNOWN,
+                      Presentation(),
+                      ActionManager.getInstance(),
+                      0)
+              OpenCodySettingsEditorAction().actionPerformed(anActionEvent)
             })
   }
 }

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/initialization/SuggestAutoedit.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/initialization/SuggestAutoedit.kt
@@ -1,0 +1,55 @@
+package com.sourcegraph.cody.initialization
+
+import com.intellij.notification.Notification
+import com.intellij.notification.NotificationAction
+import com.intellij.notification.NotificationType
+import com.intellij.notification.impl.NotificationFullContent
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.Project
+import com.sourcegraph.Icons
+import com.sourcegraph.cody.agent.CodyAgentService
+import com.sourcegraph.cody.agent.protocol.GetFeatureFlag.CodyAutoeditExperimentEnabledFeatureFlag
+import com.sourcegraph.common.CodyBundle
+import com.sourcegraph.common.NotificationGroups
+import java.util.concurrent.CompletableFuture
+
+class SuggestAutoedit(val isDotcom: Boolean) : Activity {
+
+  override fun runActivity(project: Project) {
+    CodyAgentService.withAgent(project) {
+      val isProOrEnterpriseFuture =
+          if (isDotcom) {
+            it.server.graphql_currentUserIsPro(null)
+          } else CompletableFuture.completedFuture(true)
+
+      it.server.featureFlags_getFeatureFlag(CodyAutoeditExperimentEnabledFeatureFlag).thenCombine(
+          isProOrEnterpriseFuture) { featureFlag, isProOrEnterprise ->
+            if (isProOrEnterprise && featureFlag == true) {
+              SuggestAutoeditNotification().notify(project)
+            }
+          }
+    }
+  }
+}
+
+class SuggestAutoeditNotification :
+    Notification(
+        NotificationGroups.CODY_AUTH,
+        CodyBundle.getString("AutoeditSuggestionNotification.title"),
+        CodyBundle.getString("AutoeditSuggestionNotification.content"),
+        NotificationType.INFORMATION),
+    NotificationFullContent {
+
+  init {
+    icon = Icons.SourcegraphLogo
+
+    addAction(
+        object : NotificationAction(CodyBundle.getString("AutoeditSuggestionNotification.button")) {
+          override fun actionPerformed(anActionEvent: AnActionEvent, notification: Notification) {
+            println("configure and restart")
+          }
+        })
+
+    configureDoNotAskOption("autoedit-notification", "Don’t show again")
+  }
+}

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/initialization/SuggestAutoedit.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/initialization/SuggestAutoedit.kt
@@ -16,6 +16,7 @@ import com.sourcegraph.cody.agent.protocol.GetFeatureFlag.CodyAutoeditJetBrainsE
 import com.sourcegraph.cody.config.actions.OpenCodySettingsEditorAction
 import com.sourcegraph.common.CodyBundle
 import com.sourcegraph.common.NotificationGroups
+import com.sourcegraph.config.ConfigUtil
 import java.util.concurrent.CompletableFuture
 
 class SuggestAutoedit(private val isDotcom: Boolean) : Activity {
@@ -55,6 +56,7 @@ class SuggestAutoeditNotification(project: Project) :
     addAction(
         NotificationAction.createExpiring(
             CodyBundle.getString("AutoeditSuggestionNotification.configure")) { _, _ ->
+              ConfigUtil.addSettings(project, mapOf("cody.suggestions.mode" to "auto-edit (Beta)"))
             })
 
     addAction(

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/initialization/SuggestAutoedit.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/initialization/SuggestAutoedit.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.actionSystem.ActionPlaces
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.Presentation
 import com.intellij.openapi.actionSystem.impl.SimpleDataContext
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.sourcegraph.Icons
 import com.sourcegraph.cody.agent.CodyAgentService
@@ -57,6 +58,7 @@ class SuggestAutoeditNotification(project: Project) :
         NotificationAction.createExpiring(
             CodyBundle.getString("AutoeditSuggestionNotification.configure")) { _, _ ->
               ConfigUtil.addSettings(project, mapOf("cody.suggestions.mode" to "auto-edit (Beta)"))
+              ApplicationManager.getApplication().restart()
             })
 
     addAction(

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/initialization/SuggestAutoedit.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/initialization/SuggestAutoedit.kt
@@ -8,7 +8,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.project.Project
 import com.sourcegraph.Icons
 import com.sourcegraph.cody.agent.CodyAgentService
-import com.sourcegraph.cody.agent.protocol.GetFeatureFlag.CodyAutoeditExperimentEnabledFeatureFlag
+import com.sourcegraph.cody.agent.protocol.GetFeatureFlag.CodyAutoeditJetBrainsExperimentEnabledFeatureFlag
 import com.sourcegraph.common.CodyBundle
 import com.sourcegraph.common.NotificationGroups
 import java.util.concurrent.CompletableFuture
@@ -22,8 +22,9 @@ class SuggestAutoedit(val isDotcom: Boolean) : Activity {
             it.server.graphql_currentUserIsPro(null)
           } else CompletableFuture.completedFuture(true)
 
-      it.server.featureFlags_getFeatureFlag(CodyAutoeditExperimentEnabledFeatureFlag).thenCombine(
-          isProOrEnterpriseFuture) { featureFlag, isProOrEnterprise ->
+      it.server
+          .featureFlags_getFeatureFlag(CodyAutoeditJetBrainsExperimentEnabledFeatureFlag)
+          .thenCombine(isProOrEnterpriseFuture) { featureFlag, isProOrEnterprise ->
             if (isProOrEnterprise && featureFlag == true) {
               SuggestAutoeditNotification().notify(project)
             }

--- a/jetbrains/src/main/kotlin/com/sourcegraph/config/ConfigUtil.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/config/ConfigUtil.kt
@@ -208,9 +208,10 @@ object ConfigUtil {
           ""
         }
 
-    var config = ConfigFactory.parseString(text).resolve()
+    val oldConfigEntrySet = ConfigFactory.parseString(text).resolve().root().entries
     val globalConfig = ConfigFactory.parseString(GlobalCodySettings.getConfigJson()).resolve()
-    settings.forEach { (key, value) ->
+    var config = ConfigFactory.empty()
+    oldConfigEntrySet.plus(settings.entries).forEach { (key, value) ->
       config = config.withValue(key, ConfigValueFactory.fromAnyRef(value))
     }
     return Pair(config, globalConfig)

--- a/jetbrains/src/main/kotlin/com/sourcegraph/config/ConfigUtil.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/config/ConfigUtil.kt
@@ -93,8 +93,7 @@ object ConfigUtil {
   fun getAgentConfiguration(
       project: Project,
       endpoint: SourcegraphServerPath? = null,
-      token: String? = null,
-      customConfigContent: String? = null
+      token: String? = null
   ): ExtensionConfiguration {
 
     return ExtensionConfiguration(
@@ -107,7 +106,7 @@ object ConfigUtil {
             UserLevelConfig.getAutocompleteProviderType()?.vscodeSettingString(),
         debug = isCodyDebugEnabled(),
         verboseDebug = isCodyVerboseDebugEnabled(),
-        customConfigurationJson = getCustomConfiguration(project, customConfigContent),
+        customConfigurationJson = getCustomConfiguration(project),
     )
   }
 
@@ -159,7 +158,7 @@ object ConfigUtil {
   }
 
   @JvmStatic
-  fun getCustomConfiguration(project: Project, customConfigContent: String?): String {
+  fun getCustomConfiguration(project: Project): String {
     // Needed by Edit commands to trigger smart-selection; without it things break.
     // So it isn't optional in JetBrains clients, which do not offer language-neutral solutions
     // to this problem; instead we hardwire it to use the indentation-based provider.
@@ -171,7 +170,7 @@ object ConfigUtil {
     try {
       val text =
           try {
-            customConfigContent ?: getSettingsFile(project).readText()
+            getSettingsFile(project).readText()
           } catch (e: Exception) {
             logger.info("No user defined settings file found. Proceeding with empty custom config")
             ""

--- a/jetbrains/src/main/resources/CodyBundle.properties
+++ b/jetbrains/src/main/resources/CodyBundle.properties
@@ -102,9 +102,9 @@ JcefRuntimeNotification.title=Cody requires a runtime with JCEF
 JcefRuntimeNotification.content=Your current runtime does not support Java Chromium Embedded Framework (JCEF), which is essential for Cody to work properly.
 MissingJcefPanel.content=Cody relies on Java Chromium Embedded Framework (JCEF) to function. To continue using Cody in your IDE, please switch to a runtime that includes JCEF.
 chooseRuntimeWithJcef.button=Choose a runtime with JCEF...
-AutoeditSuggestionNotification.title=Auto-edits are available
-AutoeditSuggestionNotification.content=Check out Cody's new auto-edits for an enhanced code completion experience. Give it a try now!
-AutoeditSuggestionNotification.button=Configure && Restart IDE
+AutoeditSuggestionNotification.title=Auto-edits are now available
+AutoeditSuggestionNotification.content=<html>An advanced mode for completions is now available. This is configured via ''cody_settings.json'', give it a try now.</html>
+AutoeditSuggestionNotification.button=Configure auto-edits and Restart
 
 ErrorPanel.content=Check the IDE logs for errors
 ErrorPanel.label=Cody encountered an unexpected error

--- a/jetbrains/src/main/resources/CodyBundle.properties
+++ b/jetbrains/src/main/resources/CodyBundle.properties
@@ -104,7 +104,8 @@ MissingJcefPanel.content=Cody relies on Java Chromium Embedded Framework (JCEF) 
 chooseRuntimeWithJcef.button=Choose a runtime with JCEF...
 AutoeditSuggestionNotification.title=Auto-edits are now available
 AutoeditSuggestionNotification.content=<html>An advanced mode for completions is now available. This is configured via ''cody_settings.json'', give it a try now.</html>
-AutoeditSuggestionNotification.button=Configure auto-edits and Restart
+AutoeditSuggestionNotification.configure=Configure auto-edits and Restart
+AutoeditSuggestionNotification.openFile=Open cody_settings.json file
 
 ErrorPanel.content=Check the IDE logs for errors
 ErrorPanel.label=Cody encountered an unexpected error

--- a/jetbrains/src/main/resources/CodyBundle.properties
+++ b/jetbrains/src/main/resources/CodyBundle.properties
@@ -103,9 +103,9 @@ JcefRuntimeNotification.content=Your current runtime does not support Java Chrom
 MissingJcefPanel.content=Cody relies on Java Chromium Embedded Framework (JCEF) to function. To continue using Cody in your IDE, please switch to a runtime that includes JCEF.
 chooseRuntimeWithJcef.button=Choose a runtime with JCEF...
 AutoeditSuggestionNotification.title=Auto-edits are now available
-AutoeditSuggestionNotification.content=<html>An advanced mode for completions is now available. This is configured via ''cody_settings.json'', give it a try now.</html>
+AutoeditSuggestionNotification.content=An advanced mode for completions is now available. This is configured <b>cody_settings.json</b>, give it a try now.
 AutoeditSuggestionNotification.configure=Configure auto-edits and Restart
-AutoeditSuggestionNotification.openFile=Open cody_settings.json file
+AutoeditSuggestionNotification.openFile=Open cody__settings.json
 
 ErrorPanel.content=Check the IDE logs for errors
 ErrorPanel.label=Cody encountered an unexpected error

--- a/jetbrains/src/main/resources/CodyBundle.properties
+++ b/jetbrains/src/main/resources/CodyBundle.properties
@@ -104,7 +104,7 @@ MissingJcefPanel.content=Cody relies on Java Chromium Embedded Framework (JCEF) 
 chooseRuntimeWithJcef.button=Choose a runtime with JCEF...
 AutoeditSuggestionNotification.title=Auto-edits are available
 AutoeditSuggestionNotification.content=Check out Cody's new auto-edits for an enhanced code completion experience. Give it a try now!
-AutoeditSuggestionNotification.button=Configure \& Restart IDE
+AutoeditSuggestionNotification.button=Configure && Restart IDE
 
 ErrorPanel.content=Check the IDE logs for errors
 ErrorPanel.label=Cody encountered an unexpected error

--- a/jetbrains/src/main/resources/CodyBundle.properties
+++ b/jetbrains/src/main/resources/CodyBundle.properties
@@ -103,7 +103,7 @@ JcefRuntimeNotification.content=Your current runtime does not support Java Chrom
 MissingJcefPanel.content=Cody relies on Java Chromium Embedded Framework (JCEF) to function. To continue using Cody in your IDE, please switch to a runtime that includes JCEF.
 chooseRuntimeWithJcef.button=Choose a runtime with JCEF...
 AutoeditSuggestionNotification.title=Auto-edits are now available
-AutoeditSuggestionNotification.content=An advanced mode for completions is now available. This is configured <b>cody_settings.json</b>, give it a try now.
+AutoeditSuggestionNotification.content=An advanced mode for completions is now available. This is configured via <b>cody_settings.json</b>, give it a try now.
 AutoeditSuggestionNotification.configure=Configure auto-edits and Restart
 AutoeditSuggestionNotification.openFile=Open cody__settings.json
 

--- a/jetbrains/src/main/resources/CodyBundle.properties
+++ b/jetbrains/src/main/resources/CodyBundle.properties
@@ -102,6 +102,9 @@ JcefRuntimeNotification.title=Cody requires a runtime with JCEF
 JcefRuntimeNotification.content=Your current runtime does not support Java Chromium Embedded Framework (JCEF), which is essential for Cody to work properly.
 MissingJcefPanel.content=Cody relies on Java Chromium Embedded Framework (JCEF) to function. To continue using Cody in your IDE, please switch to a runtime that includes JCEF.
 chooseRuntimeWithJcef.button=Choose a runtime with JCEF...
+AutoeditSuggestionNotification.title=Auto-edits are available
+AutoeditSuggestionNotification.content=Check out Cody's new auto-edits for an enhanced code completion experience. Give it a try now!
+AutoeditSuggestionNotification.button=Configure \& Restart IDE
 
 ErrorPanel.content=Check the IDE logs for errors
 ErrorPanel.label=Cody encountered an unexpected error

--- a/jetbrains/src/test/kotlin/com/sourcegraph/config/ConfigUtilTest.kt
+++ b/jetbrains/src/test/kotlin/com/sourcegraph/config/ConfigUtilTest.kt
@@ -1,6 +1,7 @@
 import com.google.gson.JsonParser
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import com.sourcegraph.config.ConfigUtil
+import com.sourcegraph.utils.CodyEditorUtil
 
 class ConfigUtils : BasePlatformTestCase() {
 
@@ -12,7 +13,8 @@ class ConfigUtils : BasePlatformTestCase() {
       "cody.suggestions.mode": "autocomplete"
     }
     """
-    val result = ConfigUtil.getCustomConfiguration(project, input)
+    setCodySettingsJsonContent(input)
+    val result = ConfigUtil.getCustomConfiguration(project)
     val parsed = JsonParser.parseString(result).asJsonObject
 
     assertEquals(
@@ -34,7 +36,8 @@ class ConfigUtils : BasePlatformTestCase() {
       "cody.suggestions.mode": "autocomplete"
     }
     """
-    val result = ConfigUtil.getCustomConfiguration(project, input)
+    setCodySettingsJsonContent(input)
+    val result = ConfigUtil.getCustomConfiguration(project)
     assertNotNull(result)
     val parsed = JsonParser.parseString(result).asJsonObject
     assertEquals(2 + 1, parsed.size()) // +1 for the additional folding property
@@ -49,9 +52,15 @@ class ConfigUtils : BasePlatformTestCase() {
       "cody.suggestions.mode": "autocomplete"
     }
     """
-    val result = ConfigUtil.getCustomConfiguration(project, input)
+    setCodySettingsJsonContent(input)
+    val result = ConfigUtil.getCustomConfiguration(project)
     assertNotNull(result)
     val parsed = JsonParser.parseString(result).asJsonObject
     assertEquals(2 + 1, parsed.size()) // +1 for the additional folding property
+  }
+
+  private fun setCodySettingsJsonContent(codySettingsContent: String) {
+    val uriString = ConfigUtil.getSettingsFile(project).toUri().toString()
+    CodyEditorUtil.createFileOrScratchFromUntitled(project, uriString, codySettingsContent)
   }
 }

--- a/jetbrains/src/test/kotlin/com/sourcegraph/config/ConfigUtilTest.kt
+++ b/jetbrains/src/test/kotlin/com/sourcegraph/config/ConfigUtilTest.kt
@@ -42,7 +42,11 @@ class ConfigUtils : BasePlatformTestCase() {
     val result = ConfigUtil.getCustomConfiguration(project)
     assertNotNull(result)
     val parsed = JsonParser.parseString(result).asJsonObject
-    assertEquals(2 + 1, parsed.size()) // +1 for the additional folding property
+    assertEquals(
+        2 + 2,
+        parsed
+            .getAsJsonObject("cody")
+            .size()) // +2 for the additional folding property and productCode
   }
 
   fun testGetCustomConfiguration_handlesComments() {
@@ -58,7 +62,11 @@ class ConfigUtils : BasePlatformTestCase() {
     val result = ConfigUtil.getCustomConfiguration(project)
     assertNotNull(result)
     val parsed = JsonParser.parseString(result).asJsonObject
-    assertEquals(2 + 1, parsed.size()) // +1 for the additional folding property
+    assertEquals(
+        2 + 2,
+        parsed
+            .getAsJsonObject("cody")
+            .size()) // +2 for the additional folding property and productCode
   }
 
   fun testAddSettings_addASetting() {
@@ -90,8 +98,7 @@ class ConfigUtils : BasePlatformTestCase() {
 
     val result = ConfigUtil.getSettingsFile(project).readText()
     assertContains(result, "auto-edit (Beta)")
-    assertContains(result, "\"cody.debug\" : true")
-    assertDoesntContain(result, listOf("autocomplete"))
+    assertFalse(result.contains("autocomplete"))
   }
 
   fun testAddSettings_persistExistingSettings() {
@@ -107,7 +114,6 @@ class ConfigUtils : BasePlatformTestCase() {
 
     val result = ConfigUtil.getSettingsFile(project).readText()
     assertContains(result, "auto-edit (Beta)")
-    assertContains(result, "\"cody.debug\" : true")
   }
 
   private fun setCodySettingsJsonContent(codySettingsContent: String) {

--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -63,7 +63,7 @@ export enum FeatureFlag {
     CodySmartApplyPrefetching = 'cody-smart-apply-prefetching',
 
     CodyAutoEditExperimentEnabledFeatureFlag = 'cody-autoedit-experiment-enabled-flag',
-    CodyAutoeditExperimentEnabledFeatureFlag = 'cody-autoedit-jetbrains-experiment-enabled-flag',
+    CodyAutoeditJetBrainsExperimentEnabledFeatureFlag = 'cody-autoedit-jetbrains-experiment-enabled-flag',
 
     // Enables inline rendering of autoedit suggestions
     CodyAutoEditInlineRendering = 'cody-autoedit-inline-rendering',

--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -63,6 +63,7 @@ export enum FeatureFlag {
     CodySmartApplyPrefetching = 'cody-smart-apply-prefetching',
 
     CodyAutoEditExperimentEnabledFeatureFlag = 'cody-autoedit-experiment-enabled-flag',
+    CodyAutoeditExperimentEnabledFeatureFlag = 'cody-autoedit-jetbrains-experiment-enabled-flag',
 
     // Enables inline rendering of autoedit suggestions
     CodyAutoEditInlineRendering = 'cody-autoedit-inline-rendering',


### PR DESCRIPTION
We want to suggests a switch to auto-edits for pro and enterprise users (having a ff enabled).
This PR adds a notification with an action that adds the config and restarts the IDE.

![image](https://github.com/user-attachments/assets/d6b77d62-a67d-4801-8322-b4be39915c66)

## Test plan
1. Have enterprise (s2) or pro account
2. Have ff enabled
3. Do not have `"cody.suggestions.mode": "auto-edit (Beta)"` (set it to "autocomplete"/"off" or remove that setting)
4. Open IDE / switch the account to pro or enterprise (s2)

The notification should appear.

It should not appear if auto-edits are turned on.

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
