### PR TITLE
Change 'auto-edit (Beta)' to 'auto-edit'

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/Constants.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/Constants.kt
@@ -19,7 +19,7 @@ object Constants {
   const val ask = "ask"
   const val assistant = "assistant"
   const val authenticated = "authenticated"
-  const val `auto-edit-Beta` = "auto-edit (Beta)"
+  const val `auto-edit` = "auto-edit"
   const val autocomplete = "autocomplete"
   const val balanced = "balanced"
   const val byok = "byok"

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/ExtensionConfiguration.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/ExtensionConfiguration.kt
@@ -11,7 +11,7 @@ data class ExtensionConfiguration(
   val anonymousUserID: String? = null,
   val autocompleteAdvancedProvider: String? = null,
   val autocompleteAdvancedModel: String? = null,
-  val suggestionsMode: SuggestionsModeEnum? = null, // Oneof: autocomplete, auto-edit (Beta), off
+  val suggestionsMode: SuggestionsModeEnum? = null, // Oneof: autocomplete, auto-edit, off
   val debug: Boolean? = null,
   val verboseDebug: Boolean? = null,
   val telemetryClientName: String? = null,
@@ -23,7 +23,7 @@ data class ExtensionConfiguration(
 
   enum class SuggestionsModeEnum {
     @SerializedName("autocomplete") Autocomplete,
-    @SerializedName("auto-edit (Beta)") `Auto-edit-Beta`,
+    @SerializedName("auto-edit") `Auto-edit`,
     @SerializedName("off") Off,
   }
 }

--- a/jetbrains/src/integrationTest/kotlin/com/sourcegraph/cody/autocomplete/AutocompleteEditTest.kt
+++ b/jetbrains/src/integrationTest/kotlin/com/sourcegraph/cody/autocomplete/AutocompleteEditTest.kt
@@ -21,7 +21,7 @@ class AutocompleteEditTest : BaseAutocompleteTest() {
   companion object {
     private val codySettingsContent =
         """{
-          |  "cody.suggestions.mode": "auto-edit (Beta)"
+          |  "cody.suggestions.mode": "auto-edit"
           |}
           |"""
             .trimMargin()

--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -239,7 +239,7 @@ export enum CodyAutoSuggestionMode {
     /**
      * The suggestion mode where suggestions come from the Cody AI agent chat API.
      */
-    Autoedit = 'auto-edit (Beta)',
+    Autoedit = 'auto-edit',
     /**
      * Disable Cody suggestions altogether.
      */

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -595,7 +595,7 @@
       {
         "command": "cody.command.autoedit-manual-trigger",
         "title": "Autoedits Manual Trigger",
-        "enablement": "cody.activated && config.cody.suggestions.mode == 'auto-edit (Beta)'"
+        "enablement": "cody.activated && config.cody.suggestions.mode == 'auto-edit'"
       },
       {
         "command": "cody.command.autoedit.open-debug-panel",
@@ -720,7 +720,7 @@
       {
         "command": "cody.supersuggest.testExample",
         "key": "ctrl+alt+enter",
-        "when": "cody.activated && config.cody.suggestions.mode == 'auto-edit (Beta)'"
+        "when": "cody.activated && config.cody.suggestions.mode == 'auto-edit'"
       }
     ],
     "submenus": [
@@ -963,7 +963,7 @@
         },
         "cody.suggestions.mode": {
           "type": "string",
-          "enum": ["autocomplete", "auto-edit (Beta)", "off"],
+          "enum": ["autocomplete", "auto-edit", "off"],
           "enumDescriptions": [
             "Suggests standard code completions as you type.",
             "Suggests advanced context-aware code edits as you navigate the codebase. Experimental feature for Pro and Enterprise users.",

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -56,7 +56,10 @@ export function getConfiguration(
     // If auto-edit was turned on - override the suggestion mode to "auto-edit".
     // TODO: clean up after the beta release
     // https://linear.app/sourcegraph/issue/CODY-4701/clean-up-backwards-compatbility-settings-after-the-release
-    if (codyAutoSuggestionsMode === 'auto-edit (Experimental)') {
+    if (
+        codyAutoSuggestionsMode === 'auto-edit (Experimental)' ||
+        codyAutoSuggestionsMode === 'auto-edit (Beta)'
+    ) {
         codyAutoSuggestionsMode = CodyAutoSuggestionMode.Autoedit
 
         void vscode.workspace

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -647,7 +647,7 @@ export interface ExtensionConfiguration {
 
     autocompleteAdvancedProvider?: string | undefined | null
     autocompleteAdvancedModel?: string | undefined | null
-    suggestionsMode?: 'autocomplete' | 'auto-edit (Beta)' | 'off' | undefined | null
+    suggestionsMode?: 'autocomplete' | 'auto-edit' | 'off' | undefined | null
     debug?: boolean | undefined | null
     verboseDebug?: boolean | undefined | null
     telemetryClientName?: string | undefined | null

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -781,7 +781,7 @@ interface StatusBarLoader {
 
 enum CodyStatusBarSuggestionModeLabels {
     Autocomplete = 'Autocomplete',
-    AutoEdit = 'Auto-edit (Beta)',
+    AutoEdit = 'Auto-edit',
     Disabled = 'Disabled',
 }
 


### PR DESCRIPTION
Reflecting that Auto-Edits are a beta feature in the setting value feels redundant and could potentially cause issues from a marketing perspective. Let's remove it.

## Test plan
- ci

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
