### PR TITLE
Fix flaky tests caused by too often refresh of siteVersion

### DIFF
--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -708,7 +708,7 @@ export class SourcegraphGraphQLAPIClient {
     private readonly siteVersionCache: GraphQLResultCache<string>
 
     public static withGlobalConfig(): SourcegraphGraphQLAPIClient {
-        return new SourcegraphGraphQLAPIClient(resolvedConfig)
+        return new SourcegraphGraphQLAPIClient(resolvedConfig.pipe(distinctUntilChanged()))
     }
 
     /**

--- a/lib/shared/src/sourcegraph-api/siteVersion.ts
+++ b/lib/shared/src/sourcegraph-api/siteVersion.ts
@@ -3,7 +3,7 @@ import semver from 'semver'
 import { authStatus } from '../auth/authStatus'
 import type { AuthStatus } from '../auth/types'
 import { logError } from '../logger'
-import { distinctUntilChanged, pick, promiseFactoryToObservable } from '../misc/observable'
+import { distinctUntilChanged, pick, promiseFactoryToObservable, retry } from '../misc/observable'
 import {
     firstResultFromOperation,
     pendingOperation,
@@ -59,29 +59,31 @@ export const siteVersion: Observable<SiteAndCodyAPIVersions | null | typeof pend
                 if (authStatus.pendingValidation) {
                     return Observable.of(pendingOperation)
                 }
-
                 if (!authStatus.authenticated) {
                     return Observable.of(null)
                 }
 
                 return promiseFactoryToObservable(signal => graphqlClient.getSiteVersion(signal)).pipe(
-                    map((siteVersion): SiteAndCodyAPIVersions | null => {
-                        if (isError(siteVersion)) {
-                            logError(
-                                'siteVersion',
-                                `Failed to get site version from ${authStatus.endpoint}: ${siteVersion}`
-                            )
-                            return null
-                        }
-                        return {
-                            siteVersion,
-                            codyAPIVersion: inferCodyApiVersion(siteVersion, isDotCom(authStatus)),
-                        }
+                    map((siteVersion): SiteAndCodyAPIVersions | Error => {
+                        return isError(siteVersion)
+                            ? siteVersion
+                            : {
+                                  siteVersion,
+                                  codyAPIVersion: inferCodyApiVersion(siteVersion, isDotCom(authStatus)),
+                              }
                     })
                 )
             }
         ),
-        map(result => (isError(result) ? null : result)) // the operation catches its own errors, so errors will never get here
+        retry(3),
+        map(siteVersion => {
+            if (isError(siteVersion)) {
+                logError('siteVersion', `Failed to get site version: ${siteVersion}`)
+                return null
+            }
+
+            return siteVersion
+        })
     )
 
 // Only emit when authenticated

--- a/vscode/test/integration/single-root/chat.test.ts
+++ b/vscode/test/integration/single-root/chat.test.ts
@@ -29,10 +29,7 @@ suite('Chat', function () {
     this.beforeEach(() => beforeIntegrationTest())
     this.afterEach(() => afterIntegrationTest())
 
-    // TODO: This test is flaky and occasionally throws an uncaught AbortError.
-    // Example failure: https://github.com/sourcegraph/cody/actions/runs/14273152078/job/40010754961#step:11:108
-    // Issue to fix: https://github.com/sourcegraph/cody/issues/7673
-    test.skip('sends and receives a message', async () => {
+    test('sends and receives a message', async () => {
         await vscode.commands.executeCommand('cody.chat.newEditorPanel')
         const chatView = await getChatViewProvider()
         await chatView.handleUserMessage({
@@ -49,11 +46,7 @@ suite('Chat', function () {
         )
     })
 
-    // TODO: This test is flaky and occasionally throws an uncaught AbortError.
-    // Example failure: https://github.com/sourcegraph/cody/actions/runs/14273152078/job/40010754961#step:11:108
-    // Issue to fix: https://github.com/sourcegraph/cody/issues/7673
-    // do not display filename even when there is a selection in active editor
-    test.skip('append current file link to display text on editor selection', async () => {
+    test('append current file link to display text on editor selection', async () => {
         await getTextEditorWithSelection()
         await vscode.commands.executeCommand('cody.chat.newEditorPanel')
         const chatView = await getChatViewProvider()


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/cody/issues/7673

## Test plan

Rerun a `test-integration (ubuntu)` few times - all reruns should be green.