### PR TITLE
chore(CI): Fix agent bindings

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/Chat_ModelsParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/Chat_ModelsParams.kt
@@ -2,6 +2,6 @@
 package com.sourcegraph.cody.agent.protocol_generated;
 
 data class Chat_ModelsParams(
-  val modelUsage: ModelUsage, // Oneof: chat, edit, autocomplete
+  val modelUsage: ModelUsage, // Oneof: chat, edit, autocomplete, unlimitedChat
 )
 

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/Constants.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/Constants.kt
@@ -139,6 +139,8 @@ object Constants {
   const val unauthenticated = "unauthenticated"
   const val unchanged = "unchanged"
   const val unified = "unified"
+  const val unlimited = "unlimited"
+  const val unlimitedChat = "unlimitedChat"
   const val use = "use"
   const val user = "user"
   const val vision = "vision"

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/Model.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/Model.kt
@@ -10,5 +10,6 @@ data class Model(
   val title: String,
   val tags: List<ModelTag>? = null,
   val modelRef: ModelRef? = null,
+  val disabled: Boolean? = null,
 )
 

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/ModelTag.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/ModelTag.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
 package com.sourcegraph.cody.agent.protocol_generated;
 
-typealias ModelTag = String // One of: power, speed, balanced, other, recommended, deprecated, experimental, waitlist, on-waitlist, early-access, internal, pro, free, enterprise, gateway, byok, local, ollama, dev, stream-disabled, vision, reasoning, tools, default
+typealias ModelTag = String // One of: power, speed, balanced, other, recommended, deprecated, experimental, waitlist, on-waitlist, early-access, internal, pro, free, enterprise, gateway, byok, local, ollama, dev, stream-disabled, vision, reasoning, tools, default, unlimited
 

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/ModelUsage.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/ModelUsage.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
 package com.sourcegraph.cody.agent.protocol_generated;
 
-typealias ModelUsage = String // One of: chat, edit, autocomplete
+typealias ModelUsage = String // One of: chat, edit, autocomplete, unlimitedChat
 


### PR DESCRIPTION
Fixes broken test caused by https://github.com/sourcegraph/cody/pull/7367

## Test plan

Green `agent-bindings` test on CI.

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
