### PR TITLE
[JetBrains] Collecting context information when JavaToJSBridge.query is null.

### DIFF
--- a/jetbrains/src/main/java/com/sourcegraph/find/FindService.java
+++ b/jetbrains/src/main/java/com/sourcegraph/find/FindService.java
@@ -46,9 +46,7 @@ public class FindService implements Disposable {
     if (popup != null && popup.isVisible()) {
       JavaToJSBridge javaToJSBridge = mainPanel.getJavaToJSBridge();
       if (javaToJSBridge != null) {
-        mainPanel
-            .getJavaToJSBridge()
-            .callJS("pluginSettingsChanged", ConfigUtil.getConfigAsJson(project));
+        javaToJSBridge.callJS("pluginSettingsChanged", ConfigUtil.getConfigAsJson(project));
       }
     }
   }


### PR DESCRIPTION
Continuation of #7651. `IllegalStateException - JS query has been disposed` is still showing in the version  [7.82.0](https://sourcegraph.sentry.io/issues/6372518034/events/?query=release%3A%22cody-jb%407.82.0%22)

Sending `action` parameter to Sentry to see in which context `JavaToJSBridge.query` is null and `callJS()` is called.

## Test plan

Monitor [sentry issue](https://sourcegraph.sentry.io/issues/6372518034/?project=4508886063644672)
