### PR TITLE
feat(smart-apply): Ship instant smart apply model

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -55,6 +55,7 @@ export enum FeatureFlag {
     CodyAutocompleteContextExperimentVariant4 = 'cody-autocomplete-context-experiment-variant-4',
     CodyAutocompleteContextExperimentControl = 'cody-autocomplete-context-experiment-control',
 
+    CodySmartApplyInstantModeEnabled = 'cody-smart-apply-instant-mode-enabled',
     CodySmartApplyExperimentEnabledFeatureFlag = 'cody-smart-apply-experiment-enabled-flag',
     CodySmartApplyExperimentVariant1 = 'cody-smart-apply-experiment-variant-1',
     CodySmartApplyExperimentVariant2 = 'cody-smart-apply-experiment-variant-2',

--- a/vscode/src/services/utils/codeblock-action-tracker.ts
+++ b/vscode/src/services/utils/codeblock-action-tracker.ts
@@ -9,10 +9,8 @@ import {
     combineLatest,
     distinctUntilChanged,
     featureFlagProvider,
-    firstValueFrom,
     isDotCom,
     isS2,
-    skipPendingOperation,
     switchMap,
     telemetryRecorder,
 } from '@sourcegraph/cody-shared'
@@ -141,37 +139,25 @@ export async function handleCodeFromInsertAtCursor(text: string): Promise<void> 
     await vscode.workspace.applyEdit(workspaceEdit)
 }
 
-function getSmartApplyExperimentModel(
-    defaultModel: EditModel | undefined
-): Observable<EditModel | undefined> {
+function isSmartApplyInstantModeEnabled(): Observable<boolean> {
     return combineLatest(
-        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodySmartApplyExperimentEnabledFeatureFlag),
-        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodySmartApplyExperimentVariant1),
-        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodySmartApplyExperimentVariant2),
-        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodySmartApplyExperimentVariant3)
+        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodySmartApplyInstantModeEnabled)
     ).pipe(
-        switchMap(([isExperimentEnabled, isVariant1Enabled, isVariant2Enabled, isVariant3Enabled]) => {
-            // We run fine tuning experiment for VSC client only.
-            // We disable for all agent clients like the JetBrains plugin.
-            if (!isExperimentEnabled) {
-                return Observable.of(defaultModel)
+        switchMap(([isEnabled]) => {
+            // If the instant mode is enabled, return true to use qwen model.
+            if (isEnabled) {
+                return Observable.of(true)
             }
-            if (isVariant1Enabled) {
-                return Observable.of(SMART_APPLY_MODEL_IDENTIFIERS.FireworksQwenCodeDefault)
-            }
-            if (isVariant2Enabled) {
-                return Observable.of(SMART_APPLY_MODEL_IDENTIFIERS.FireworksQwenCodeVariant2)
-            }
-            if (isVariant3Enabled) {
-                return Observable.of(SMART_APPLY_MODEL_IDENTIFIERS.FireworksQwenCodeVariant3)
-            }
-            return Observable.of(defaultModel)
+            return Observable.of(false)
         }),
         distinctUntilChanged()
     )
 }
 
 async function getSmartApplyModel(authStatus: AuthStatus): Promise<EditModel | undefined> {
+    if (isSmartApplyInstantModeEnabled()) {
+        return SMART_APPLY_MODEL_IDENTIFIERS.FireworksQwenCodeDefault
+    }
     if (isDotCom(authStatus) || isS2(authStatus)) {
         const defaultModel: EditModel = 'anthropic/claude-3-5-sonnet-20240620'
         /**
@@ -179,12 +165,8 @@ async function getSmartApplyModel(authStatus: AuthStatus): Promise<EditModel | u
          * as it is the most reliable model for smart apply from our testing.
          * We choose the model based on the feature flag but default to the sonnet model if the flag is not enabled or as default model.
          */
-        const smartApplyModel = await firstValueFrom(
-            getSmartApplyExperimentModel(defaultModel).pipe(skipPendingOperation())
-        )
-        return smartApplyModel
+        return defaultModel
     }
-
     // We cannot be sure what model we're using for enterprise, we will let this fall through
     // to the default edit/smart apply behaviour where we use the configured enterprise model.
     return undefined

--- a/vscode/src/services/utils/codeblock-action-tracker.ts
+++ b/vscode/src/services/utils/codeblock-action-tracker.ts
@@ -9,8 +9,10 @@ import {
     combineLatest,
     distinctUntilChanged,
     featureFlagProvider,
+    firstValueFrom,
     isDotCom,
     isS2,
+    skipPendingOperation,
     switchMap,
     telemetryRecorder,
 } from '@sourcegraph/cody-shared'
@@ -155,7 +157,10 @@ function isSmartApplyInstantModeEnabled(): Observable<boolean> {
 }
 
 async function getSmartApplyModel(authStatus: AuthStatus): Promise<EditModel | undefined> {
-    if (isSmartApplyInstantModeEnabled()) {
+    const isInstantModeEnabled = await firstValueFrom(
+        isSmartApplyInstantModeEnabled().pipe(skipPendingOperation())
+    )
+    if (isInstantModeEnabled) {
         return SMART_APPLY_MODEL_IDENTIFIERS.FireworksQwenCodeDefault
     }
     if (isDotCom(authStatus) || isS2(authStatus)) {


### PR DESCRIPTION
Add a feature flag to use the instant smart apply model when enabled.

## Test plan
- Override the user in the feature flag and test if we use the new smart apply model for both dotcom and enterprise accounts.

