### PR TITLE
feat(jetbrains): Improve password management in jetbrains

### DIFF
--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentClient.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentClient.kt
@@ -107,19 +107,19 @@ class CodyAgentClient(private val project: Project, private val webview: NativeW
   }
 
   override fun secrets_get(params: Secrets_GetParams): CompletableFuture<String?> {
-    return runInBackground { CodySecureStore.getFromSecureStore(params.key) }
+    return runInBackground { CodySecureStore.getInstance().getFromSecureStore(params.key) }
   }
 
   override fun secrets_store(params: Secrets_StoreParams): CompletableFuture<Null?> {
     return runInBackground {
-      CodySecureStore.writeToSecureStore(params.key, params.value)
+      CodySecureStore.getInstance().writeToSecureStore(params.key, params.value)
       null
     }
   }
 
   override fun secrets_delete(params: Secrets_DeleteParams): CompletableFuture<Null?> {
     return runInBackground {
-      CodySecureStore.writeToSecureStore(params.key, null)
+      CodySecureStore.getInstance().writeToSecureStore(params.key, null)
       null
     }
   }

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/auth/CodySecureStore.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/auth/CodySecureStore.kt
@@ -4,16 +4,155 @@ import com.intellij.credentialStore.CredentialAttributes
 import com.intellij.credentialStore.Credentials
 import com.intellij.credentialStore.generateServiceName
 import com.intellij.ide.passwordSafe.PasswordSafe
+import com.intellij.notification.Notification
+import com.intellij.notification.NotificationAction
+import com.intellij.notification.NotificationType
+import com.intellij.notification.Notifications
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.runInEdt
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.options.ShowSettingsUtil
+import com.sourcegraph.common.CodyBundle
+import com.sourcegraph.common.NotificationGroups
+import com.sourcegraph.config.ConfigUtil
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.security.KeyStore
+import java.util.UUID
+import javax.crypto.spec.SecretKeySpec
+import org.apache.commons.lang.RandomStringUtils
 
