### PR TITLE
fix(agentic chat): Put the settings tab behind a feature flag

### DIFF
--- a/vscode/webviews/tabs/TabsBar.tsx
+++ b/vscode/webviews/tabs/TabsBar.tsx
@@ -16,10 +16,11 @@ import {
 import { getVSCodeAPI } from '../utils/VSCodeApi'
 import { View } from './types'
 
-import { type AuthenticatedAuthStatus, CodyIDE, isDefined } from '@sourcegraph/cody-shared'
+import { type AuthenticatedAuthStatus, CodyIDE, isDefined, FeatureFlag } from '@sourcegraph/cody-shared'
 import { type FC, Fragment, forwardRef, memo, useCallback, useMemo, useState } from 'react'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../components/shadcn/ui/tooltip'
 import { useConfig } from '../utils/useConfig'
+import { useFeatureFlag } from '../utils/useFeatureFlags'
 
 import { useExtensionAPI } from '@sourcegraph/prompt-editor'
 import { isEqual } from 'lodash'
@@ -360,7 +361,7 @@ TabButton.displayName = 'TabButton'
  */
 function useTabs(input: Pick<TabsBarProps, 'user'>): TabConfig[] {
     const IDE = input.user.IDE
-
+    const isMcpEnabled = useFeatureFlag(FeatureFlag.NextAgenticChatInternal)
     const extensionAPI = useExtensionAPI<'userHistory'>()
 
     return useMemo<TabConfig[]>(
@@ -416,14 +417,14 @@ function useTabs(input: Pick<TabsBarProps, 'user'>): TabConfig[] {
                         Icon: BookTextIcon,
                         changesView: true,
                     },
-                    {
+                    isMcpEnabled ? {
                         view: View.Settings,
                         title: 'Settings',
                         Icon: Settings2Icon,
                         changesView: true,
-                    },
+                    } : null,
                 ] as (TabConfig | null)[]
             ).filter(isDefined),
-        [IDE, extensionAPI]
+        [IDE, extensionAPI, isMcpEnabled]
     )
 }

--- a/vscode/webviews/tabs/TabsBar.tsx
+++ b/vscode/webviews/tabs/TabsBar.tsx
@@ -16,7 +16,7 @@ import {
 import { getVSCodeAPI } from '../utils/VSCodeApi'
 import { View } from './types'
 
-import { type AuthenticatedAuthStatus, CodyIDE, isDefined, FeatureFlag } from '@sourcegraph/cody-shared'
+import { type AuthenticatedAuthStatus, CodyIDE, FeatureFlag, isDefined } from '@sourcegraph/cody-shared'
 import { type FC, Fragment, forwardRef, memo, useCallback, useMemo, useState } from 'react'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../components/shadcn/ui/tooltip'
 import { useConfig } from '../utils/useConfig'
@@ -417,12 +417,14 @@ function useTabs(input: Pick<TabsBarProps, 'user'>): TabConfig[] {
                         Icon: BookTextIcon,
                         changesView: true,
                     },
-                    isMcpEnabled ? {
-                        view: View.Settings,
-                        title: 'Settings',
-                        Icon: Settings2Icon,
-                        changesView: true,
-                    } : null,
+                    isMcpEnabled
+                        ? {
+                              view: View.Settings,
+                              title: 'Settings',
+                              Icon: Settings2Icon,
+                              changesView: true,
+                          }
+                        : null,
                 ] as (TabConfig | null)[]
             ).filter(isDefined),
         [IDE, extensionAPI, isMcpEnabled]


### PR DESCRIPTION
CLOSING https://sourcegraph.slack.com/archives/C08DP4R5CG0/p1744059407418759
Put the settings tab behind the internal-only flag `next-agentic-chat-internal`. This flag is already used for MCP servers.

## Test plan
Toggle the feature flag on S2 and check that the setting is not there when the flag value is false.
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
