### PR TITLE
fix(chat): Add intent persistence for prompt templates (CODY-5608)

### DIFF
--- a/lib/shared/src/models/sync.ts
+++ b/lib/shared/src/models/sync.ts
@@ -192,7 +192,8 @@ export function syncModels({
                                         ),
                                         enableToolCody,
                                         featureFlagProvider.evaluateFeatureFlag(
-                                            FeatureFlag.EnhancedContextWindow
+                                            FeatureFlag.EnhancedContextWindow,
+                                            true
                                         ),
                                         featureFlagProvider.evaluateFeatureFlag(
                                             FeatureFlag.FallbackToFlash

--- a/vscode/webviews/chat/ChatContext.tsx
+++ b/vscode/webviews/chat/ChatContext.tsx
@@ -1,0 +1,35 @@
+/**
+ * ChatContext.tsx
+ *
+ * This file provides a global React context for managing chat state across components,
+ * particularly for handling prompt templates and intent persistence.
+ *
+ * The context addresses a key challenge: when users select a prompt template,
+ * we need to:
+ * 1. Save their current chat intent
+ * 2. Track that they're using a prompt
+ * 3. Restore their original intent after the prompt is submitted
+ *
+ * This context provides a reliable way to access these state values throughout
+ * the component tree without passing props through every component.
+ */
+import type { ChatMessage } from '@sourcegraph/cody-shared'
+import { createContext, useContext } from 'react'
+
+interface ChatContextType {
+    isPromptInput: boolean | undefined
+    setIsPromptInput: (value: boolean) => void
+
+    /** The intent that was active before a prompt template was selected */
+    savedIntentBeforePrompt: ChatMessage['intent']
+    setSavedIntentBeforePrompt: (intent: ChatMessage['intent']) => void
+}
+
+export const ChatContext = createContext<ChatContextType>({
+    isPromptInput: false,
+    setIsPromptInput: () => {},
+    savedIntentBeforePrompt: 'chat',
+    setSavedIntentBeforePrompt: () => {},
+})
+
+export const useChatContext = () => useContext(ChatContext)

--- a/vscode/webviews/chat/Transcript.story.tsx
+++ b/vscode/webviews/chat/Transcript.story.tsx
@@ -46,6 +46,11 @@ const meta: Meta<typeof Transcript> = {
         manuallySelectedIntent: null,
         setManuallySelectedIntent: () => {},
         guardrails: new MockNoGuardrails(),
+        savedIntentBeforePrompt: null,
+        setSavedIntentBeforePrompt: () => {},
+        isPromptInput: false,
+        setIsPromptInput: () => {},
+        determineIntent: () => null,
     } satisfies ComponentProps<typeof Transcript>,
 
     decorators: [

--- a/vscode/webviews/chat/Transcript.test.tsx
+++ b/vscode/webviews/chat/Transcript.test.tsx
@@ -20,6 +20,11 @@ const PROPS: Omit<ComponentProps<typeof Transcript>, 'transcript'> = {
     manuallySelectedIntent: undefined,
     setManuallySelectedIntent: () => {},
     guardrails: new MockNoGuardrails(),
+    savedIntentBeforePrompt: undefined,
+    setSavedIntentBeforePrompt: () => {},
+    isPromptInput: false,
+    setIsPromptInput: () => {},
+    determineIntent: () => null,
 }
 
 vi.mock('../utils/VSCodeApi', () => ({

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -303,9 +303,6 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
         editorRef: parentEditorRef,
         manuallySelectedIntent,
         setManuallySelectedIntent,
-        savedIntentBeforePrompt,
-        setSavedIntentBeforePrompt,
-        isPromptInput,
         setIsPromptInput,
         determineIntent,
     } = props
@@ -376,8 +373,8 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
                     manuallySelectedIntent: resolvedIntent,
                 })
             }
-            if (props.setIsPromptInput) {
-                props.setIsPromptInput(false)
+            if (setIsPromptInput) {
+                setIsPromptInput(false)
             }
         },
         [
@@ -386,11 +383,8 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
             isLastSentInteraction,
             lastEditorRef,
             manuallySelectedIntent,
-            savedIntentBeforePrompt,
-            setSavedIntentBeforePrompt,
-            isPromptInput,
-            setIsPromptInput,
             determineIntent,
+            setIsPromptInput,
         ]
     )
 

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -67,6 +67,11 @@ interface TranscriptProps {
 
     manuallySelectedIntent: ChatMessage['intent']
     setManuallySelectedIntent: (intent: ChatMessage['intent']) => void
+    savedIntentBeforePrompt: ChatMessage['intent']
+    setSavedIntentBeforePrompt: (intent: ChatMessage['intent']) => void
+    isPromptInput: boolean | undefined
+    setIsPromptInput: (isPromptInput: boolean) => void
+    determineIntent: (proposedIntent?: ChatMessage['intent']) => ChatMessage['intent']
 }
 
 export const Transcript: FC<TranscriptProps> = props => {
@@ -85,6 +90,11 @@ export const Transcript: FC<TranscriptProps> = props => {
         smartApply,
         manuallySelectedIntent,
         setManuallySelectedIntent,
+        savedIntentBeforePrompt,
+        setSavedIntentBeforePrompt,
+        isPromptInput,
+        setIsPromptInput,
+        determineIntent,
     } = props
 
     const interactions = useMemo(
@@ -164,6 +174,11 @@ export const Transcript: FC<TranscriptProps> = props => {
                         onAddToFollowupChat={onAddToFollowupChat}
                         manuallySelectedIntent={manuallySelectedIntent}
                         setManuallySelectedIntent={setManuallySelectedIntent}
+                        savedIntentBeforePrompt={savedIntentBeforePrompt}
+                        setSavedIntentBeforePrompt={setSavedIntentBeforePrompt}
+                        isPromptInput={isPromptInput}
+                        setIsPromptInput={setIsPromptInput}
+                        determineIntent={determineIntent}
                     />
                 ))}
             </LastEditorContext.Provider>
@@ -262,6 +277,12 @@ interface TranscriptInteractionProps
     }) => void
     manuallySelectedIntent: ChatMessage['intent']
     setManuallySelectedIntent: (intent: ChatMessage['intent']) => void
