### PR TITLE
Fix search results not getting mentioned in follow up chat

### DIFF
--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -1,10 +1,8 @@
 import {
     type ChatMessage,
-    ContextItemSource,
     type Guardrails,
     type Model,
     type NLSSearchDynamicFilter,
-    REMOTE_FILE_PROVIDER_URI,
     type SerializedPromptEditorValue,
     deserializeContextItem,
     isAbortErrorOrSocketHangUp,
@@ -24,7 +22,6 @@ import {
     useRef,
     useState,
 } from 'react'
-import { URI } from 'vscode-uri'
 import type { UserAccountInfo } from '../Chat'
 import type { ApiPostMessage } from '../Chat'
 import { getVSCodeAPI } from '../utils/VSCodeApi'
@@ -94,39 +91,6 @@ export const Transcript: FC<TranscriptProps> = props => {
 
     const lastHumanEditorRef = useRef<PromptEditorRefAPI | null>(null)
 
-    const onAddToFollowupChat = useCallback(
-        ({
-            repoName,
-            filePath,
-            fileURL,
-        }: {
-            repoName: string
-            filePath: string
-            fileURL: string
-        }) => {
-            lastHumanEditorRef.current?.addMentions([
-                {
-                    providerUri: REMOTE_FILE_PROVIDER_URI,
-                    provider: 'openctx',
-                    type: 'openctx',
-                    uri: URI.parse(fileURL),
-                    title: filePath.split('/').at(-1) ?? filePath,
-                    description: filePath,
-                    source: ContextItemSource.User,
-                    mention: {
-                        uri: fileURL,
-                        description: filePath,
-                        data: {
-                            repoName,
-                            filePath: filePath,
-                        },
-                    },
-                },
-            ])
-        },
-        []
-    )
-
     return (
         <div
             className={clsx(' tw-px-8 tw-py-4 tw-flex tw-flex-col tw-gap-4', {
@@ -157,11 +121,13 @@ export const Transcript: FC<TranscriptProps> = props => {
                         )}
                         smartApply={smartApply}
                         editorRef={
-                            interaction.humanMessage.index === -1 && !messageInProgress
+                            ((interaction.humanMessage.intent === 'agentic' &&
+                                interaction.humanMessage.index === -1) ||
+                                i === interactions.length - 1) &&
+                            !messageInProgress
                                 ? lastHumanEditorRef
                                 : undefined
                         }
-                        onAddToFollowupChat={onAddToFollowupChat}
                         manuallySelectedIntent={manuallySelectedIntent}
                         setManuallySelectedIntent={setManuallySelectedIntent}
                     />
@@ -255,11 +221,6 @@ interface TranscriptInteractionProps
     isLastSentInteraction: boolean
     priorAssistantMessageIsLoading: boolean
     editorRef?: React.RefObject<PromptEditorRefAPI | null>
-    onAddToFollowupChat?: (props: {
-        repoName: string
-        filePath: string
-        fileURL: string
-    }) => void
     manuallySelectedIntent: ChatMessage['intent']
     setManuallySelectedIntent: (intent: ChatMessage['intent']) => void
 }


### PR DESCRIPTION
closes: https://linear.app/sourcegraph/issue/CODY-5680/on-non-pro-non-free-plan-vs-code-latest-pre-release-after-triggering-a

In search mode, once we get the results, we add a results mention chip to the last editor ref. 

As part of https://github.com/sourcegraph/cody/pull/7550/files, the condition to pass the lastEditorRef to the last TranscriptInteraction was changed and made agent mode specific. But that logic doesn't work for the other modes and hence broke the search mode. 

This PR fix that logic so that the last editor ref is not always null. This PR also removes `onAddToFollowupChat` which is no longer used now. 

## Test plan

- make an interaction using search mode
- it should add a search results mention chip in the follow up chat
- selecting/deselecting the search results using the checkbox should update the mention chip 

<img width="822" alt="image" src="https://github.com/user-attachments/assets/d2f888a4-0d1e-4b38-968a-9af6666f0b10" />