-object CodySecureStore {
-  private fun credentialAttributes(key: String): CredentialAttributes =
-      CredentialAttributes(generateServiceName("Sourcegraph", key))
+@Service(Service.Level.APP)
+class CodySecureStore {
+  // The version of the storage format, increment in case of breaking changes in the implementation
+  private val storageVersion = 2
+  private val passwordKey = "KeyStorePassword.v$storageVersion"
+
+  private val keyStoreFile =
+      if (ConfigUtil.isIntegrationTestModeEnabled() || PasswordSafe.instance.isMemoryOnly) {
+        val tempDir = System.getProperty("java.io.tmpdir")
+        val file = File(tempDir, "cody-${UUID.randomUUID()}.keystore")
+        file.deleteOnExit()
+        file
+      } else {
+        File(System.getProperty("user.home"), ".sourcegraph/cody.v$storageVersion.keystore")
+      }
+
+  init {
+    if (PasswordSafe.instance.isMemoryOnly) {
+      showInMemoryOnlyPasswordWarning()
+    }
+  }
 
   fun getFromSecureStore(key: String): String? {
-    return PasswordSafe.instance.get(credentialAttributes(key))?.getPasswordAsString()
+    val keyStore = getKeyStore()
+    if (!keyStore.containsAlias(key)) return null
+
+    val protParam = KeyStore.PasswordProtection(getKeystorePassword())
+    val entry = keyStore.getEntry(key, protParam) as? KeyStore.SecretKeyEntry
+    return entry?.secretKey?.encoded?.toString(Charsets.UTF_8)
+        ?: CodyPasswordStore.getFromPasswordStore(key)
   }
 
   fun writeToSecureStore(key: String, value: String?) {
-    PasswordSafe.instance.set(credentialAttributes(key), Credentials(user = "", value))
+    val keyStore = getKeyStore()
+    if (value == null) {
+      keyStore.deleteEntry(key)
+    } else {
+      val secretKey = SecretKeySpec(value.toByteArray(Charsets.UTF_8), "AES")
+      val keyEntry = KeyStore.SecretKeyEntry(secretKey)
+      val protParam = KeyStore.PasswordProtection(getKeystorePassword())
+      keyStore.setEntry(key, keyEntry, protParam)
+    }
+
+    FileOutputStream(keyStoreFile).use { fos -> keyStore.store(fos, getKeystorePassword()) }
+  }
+
+  private fun getKeystorePassword(): CharArray {
+    var password = CodyPasswordStore.getFromPasswordStore(passwordKey)
+    if (password == null) {
+      password = RandomStringUtils.randomAlphabetic(64)
+      CodyPasswordStore.writeToPasswordStore(passwordKey, password)
+    }
+    return password!!.toCharArray()
+  }
+
+  private fun showInMemoryOnlyPasswordWarning() {
+    runInEdt {
+      val notification =
+          Notification(
+              NotificationGroups.CODY_AUTH,
+              CodyBundle.getString("notification.auth.inMemoryOnly.title"),
+              CodyBundle.getString("notification.auth.inMemoryOnly.detail"),
+              NotificationType.WARNING)
+
+      notification.addAction(
+          NotificationAction.createSimple("Configure password storage") {
+            notification.expire()
+            ShowSettingsUtil.getInstance().showSettingsDialog(null, "Passwords")
+          })
+
+      Notifications.Bus.notify(notification)
+    }
+  }
+
+  private fun reinitialize() {
+    if (keyStoreFile.exists()) {
+      val backupFile = File(keyStoreFile.absolutePath + ".bak")
+      if (backupFile.exists()) backupFile.delete()
+      keyStoreFile.renameTo(backupFile)
+
+      val notification =
+          Notification(
+              NotificationGroups.CODY_AUTH,
+              CodyBundle.getString("notification.auth.reinitialize.title"),
+              CodyBundle.getString("notification.auth.reinitialize.detail"),
+              NotificationType.ERROR)
+
+      Notifications.Bus.notify(notification)
+    }
+
+    if (!keyStoreFile.exists()) {
+      keyStoreFile.parentFile.mkdirs()
+      val keyStore = KeyStore.getInstance(KeyStore.getDefaultType())
+      val password = getKeystorePassword()
+      keyStore.load(null, password)
+      FileOutputStream(keyStoreFile).use { fos -> keyStore.store(fos, password) }
+    }
+  }
+
+  private fun getKeyStore(reinitializeOnError: Boolean = true): KeyStore {
+    try {
+      val keyStore = KeyStore.getInstance(KeyStore.getDefaultType())
+      FileInputStream(keyStoreFile).use { fis -> keyStore.load(fis, getKeystorePassword()) }
+      return keyStore
+    } catch (e: Exception) {
+      if (reinitializeOnError) {
+        reinitialize()
+        return getKeyStore(reinitializeOnError = false)
+      }
+      throw e
+    }
+  }
+
+  private object CodyPasswordStore {
+    private fun credentialAttributes(key: String): CredentialAttributes =
+        CredentialAttributes(generateServiceName("Sourcegraph", key))
+
+    fun getFromPasswordStore(key: String): String? {
+      return PasswordSafe.instance.get(credentialAttributes(key))?.getPasswordAsString()
+    }
+
+    fun writeToPasswordStore(key: String, value: String?) {
+      PasswordSafe.instance.set(credentialAttributes(key), Credentials(user = "", value))
+    }
+  }
+
+  companion object {
+    @JvmStatic
+    fun getInstance(): CodySecureStore {
+      return ApplicationManager.getApplication().getService(CodySecureStore::class.java)
+    }
   }
 }

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/migration/AccountsMigration.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/migration/AccountsMigration.kt
@@ -9,7 +9,7 @@ object AccountsMigration {
     codyAccountManager.getAccounts().forEach { oldAccount ->
       val token = codyAccountManager.getTokenForAccount(oldAccount)
       if (token != null) {
-        CodySecureStore.writeToSecureStore(oldAccount.server.url, token)
+        CodySecureStore.getInstance().writeToSecureStore(oldAccount.server.url, token)
       }
     }
   }

--- a/jetbrains/src/main/kotlin/com/sourcegraph/config/ConfigUtil.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/config/ConfigUtil.kt
@@ -126,7 +126,7 @@ object ConfigUtil {
         }
       }
     } else {
-      val token = CodySecureStore.getFromSecureStore(endpoint.url)
+      val token = CodySecureStore.getInstance().getFromSecureStore(endpoint.url)
       if (token != null) {
         authHeaders.complete(mapOf("Authorization" to "token $token"))
       }

--- a/jetbrains/src/main/resources/CodyBundle.properties
+++ b/jetbrains/src/main/resources/CodyBundle.properties
@@ -112,11 +112,13 @@ export.failed=Cody: Chat export failed. Please retry...
 gotit.autocomplete.header=Your first Cody Autocomplete
 gotit.autocomplete.message=This is how Cody displays autocomplete suggestions.<br>Press <b>{0}</b> to insert it into the editor.<br>Press <b>{1}</b> and <b>{2}</b> to cycle through alternatives.
 
-# User Friendly Error Notifications
+# User Friendly Notifications
+notification.auth.inMemoryOnly.title=Configure password manager...
+notification.auth.inMemoryOnly.detail=IntelliJ is configured to store passwords in memory only. Your Cody credentials won't be saved between sessions.
+notification.auth.reinitialize.title=Cody authentication storage error
+notification.auth.reinitialize.detail=Cody encountered an error with your secure credential storage. You may need to sign in again to Sourcegraph.
 notification.general.cody-not-running.title=Cody is starting...
 notification.general.cody-not-running.detail=Please wait a few seconds. If Cody still won't start, check the IDE logs for errors.
-notifications.edits.editing-not-available.title=Cody can't edit the file
-notifications.edits.editing-not-available.detail=This could be because the file is not writable or Cody has trouble communicating with the editor.
 notifications.cody-connection-timeout.title=Cody's connection timeout
 notifications.cody-connection-timeout.detail=Cody took longer than expected to start. Please run any Cody action or restart Cody to retry.
 error.cody-connection-timeout.message=Failed to start Cody in timely manner, please run any Cody action to retry
@@ -140,26 +142,3 @@ settings.migration.llm-upgrade-notification.body=\
 
 # URLs
 url.sourcegraph.subscription=https://sourcegraph.com/cody/subscription
-
-# Authentication
-login.dialog.title=Add Sourcegraph Account
-login.dialog.authorize-in-browser=Authorize in Browser
-login.dialog.add-account=Add Account
-login.dialog.show-advanced=Show Advanced...
-login.dialog.hide-advanced=Hide Advanced...
-login.dialog.check-browser=Logging in, check your browser
-login.dialog.instance-url.label=Instance URL:
-login.dialog.instance-url.comment=Enter the address of your Sourcegraph instance. For example https://sourcegraph.&lt;yourcompany&gt;.org
-login.dialog.instance-url.empty=https://sourcegraph.<yourcompany>.org
-login.dialog.token.label=Token:
-login.dialog.custom-headers.label=Custom request headers:
-login.dialog.custom-headers.comment=Any custom headers to send with every request to Sourcegraph.<br>Use any number of pairs: "header1, value1, header2, value2, ...".<br>Whitespace around commas doesn't matter.
-login.dialog.custom-headers.empty=Client-ID, client-one, X-Extra, some metadata
-login.dialog.optional.group=Optional
-login.dialog.validation.empty-token=Token cannot be empty
-login.dialog.validation.invalid-token=Invalid access token
-login.dialog.validation.empty-instance-url=Instance URL cannot be empty
-login.dialog.validation.invalid-instance-url=Invalid instance URL
-login.dialog.error.server-unreachable=Server is unreachable
-login.dialog.error.incorrect-credentials=Incorrect credentials.\n{0}
-login.dialog.error.invalid-authentication=Invalid authentication data.\n{0}

--- a/jetbrains/src/test/kotlin/com/sourcegraph/cody/auth/CodySecureStoreTest.kt
+++ b/jetbrains/src/test/kotlin/com/sourcegraph/cody/auth/CodySecureStoreTest.kt
@@ -1,0 +1,154 @@
+package com.sourcegraph.cody.auth
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import java.io.File
+import org.junit.Test
+
+class CodySecureStoreTest : BasePlatformTestCase() {
+  private lateinit var secureStore: CodySecureStore
+
+  public override fun setUp() {
+    super.setUp()
+    secureStore = CodySecureStore()
+  }
+
+  @Test
+  fun testSecureStoreWriteAndRead() {
+    // Basic test for writing and reading from the secure store
+    val testKey = "testKey"
+    val testValue = "testValue123"
+
+    // Write to the store
+    secureStore.writeToSecureStore(testKey, testValue)
+
+    // Read from the store
+    val retrievedValue = secureStore.getFromSecureStore(testKey)
+
+    // Verify results
+    assertEquals("Retrieved value should match what was stored", testValue, retrievedValue)
+  }
+
+  @Test
+  fun testSecureStoreRemoveValue() {
+    // Test removing a value from the secure store
+    val testKey = "testKey"
+    val testValue = "testValue123"
+
+    // First add the value
+    secureStore.writeToSecureStore(testKey, testValue)
+
+    // Verify it was added
+    val retrievedValue = secureStore.getFromSecureStore(testKey)
+    assertEquals("Value should be stored correctly", testValue, retrievedValue)
+
+    // Now remove it
+    secureStore.writeToSecureStore(testKey, null)
+
+    // Verify it was removed
+    val afterRemoveValue = secureStore.getFromSecureStore(testKey)
+    assertNull("Value should be null after removal", afterRemoveValue)
+  }
+
+  @Test
+  fun testSecureStoreNonExistentKey() {
+    // Test behavior when trying to access a non-existent key
+    val nonExistentKey = "nonExistentKey${System.currentTimeMillis()}"
+
+    // Try to read a key that doesn't exist
+    val value = secureStore.getFromSecureStore(nonExistentKey)
+
+    // Verify result
+    assertNull("Non-existent key should return null", value)
+  }
+
+  @Test
+  fun testSecureStoreKeyOverwrite() {
+    // Test overwriting an existing value
+    val testKey = "testKey"
+    val initialValue = "initialValue"
+    val newValue = "newValue"
+
+    // Write initial value
+    secureStore.writeToSecureStore(testKey, initialValue)
+
+    // Verify initial value
+    val initialRetrieval = secureStore.getFromSecureStore(testKey)
+    assertEquals("Initial value should be stored correctly", initialValue, initialRetrieval)
+
+    // Overwrite with new value
+    secureStore.writeToSecureStore(testKey, newValue)
+
+    // Verify new value
+    val newRetrieval = secureStore.getFromSecureStore(testKey)
+    assertEquals("New value should overwrite the previous value", newValue, newRetrieval)
+  }
+
+  @Test
+  fun testMultipleKeysManagement() {
+    // Test that multiple keys can be managed independently
+    val keys = listOf("key1", "key2", "key3")
+    val values = listOf("value1", "value2", "value3")
+
+    // Store all keys
+    keys.forEachIndexed { index, key -> secureStore.writeToSecureStore(key, values[index]) }
+
+    // Verify all keys can be retrieved correctly
+    keys.forEachIndexed { index, key ->
+      val value = secureStore.getFromSecureStore(key)
+      assertEquals("Value for key $key should match", values[index], value)
+    }
+
+    // Remove one key
+    secureStore.writeToSecureStore(keys[1], null)
+
+    // Verify the removed key returns null
+    assertNull("Removed key should return null", secureStore.getFromSecureStore(keys[1]))
+
+    // Verify other keys are still accessible
+    assertEquals(
+        "Unmodified key should still be accessible",
+        values[0],
+        secureStore.getFromSecureStore(keys[0]),
+    )
+    assertEquals(
+        "Unmodified key should still be accessible",
+        values[2],
+        secureStore.getFromSecureStore(keys[2]),
+    )
+  }
+
+  @Test
+  fun testReinitializeStoreOnCorruption() {
+    // Test the store reinitializes correctly when corrupted
+    val testKey = "testKey"
+    val testValue = "testValue"
+
+    // First add a value
+    secureStore.writeToSecureStore(testKey, testValue)
+
+    // Corrupt the store file
+    assertTrue(
+        "Store file should exist before corruption",
+        secureStore.getKeyStoreFile().exists(),
+    )
+    secureStore.getKeyStoreFile().writeText("This is corrupted data")
+
+    // Previous value should be lost due to reinitialization
+    val retrievedValue = secureStore.getFromSecureStore(testKey)
+    assertNull("Value should be null after reinitialization", retrievedValue)
+
+    // Verify backup file was created
+    val backupFile = File(secureStore.getKeyStoreFile().absolutePath + ".bak")
+    assertTrue("Backup file should exist after reinitialization", backupFile.exists())
+
+    // Should be able to write new values to the reinitialized store
+    val newTestKey = "newTestKey"
+    val newTestValue = "newTestValue"
+    secureStore.writeToSecureStore(newTestKey, newTestValue)
+
+    // Verify the new value was correctly stored
+    val newRetrievedValue = secureStore.getFromSecureStore(newTestKey)
+    assertEquals(
+        "New value should be retrievable after reinitialization", newTestValue, newRetrievedValue)
+  }
+}


### PR DESCRIPTION
## Changes

This PR partially mitigates the issue where users faces multiple prompt passwords if they change the endpoints in different IDEs.
To fully solve that issue it would need to be done on the JetBrains level, as I described there: https://platform.jetbrains.com/t/group-keyring-access-for-all-ides-from-jetbrains-familly/1002

With my changes only password to Cody secret store is stored in a keyring using `PasswordSafe`, and all secrets are stored in a custom java [KeyStore](https://docs.oracle.com/javase/8/docs/api/java/security/KeyStore.html). That means password need to be typed only once per different IntelliJ executable (no matter between how many endpoints user switches).

This is second attempt to deploy that changes. Compared to previous one I added some safeguards:

1. we notify user if password storage is memory only
2. we notify user if secure storage is corrupted, password from password store does not match, or if secure storage need to be recreated for any other reason
3. we automatically recreate secure storage if needed

## Test plan

**Backward compatibility test**

1. Open your keychain settings and search for `IntelliJ Platform Sourcegraph`, and then delete all entries 
![image](https://github.com/user-attachments/assets/3b39c24c-a607-4f27-9d97-e3d366735c34)
2. Open first IDE (e.g. IntelliJ Community)  with old version of Cody installed (without this changes)
3. Login to `sourcegraph.com`
4. Switch to some private instance (e.g. to sg02)
3. Open second, but different, IntelliJ IDE, e.g. Pycharm, with new version of Cody installed (with this changes)
5. IntelliJ should ask you about password to the keyring (twice!) and then log you in to your second instance
6. In the second IDE switch back to  `sourcegraph.com`
7. IntelliJ should ask you about password to the keyring AGAIN (and twice as well) and then log you in to `sourcegraph.com`

**Only new version test**
1. Open your keychain settings and search for `IntelliJ Platform Sourcegraph`, and then delete all entries 
2. Open first IDE (e.g. IntelliJ Community)  with new version of Cody installed (with this changes)
3. Login to `sourcegraph.com`
4. Switch to some private instance (e.g. to sg02)
3. Open second, but different, IntelliJ IDE, e.g. Pycharm, with new version of Cody installed (with this changes)
5. IntelliJ should ask you about password to the keyring (once!) and then log you in to your second instance
6. In the second IDE switch back to `sourcegraph.com`
7. IntelliJ should NOT ask you about any password anymore an just switch the account without any fuss
