### PR TITLE
Show Remote File & Directories Provider in the new Mentions Menu

### DIFF
--- a/lib/prompt-editor/src/v2/PromptEditor.tsx
+++ b/lib/prompt-editor/src/v2/PromptEditor.tsx
@@ -6,7 +6,6 @@ import {
     FILE_RANGE_TOOLTIP_LABEL,
     NO_SYMBOL_MATCHES_HELP_LABEL,
     REMOTE_DIRECTORY_PROVIDER_URI,
-    REMOTE_FILE_PROVIDER_URI,
     SYMBOL_CONTEXT_MENTION_PROVIDER,
     type SerializedContextItem,
     type SerializedPromptEditorState,
@@ -95,10 +94,6 @@ interface PromptEditorRefAPI {
 
 const SUGGESTION_LIST_LENGTH_LIMIT = 20
 
-// These providers are hidden from the UI but still needed for functionality
-// like remote file and directoryaccess
-const hiddenProviders = [REMOTE_FILE_PROVIDER_URI, REMOTE_DIRECTORY_PROVIDER_URI]
-
 /**
  * The component for composing and editing prompts.
  */
@@ -166,15 +161,9 @@ export const PromptEditor: FunctionComponent<Props> = ({
                         return items
                     }
 
-                    // Filter out any hidden context providers
-                    const providers = menuData.providers.filter(
-                        (provider: ContextMentionProviderMetadata) =>
-                            !hiddenProviders.includes(provider.id)
-                    )
-
                     // With a query, show only matching items
                     if (query) {
-                        return [...filteredInitialContextItems, ...providers, ...items]
+                        return [...filteredInitialContextItems, ...menuData.providers, ...items]
                     }
 
                     // Filter out any frequently used items that are already in filteredInitialContextItems
@@ -192,7 +181,7 @@ export const PromptEditor: FunctionComponent<Props> = ({
                     return [
                         ...filteredInitialContextItems,
                         ...uniqueFrequentlyUsedItems,
-                        ...providers,
+                        ...menuData.providers,
                         ...items,
                     ]
                 })


### PR DESCRIPTION
Show the remote directories and files provider in the Prose Mirror mentions menu. 

## Test plan

- make sure the flag is enabled for you here: https://sourcegraph.sourcegraph.com/site-admin/feature-flags/configuration/cody-experimental-prompt-editor
- Do @ in chat input and check if the remote files and remote directories are listed. 