### PR TITLE
chore(core): Fix unhandled AbortError errors 

### DIFF
--- a/lib/shared/src/sourcegraph-api/graphql/cache.test.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/cache.test.ts
@@ -50,7 +50,7 @@ describe('Cache abort behavior', () => {
         cache.invalidate()
         expect(fetchCount).toBe(1) // Call happened immediately
         // This depends on the fetch implementation using the abort signal...
-        await expect(promise).rejects.toThrow('aborted')
+        expect(await promise).toStrictEqual(new AbortError('aborted'))
     })
 
     test('fetching is aborted if all request abort', async () => {
@@ -85,8 +85,8 @@ describe('Cache abort behavior', () => {
         controller1.abort()
         controller2.abort()
 
-        await expect(promise1).rejects.toThrow('aborted')
-        await expect(promise2).rejects.toThrow('aborted')
+        expect(await promise1).toStrictEqual(new AbortError('aborted'))
+        expect(await promise2).toStrictEqual(new AbortError('aborted'))
     })
 
     test('fetching continues unless all fetchers abort', async () => {

--- a/lib/shared/src/sourcegraph-api/graphql/cache.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/cache.ts
@@ -207,7 +207,10 @@ export class GraphQLResultCache<V> {
 
         this.fetchTimeMsec = now
 
-        const thisFetch = fetcher(this.aborts.signal)
+        const thisFetch = fetcher(this.aborts.signal).catch(error => {
+            return error instanceof Error ? error : new Error(String(error))
+        })
+
         void (async () => {
             try {
                 const result = await thisFetch

--- a/vscode/test/integration/single-root/chat.test.ts
+++ b/vscode/test/integration/single-root/chat.test.ts
@@ -29,7 +29,7 @@ suite('Chat', function () {
     this.beforeEach(() => beforeIntegrationTest())
     this.afterEach(() => afterIntegrationTest())
 
-    test.skip('sends and receives a message', async () => {
+    test('sends and receives a message', async () => {
         await vscode.commands.executeCommand('cody.chat.newEditorPanel')
         const chatView = await getChatViewProvider()
         await chatView.handleUserMessage({
@@ -46,7 +46,7 @@ suite('Chat', function () {
         )
     })
 
-    test.skip('append current file link to display text on editor selection', async () => {
+    test('append current file link to display text on editor selection', async () => {
         await getTextEditorWithSelection()
         await vscode.commands.executeCommand('cody.chat.newEditorPanel')
         const chatView = await getChatViewProvider()


### PR DESCRIPTION
## Changes

`GraphQLResultCache::get` is used by `getSiteVersion`, and it by turn is user t create an observable.
Code ran in observables cannot throw exceptions.
Signature of the `get` was suggesting it returns `Errors` by value instead of throwing them, but both options were possible.
Error handling which I aeed makes sure errors are always retuned by value.

## Test plan

1. Run `pnpm -C vscode run test:integration` few times locally.
2. You should see no `AbortError` errors.

It was reproducing better on M84 for me, but on main error is still visible in the log although it does not crash the test.
With this PR error is totally gone, and on M84 tests is not crashing anymore.

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