+
+    savedIntentBeforePrompt: ChatMessage['intent']
+    setSavedIntentBeforePrompt: (intent: ChatMessage['intent']) => void
+    isPromptInput: boolean | undefined
+    setIsPromptInput: (isPromptInput: boolean) => void
+    determineIntent: (proposedIntent?: ChatMessage['intent']) => ChatMessage['intent']
 }
 
 const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
@@ -282,6 +303,11 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
         editorRef: parentEditorRef,
         manuallySelectedIntent,
         setManuallySelectedIntent,
+        savedIntentBeforePrompt,
+        setSavedIntentBeforePrompt,
+        isPromptInput,
+        setIsPromptInput,
+        determineIntent,
     } = props
 
     const { activeChatContext, setActiveChatContext } = props
@@ -326,6 +352,8 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
                 traceparent,
             }
 
+            const resolvedIntent = determineIntent(manuallySelectedIntent)
+
             if (action === 'edit') {
                 // Remove search context chips from the next input so that the user cannot
                 // reference search results that don't exist anymore.
@@ -340,13 +368,16 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
                 editHumanMessage({
                     messageIndexInTranscript: humanMessage.index,
                     ...commonProps,
-                    manuallySelectedIntent: manuallySelectedIntent,
+                    manuallySelectedIntent: resolvedIntent,
                 })
             } else {
                 submitHumanMessage({
                     ...commonProps,
-                    manuallySelectedIntent: manuallySelectedIntent,
+                    manuallySelectedIntent: resolvedIntent,
                 })
+            }
+            if (props.setIsPromptInput) {
+                props.setIsPromptInput(false)
             }
         },
         [
@@ -355,6 +386,11 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
             isLastSentInteraction,
             lastEditorRef,
             manuallySelectedIntent,
+            savedIntentBeforePrompt,
+            setSavedIntentBeforePrompt,
+            isPromptInput,
+            setIsPromptInput,
+            determineIntent,
         ]
     )
 


### PR DESCRIPTION
Bugfix: https://linear.app/sourcegraph/issue/CODY-5608/cody-mode-doesnt-reset-when-a-prompt-is-selected
  - Implements intent persistence for prompt templates in chat UI
  - Creates a global context system for prompt state management
  - Fixes issue where intent could be undefined after using a prompt

  ## Test plan
  1. Open Cody chat
  2. Set an intent 
  3. Use a prompt template and verify it works correctly
  4. Submit a message and verify the original intent is restored
  5. Test with different combinations of intents and prompts

Loom:https://www.loom.com/share/fdfd0ca339554087884d6b412e071de9
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
