### PR TITLE
fix(vscode): update release workflows to auth before integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,12 +145,14 @@ jobs:
         run: |
           $vscodeDir = "$env:USERPROFILE\.vscode"
           New-Item -ItemType Directory -Path $vscodeDir -Force | Out-Null
-          $json = @'
-          {
-            "disable-hardware-acceleration": true
-          }
-          '@
-          $json | Set-Content -Path "$vscodeDir\argv.json" -Encoding UTF8
+          
+          # Create JSON object and convert to string
+          $settings = @{ "disable-hardware-acceleration" = $true }
+          $json = ConvertTo-Json $settings -Compress
+          
+          # Write to file using Out-File with encoding parameter
+          $json | Out-File -FilePath "$vscodeDir\argv.json" -Encoding ascii -NoNewline
+          
           pnpm -C vscode run test:integration
       - name: Run tests (mac)
         run: |

--- a/.github/workflows/release-vscode-experimental.yml
+++ b/.github/workflows/release-vscode-experimental.yml
@@ -25,6 +25,15 @@ jobs:
           run_install: true
       - run: pnpm build
       - run: pnpm run test
+      # Auth for integration tests to send metrics to data team
+      - id: auth
+        uses: google-github-actions/auth@v2
+        # Skip auth if PR is from a fork
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        with:
+          workload_identity_provider: ${{ secrets.DATA_TEAM_PROVIDER_NAME }}
+          service_account: ${{ secrets.DATA_TEAM_SA_EMAIL }}
+      - uses: google-github-actions/setup-gcloud@v2
       - run: xvfb-run -a pnpm -C vscode run test:integration
       - run: xvfb-run -a pnpm -C vscode run test:e2e
         env:
@@ -39,8 +48,9 @@ jobs:
           echo "Webview Bundle Size: $WEBVIEW_BUNDLE_SIZE_MB MB"
         env:
           GITHUB_ENV: $GITHUB_ENV
-      - name: Authenticate to Google Cloud
-        id: auth
+      # This is for BigQuery data upload
+      - name: Authenticate to Google Cloud for BigQuery
+        id: bigquery_auth
         uses: "google-github-actions/auth@v2"
         with:
           project_id: "cody-core-dev"

--- a/.github/workflows/release-vscode-nightly.yml
+++ b/.github/workflows/release-vscode-nightly.yml
@@ -28,6 +28,15 @@ jobs:
           run_install: true
       - run: pnpm build
       - run: pnpm run test
+      # Auth for integration tests to send metrics to data team
+      - id: auth
+        uses: google-github-actions/auth@v2
+        # Skip auth if PR is from a fork
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        with:
+          workload_identity_provider: ${{ secrets.DATA_TEAM_PROVIDER_NAME }}
+          service_account: ${{ secrets.DATA_TEAM_SA_EMAIL }}
+      - uses: google-github-actions/setup-gcloud@v2
       - run: xvfb-run -a pnpm -C vscode run test:integration
       - run: xvfb-run -a pnpm -C vscode run test:e2e
         env:
@@ -42,8 +51,9 @@ jobs:
           echo "Webview Bundle Size: $WEBVIEW_BUNDLE_SIZE_MB MB"
         env:
           GITHUB_ENV: $GITHUB_ENV
-      - name: Authenticate to Google Cloud
-        id: auth
+      # This is for BigQuery data upload
+      - name: Authenticate to Google Cloud for BigQuery
+        id: bigquery_auth
         uses: "google-github-actions/auth@v2"
         with:
           project_id: "cody-core-dev"

--- a/.github/workflows/release-vscode-prerelease.yml
+++ b/.github/workflows/release-vscode-prerelease.yml
@@ -25,6 +25,15 @@ jobs:
           run_install: true
       - run: pnpm build
       - run: pnpm run test
+      # Auth for integration tests to send metrics to data team
+      - id: auth
+        uses: google-github-actions/auth@v2
+        # Skip auth if PR is from a fork
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        with:
+          workload_identity_provider: ${{ secrets.DATA_TEAM_PROVIDER_NAME }}
+          service_account: ${{ secrets.DATA_TEAM_SA_EMAIL }}
+      - uses: google-github-actions/setup-gcloud@v2
       - run: xvfb-run -a pnpm -C vscode run test:integration
       - run: xvfb-run -a pnpm -C vscode run test:e2e
         env:
@@ -39,8 +48,9 @@ jobs:
           echo "Webview Bundle Size: $WEBVIEW_BUNDLE_SIZE_MB MB"
         env:
           GITHUB_ENV: $GITHUB_ENV
-      - name: Authenticate to Google Cloud
-        id: auth
+      # This is for BigQuery data upload
+      - name: Authenticate to Google Cloud for BigQuery
+        id: bigquery_auth
         uses: "google-github-actions/auth@v2"
         with:
           project_id: "cody-core-dev"

--- a/.github/workflows/release-vscode-stable.yml
+++ b/.github/workflows/release-vscode-stable.yml
@@ -16,6 +16,7 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: write # for publishing the release
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
@@ -43,6 +44,15 @@ jobs:
           fi
       - run: pnpm build
       - run: pnpm run test
+      # Auth for integration tests to send metrics to data team
+      - id: auth
+        uses: google-github-actions/auth@v2
+        # Skip auth if PR is from a fork
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        with:
+          workload_identity_provider: ${{ secrets.DATA_TEAM_PROVIDER_NAME }}
+          service_account: ${{ secrets.DATA_TEAM_SA_EMAIL }}
+      - uses: google-github-actions/setup-gcloud@v2
       - run: xvfb-run -a pnpm -C vscode run test:integration
       - run: xvfb-run -a pnpm -C vscode run test:e2e
         env:


### PR DESCRIPTION
Integration steps need to auth with Data team creds since metrics gets sent during the test. So we auth before the step.

Closes DINF-923
## Test plan
CI
