### PR TITLE
chore(CI): Upload jetbrains artefact publishing reports

### DIFF
--- a/.github/workflows/release-jetbrains-experimental.yml
+++ b/.github/workflows/release-jetbrains-experimental.yml
@@ -42,3 +42,10 @@ jobs:
         env:
           PUBLISH_TOKEN: ${{ secrets.JETBRAINS_MARKETPLACE_PUBLISH_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.PRIVATE_SG_ACCESS_TOKEN }}
+      - name: Upload the report
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: publish-report
+          path: jetbrains/build/reports/problems/
+          compression-level: 9

--- a/.github/workflows/release-jetbrains-prerelease.yml
+++ b/.github/workflows/release-jetbrains-prerelease.yml
@@ -41,3 +41,10 @@ jobs:
         env:
           PUBLISH_TOKEN: ${{ secrets.JETBRAINS_MARKETPLACE_PUBLISH_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.PRIVATE_SG_ACCESS_TOKEN }}
+      - name: Upload the report
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: publish-report
+          path: jetbrains/build/reports/problems/
+          compression-level: 9

--- a/.github/workflows/release-jetbrains-stable.yml
+++ b/.github/workflows/release-jetbrains-stable.yml
@@ -37,3 +37,10 @@ jobs:
         env:
           PUBLISH_TOKEN: ${{ secrets.JETBRAINS_MARKETPLACE_PUBLISH_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.PRIVATE_SG_ACCESS_TOKEN }}
+      - name: Upload the report
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: publish-report
+          path: jetbrains/build/reports/problems/
+          compression-level: 9


### PR DESCRIPTION
## Changes

This PR should allow us to upload jetbrains publish artefact report in case of publishing failure.
Without it we barely have any visibility to the reasons of the failure.

## Test plan

N/A