### PR TITLE
Fix secret storage test implementation and reenable unauthed tests

### DIFF
--- a/.config/viteShared.ts
+++ b/.config/viteShared.ts
@@ -33,7 +33,8 @@ const defaultUserConfig: UserConfig = { logLevel: 'warn' }
 
 export function defineProjectWithDefaults(
     dir: string,
-    config: UserWorkspaceConfig
+    config: UserWorkspaceConfig,
+    additionalConfig: Record<string, any> = {}
 ): UserWorkspaceConfig {
     const name = basename(dir)
     if (!config.test) {
@@ -44,7 +45,7 @@ export function defineProjectWithDefaults(
     }
 
     return mergeConfig(
-        mergeConfig(defaultProjectConfig, defaultUserConfig),
+        mergeConfig(mergeConfig(defaultProjectConfig, defaultUserConfig), additionalConfig),
         defineProject(config) as UserWorkspaceConfig
     )
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
           - runner: ubuntu
             node: 18 # VS Code started using Node 18 in Aug 2023 in v1.82: https://code.visualstudio.com/updates/v1_82#_engineering
     runs-on: ${{ matrix.runner }}-latest
-    timeout-minutes: 10
+    timeout-minutes: 12
     permissions:
       id-token: write
       contents: read
@@ -145,14 +145,14 @@ jobs:
         run: |
           $vscodeDir = "$env:USERPROFILE\.vscode"
           New-Item -ItemType Directory -Path $vscodeDir -Force | Out-Null
-          
+
           # Create JSON object and convert to string
           $settings = @{ "disable-hardware-acceleration" = $true }
           $json = ConvertTo-Json $settings -Compress
-          
+
           # Write to file using Out-File with encoding parameter
           $json | Out-File -FilePath "$vscodeDir\argv.json" -Encoding ascii -NoNewline
-          
+
           pnpm -C vscode run test:integration
       - name: Run tests (mac)
         run: |

--- a/agent/recordings/defaultClient_631904893/recording.har.yaml
+++ b/agent/recordings/defaultClient_631904893/recording.har.yaml
@@ -2119,11 +2119,11 @@ log:
         send: 0
         ssl: -1
         wait: 801
-    - _id: 5a9352d17ae3c0541b7d607b6eec5bc5
+    - _id: 16e5bc1c8e22aaed9695f5b3c6df5883
       _order: 0
       cache: {}
       request:
-        bodySize: 2028
+        bodySize: 2056
         cookies: []
         headers:
           - name: accept-encoding
@@ -2135,15 +2135,13 @@ log:
             value: keep-alive
           - name: content-type
             value: application/json
-          - name: traceparent
-            value: 00-60f3b6122020e10bba0419f5ac56d26c-dbb309a1ee23dcf8-01
           - name: user-agent
             value: defaultclient/v1 (Node.js v20.4.0)
           - name: x-requested-with
             value: defaultclient v1
           - name: host
             value: sourcegraph.com
-        headersSize: 535
+        headersSize: 465
         httpVersion: HTTP/1.1
         method: POST
         postData:
@@ -2152,7 +2150,7 @@ log:
           textJSON:
             maxTokensToSample: 4000
             messages:
-              - speaker: system
+              - speaker: human
                 text: >-
                   You are Cody, an AI coding assistant from Sourcegraph.If your
                   answer contains fenced code blocks in Markdown, include the
@@ -2160,6 +2158,8 @@ log:
                   structure: ```$LANGUAGE:$FILEPATH```
 
                   For executable terminal commands: enclose each command in individual "bash" language code block without comments and new lines inside.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
                 text: >
                   Codebase context from file path src/animal.ts: /*
@@ -2189,14 +2189,11 @@ log:
                 text: Ok.
               - speaker: human
                 text: >-
-                  Answer positively without apologizing. 
-
-
                   You have access to the provided codebase context.
 
 
                   Question: Explain what @src/animal.ts:1-6 ( @src/animal.ts ) does in simple terms. Assume the audience is a beginner programmer who has just learned the language features and basic syntax. Focus on explaining: 1) The purpose of the code 2) What input(s) it takes 3) What output(s) it produces 4) How it achieves its purpose through the logic and algorithm. 5) Any important logic flows or data transformations happening. Use simple language a beginner could understand. Include enough detail to give a full picture of what the code aims to accomplish without getting too technical. Format the explanation in coherent paragraphs, using proper punctuation and grammar. Write the explanation assuming no prior context about the code is known. Do not make assumptions about variables or functions not shown in the shared code. Start the answer with the name of the code that is being explained.
-            model: anthropic::2024-10-22::claude-3-5-sonnet-latest
+            model: mistral::v1::mixtral-8x7b-instruct
             temperature: 0
             topK: -1
             topP: -1
@@ -2209,14 +2206,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=8&client-name=defaultclient&client-version=v1
       response:
-        bodySize: 3023
+        bodySize: 2706
         content:
           mimeType: text/event-stream
-          size: 3023
+          size: 2706
           text: >+
             event: completion
 
-            data: {"deltaText":"The Animal Interface (src/animal.ts)\n\nThis code defines a blueprint called `Animal` that acts as a template for creating different types of animals in the program. It's like a contract that says \"any animal we create must have these specific characteristics and behaviors.\"\n\nThe interface specifies three required properties that any animal must have:\n1. A `name` property that holds the animal's name as text (string)\n2. A `makeAnimalSound()` method that, when called, will return a string representing the sound the animal makes (like \"meow\" or \"woof\")\n3. An `isMammal` property that is either true or false (boolean), indicating whether the animal is a mammal or not\n\nThis interface doesn't contain any actual implementation - it's just a template. When someone wants to create a specific animal (like a cat or dog), they would need to create a new class that \"implements\" this Animal interface and provides actual values and code for all three of these requirements.\n\nFor example, if someone wanted to create a Cat class using this interface, they would need to:\n- Give it a name property\n- Write code for the makeAnimalSound() method that returns \"meow\"\n- Set isMammal to true\n\nThe purpose of this interface is to ensure consistency across different types of animals in the program and make sure they all have the same basic structure. It's like creating a standardized form that all animals must fill out to be part of the system.","stopReason":"end_turn"}
+            data: {"deltaText":"The code is an interface named \"Animal\" written in TypeScript. An interface in TypeScript is a blueprint for an object, defining what an object should look like. An interface like this one in the code defines the structure for an animal object.\n\nThe \"Animal\" interface has three properties:\n\n1. \"name\" of type string,\n2. \"makeAnimalSound\" of type function that returns a string,\n3. \"isMammal\" of type boolean.\n\nThis code does not actually do anything; it defines the shape of an animal object. It is used to ensure that any object that is claimed to be of type \"Animal\" has the required properties.\n\nFor example, if another piece of code creates an object called \"myAnimal\" and claims it is of type \"Animal\", this code will ensure that myAnimal has the required properties of name, makeAnimalSound, and isMammal.\n\nTo sum up, this code is an interface named \"Animal\" that defines the structure of an animal object, including a name, a function to make an animal sound, and a boolean to indicate whether the animal is a mammal. It is used as a blueprint to ensure that any object that is claimed to be of type \"Animal\" has the required properties."}
 
 
             event: done
@@ -2226,7 +2223,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 09 Apr 2025 14:17:03 GMT
+            value: Mon, 14 Apr 2025 15:26:45 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -2255,8 +2252,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-04-09T14:16:57.327Z
-      time: 11930
+      startedDateTime: 2025-04-14T15:26:42.217Z
+      time: 4427
       timings:
         blocked: -1
         connect: -1
@@ -2264,12 +2261,12 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 11930
-    - _id: 4ecea904afe1ba00e7ad78bd06e19a3c
+        wait: 4427
+    - _id: 6ab1509e468689cc2d8c1b8dbedf4adc
       _order: 0
       cache: {}
       request:
-        bodySize: 1824
+        bodySize: 1852
         cookies: []
         headers:
           - name: accept-encoding
@@ -2281,15 +2278,13 @@ log:
             value: keep-alive
           - name: content-type
             value: application/json
-          - name: traceparent
-            value: 00-e9468437babc3639f95f1f55293842d5-c1fe728c78d33476-01
           - name: user-agent
             value: defaultclient/v1 (Node.js v20.4.0)
           - name: x-requested-with
             value: defaultclient v1
           - name: host
             value: sourcegraph.com
-        headersSize: 535
+        headersSize: 465
         httpVersion: HTTP/1.1
         method: POST
         postData:
@@ -2298,7 +2293,7 @@ log:
           textJSON:
             maxTokensToSample: 4000
             messages:
-              - speaker: system
+              - speaker: human
                 text: >-
                   You are Cody, an AI coding assistant from Sourcegraph.If your
                   answer contains fenced code blocks in Markdown, include the
@@ -2306,6 +2301,8 @@ log:
                   structure: ```$LANGUAGE:$FILEPATH```
 
                   For executable terminal commands: enclose each command in individual "bash" language code block without comments and new lines inside.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
                 text: >
                   Codebase context from file path src/animal.ts: /*
@@ -2335,14 +2332,11 @@ log:
                 text: Ok.
               - speaker: human
                 text: >-
-                  Answer positively without apologizing. 
-
-
                   You have access to the provided codebase context.
 
 
                   Question: Please review and analyze @src/animal.ts:1-6 ( @src/animal.ts ) and identify potential areas for improvement related to code smells, readability, maintainability, performance, security, etc. Do not list issues already addressed in the given code. Focus on providing up to 5 constructive suggestions that could make the code more robust, efficient, or align with best practices. For each suggestion, provide a brief explanation of the potential benefits. After listing any recommendations, summarize if you found notable opportunities to enhance the code quality overall or if the code generally follows sound design principles. If no issues found, reply 'There are no errors.'
-            model: anthropic::2024-10-22::claude-3-5-sonnet-latest
+            model: mistral::v1::mixtral-8x7b-instruct
             temperature: 0
             topK: -1
             topP: -1
@@ -2355,14 +2349,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=8&client-name=defaultclient&client-version=v1
       response:
-        bodySize: 3146
+        bodySize: 6535
         content:
           mimeType: text/event-stream
-          size: 3146
+          size: 6535
           text: >+
             event: completion
 
-            data: {"deltaText":"Here are 4 constructive suggestions to enhance the Animal interface:\n\n1. Add JSDoc documentation above the interface to describe its purpose and requirements. This would improve code maintainability and help other developers understand how to properly implement the interface:\n\n```typescript:src/animal.ts\n/**\n * Represents a generic animal with basic properties and behaviors\n */\nexport interface Animal {\n```\n\n2. Consider adding readonly modifier to name property since it's likely an immutable characteristic. This provides better type safety and communicates intent:\n\n```typescript:src/animal.ts\nexport interface Animal {\n    readonly name: string\n```\n\n3. Add optional age property since it's a common animal attribute that implementing classes may want to track:\n\n```typescript:src/animal.ts\nexport interface Animal {\n    name: string\n    age?: number\n```\n\n4. Consider splitting makeAnimalSound() into a separate behavior interface (ISoundMaker) to follow Interface Segregation Principle. This allows for more flexible composition of animal behaviors:\n\n```typescript:src/animal.ts\nexport interface ISoundMaker {\n    makeAnimalSound(): string\n}\n\nexport interface Animal extends ISoundMaker {\n```\n\nSummary: While the current interface provides a good basic structure, there are opportunities to improve type safety, documentation, and modularity. The suggestions aim to make the code more maintainable and aligned with SOLID principles while maintaining its simplicity. The existing code follows sound design principles by keeping the interface focused and using clear naming conventions.","stopReason":"end_turn"}
+            data: {"deltaText":"Based on the provided code, I've identified some potential areas for improvement. Here are my recommendations:\n\n1. Add docstrings for better code readability and self-documentation.\n\nBenefit: Providing short explanations for the interface properties and methods will make it easier for any developer who encounters this code to understand its purpose and functionality.\n\n```ts\n/**\n * Animal interface\n */\nexport interface Animal {\n  /**\n   * The animal's name\n   */\n  name: string\n\n  /**\n   * The animal's sound\n   */\n  makeAnimalSound(): string\n\n  /**\n   * A boolean to indicate whether the animal is a mammal\n   */\n  isMammal: boolean\n}\n```\n\n2. Make the method `makeAnimalSound()` abstract, as it should be implemented by inheriting classes.\n\nBenefit: Defining this method as abstract will enforce concrete implementations in derived classes, ensuring proper customization and emphasizing their responsibilities.\n\n```ts\n/**\n * Animal interface\n */\nexport interface Animal {\n  /**\n   * The animal's name\n   */\n  name: string\n\n  /**\n   * Abstract method for making an animal sound\n   */\n  makeAnimalSound(): abstract;\n\n  /**\n   * A boolean to indicate whether the animal is a mammal\n   */\n  isMammal: boolean\n}\n```\n\n3. Add typing information for the return type of `makeAnimalSound()`.\n\nBenefit: By specifying the return type, you make it clear to developers what they can expect when utilizing this method, enhancing code maintainability and consistency.\n\n```ts\n/**\n * Animal interface\n */\nexport interface Animal {\n  /**\n   * The animal's name\n   */\n  name: string\n\n  /**\n   * Abstract method for making an animal sound\n   */\n  makeAnimalSound(): string;\n\n  /**\n   * A boolean to indicate whether the animal is a mammal\n   */\n  isMammal: boolean\n}\n```\n\n4. Add the property `readonly` to the `name` attribute, as it is unlikely to be modified after the instance creation.\n\nBenefit: Declaring the property readonly increases code readability, clarity, and safety, preventing accidental changes.\n\n```ts\n/**\n * Animal interface\n */\nexport interface Animal {\n  /**\n   * The animal's name (read-only)\n   */\n  readonly name: string\n\n  /**\n   * Abstract method for making an animal sound\n   */\n  makeAnimalSound(): string;\n\n  /**\n   * A boolean to indicate whether the animal is a mammal\n   */\n  isMammal: boolean\n}\n```\n\n5. Consider renaming the `isMammal` attribute to `isMammalian`.\n\nBenefit: This change will make the name more consistent with English grammar rules, improving the code's readability and adherence to best practices.\n\n```ts\n/**\n * Animal interface\n */\nexport interface Animal {\n  /**\n   * The animal's name (read-only)\n   */\n  readonly name: string\n\n  /**\n   * Abstract method for making an animal sound\n   */\n  makeAnimalSound(): string;\n\n  /**\n   * A boolean to indicate whether the animal is mammalian\n   */\n  isMammalian: boolean\n}\n```\n\nOverall, the code you provided follows good design principles. However, implementing the suggestions above would enhance its readability, maintainability, and consistency."}
 
 
             event: done
@@ -2372,7 +2366,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 09 Apr 2025 14:17:11 GMT
+            value: Mon, 14 Apr 2025 15:26:47 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -2401,8 +2395,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-04-09T14:17:09.384Z
-      time: 7929
+      startedDateTime: 2025-04-14T15:26:46.722Z
+      time: 4522
       timings:
         blocked: -1
         connect: -1
@@ -2410,7 +2404,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 7929
+        wait: 4522
     - _id: f1b1cde4cd57488b7f0137954f0302f5
       _order: 0
       cache: {}

--- a/agent/recordings/defaultClient_631904893/recording.har.yaml
+++ b/agent/recordings/defaultClient_631904893/recording.har.yaml
@@ -2119,11 +2119,11 @@ log:
         send: 0
         ssl: -1
         wait: 801
-    - _id: 16e5bc1c8e22aaed9695f5b3c6df5883
+    - _id: 5a9352d17ae3c0541b7d607b6eec5bc5
       _order: 0
       cache: {}
       request:
-        bodySize: 2056
+        bodySize: 2028
         cookies: []
         headers:
           - name: accept-encoding
@@ -2136,7 +2136,7 @@ log:
           - name: content-type
             value: application/json
           - name: traceparent
-            value: 00-ad6110134836ce709de9e0f11a55259f-e1f76d4d56facf1b-01
+            value: 00-60f3b6122020e10bba0419f5ac56d26c-dbb309a1ee23dcf8-01
           - name: user-agent
             value: defaultclient/v1 (Node.js v20.4.0)
           - name: x-requested-with
@@ -2152,7 +2152,7 @@ log:
           textJSON:
             maxTokensToSample: 4000
             messages:
-              - speaker: human
+              - speaker: system
                 text: >-
                   You are Cody, an AI coding assistant from Sourcegraph.If your
                   answer contains fenced code blocks in Markdown, include the
@@ -2160,8 +2160,6 @@ log:
                   structure: ```$LANGUAGE:$FILEPATH```
 
                   For executable terminal commands: enclose each command in individual "bash" language code block without comments and new lines inside.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
                 text: >
                   Codebase context from file path src/animal.ts: /*
@@ -2191,11 +2189,14 @@ log:
                 text: Ok.
               - speaker: human
                 text: >-
+                  Answer positively without apologizing. 
+
+
                   You have access to the provided codebase context.
 
 
                   Question: Explain what @src/animal.ts:1-6 ( @src/animal.ts ) does in simple terms. Assume the audience is a beginner programmer who has just learned the language features and basic syntax. Focus on explaining: 1) The purpose of the code 2) What input(s) it takes 3) What output(s) it produces 4) How it achieves its purpose through the logic and algorithm. 5) Any important logic flows or data transformations happening. Use simple language a beginner could understand. Include enough detail to give a full picture of what the code aims to accomplish without getting too technical. Format the explanation in coherent paragraphs, using proper punctuation and grammar. Write the explanation assuming no prior context about the code is known. Do not make assumptions about variables or functions not shown in the shared code. Start the answer with the name of the code that is being explained.
-            model: mistral::v1::mixtral-8x7b-instruct
+            model: anthropic::2024-10-22::claude-3-5-sonnet-latest
             temperature: 0
             topK: -1
             topP: -1
@@ -2208,14 +2209,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=8&client-name=defaultclient&client-version=v1
       response:
-        bodySize: 5876
+        bodySize: 3023
         content:
           mimeType: text/event-stream
-          size: 5876
+          size: 3023
           text: >+
             event: completion
 
-            data: {"deltaText":"Sure! This is the TypeScript code for defining an interface named `Animal`. Here's an explanation for it:\n\nThe Animal Interface\n-------------------\n\nThe `Animal` interface defines the required properties and methods for an object that represents an animal. In simple terms, it outlines what an animal **should have** or **should do**. In this case, an animal has a `name` property (a string), a `makeAnimalSound()` method (returns a string), and an `isMammal` property (a boolean value). Interfaces in TypeScript are used to ensure consistency and cohesion in object-oriented programming. Here, the `Animal` interface can be used for type checking and ensuring that any objects implementing this interface will have the essential properties and methods of an animal.\n\nPurpose, Inputs, and Outputs\n----------------------------\n\nThe `Animal` interface doesn't have any specific inputs or outputs, as it deals with defining the structure for object types. When using this interface in your code, if you create an object implementing it, the object would be expected to provide a `name`, implement the `makeAnimalSound()` method, and set the `isMammal` property.\n\nThe primary purpose of this `Animal` interface is to give guidance and maintain consistency in the code and between objects representing animals. This aids in better code organization, code understanding, and developer communication.\n\nIn essence, this interface gives us a blueprint for creating structurally consistent animal objects. It helps ensure that wherever we use this `Animal` interface, the core traits of an animal (its `name`, `makeAnimalSound()` method, and `isMammal` property) will be properly addressed.\n\nAchieving the Purpose\n--------------------\n\nBy declaring the `Animal` interface, you create a pattern that other parts of the codebase can adhere to when building objects intended to emulate animal entities. This enables developers to manage and visualize all animal objects with similar structures, ensuring every animal object shares the same building blocks.\n\nUsing this interface, you can create an instance of an object representing a specific animal and ensure it has the required properties and methods (`name`, `makeAnimalSound()`, and `isMammal`). This consistency guarantees clear and predictable functionality while dealing with the animal objects throughout the codebase.\n\nTo sum up, the `Animal` interface, as shown in the code, lays the foundation for declaring the necessary structure and functionality of an animal object. It doesn't produce any specific outputs or handle particular inputs but rather guides developers to build objects that fit a common animal pattern, enhancing communication, manageability, and functionality."}
+            data: {"deltaText":"The Animal Interface (src/animal.ts)\n\nThis code defines a blueprint called `Animal` that acts as a template for creating different types of animals in the program. It's like a contract that says \"any animal we create must have these specific characteristics and behaviors.\"\n\nThe interface specifies three required properties that any animal must have:\n1. A `name` property that holds the animal's name as text (string)\n2. A `makeAnimalSound()` method that, when called, will return a string representing the sound the animal makes (like \"meow\" or \"woof\")\n3. An `isMammal` property that is either true or false (boolean), indicating whether the animal is a mammal or not\n\nThis interface doesn't contain any actual implementation - it's just a template. When someone wants to create a specific animal (like a cat or dog), they would need to create a new class that \"implements\" this Animal interface and provides actual values and code for all three of these requirements.\n\nFor example, if someone wanted to create a Cat class using this interface, they would need to:\n- Give it a name property\n- Write code for the makeAnimalSound() method that returns \"meow\"\n- Set isMammal to true\n\nThe purpose of this interface is to ensure consistency across different types of animals in the program and make sure they all have the same basic structure. It's like creating a standardized form that all animals must fill out to be part of the system.","stopReason":"end_turn"}
 
 
             event: done
@@ -2225,7 +2226,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 07 Mar 2025 18:54:34 GMT
+            value: Wed, 09 Apr 2025 14:17:03 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -2249,13 +2250,13 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1320
+        headersSize: 1368
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-03-07T18:54:32.732Z
-      time: 4075
+      startedDateTime: 2025-04-09T14:16:57.327Z
+      time: 11930
       timings:
         blocked: -1
         connect: -1
@@ -2263,12 +2264,12 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 4075
-    - _id: 6ab1509e468689cc2d8c1b8dbedf4adc
+        wait: 11930
+    - _id: 4ecea904afe1ba00e7ad78bd06e19a3c
       _order: 0
       cache: {}
       request:
-        bodySize: 1852
+        bodySize: 1824
         cookies: []
         headers:
           - name: accept-encoding
@@ -2281,7 +2282,7 @@ log:
           - name: content-type
             value: application/json
           - name: traceparent
-            value: 00-b8d7e39f2ded58ad90352a0aaf468e25-13ed8312e7105df4-01
+            value: 00-e9468437babc3639f95f1f55293842d5-c1fe728c78d33476-01
           - name: user-agent
             value: defaultclient/v1 (Node.js v20.4.0)
           - name: x-requested-with
@@ -2297,7 +2298,7 @@ log:
           textJSON:
             maxTokensToSample: 4000
             messages:
-              - speaker: human
+              - speaker: system
                 text: >-
                   You are Cody, an AI coding assistant from Sourcegraph.If your
                   answer contains fenced code blocks in Markdown, include the
@@ -2305,8 +2306,6 @@ log:
                   structure: ```$LANGUAGE:$FILEPATH```
 
                   For executable terminal commands: enclose each command in individual "bash" language code block without comments and new lines inside.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
                 text: >
                   Codebase context from file path src/animal.ts: /*
@@ -2336,11 +2335,14 @@ log:
                 text: Ok.
               - speaker: human
                 text: >-
+                  Answer positively without apologizing. 
+
+
                   You have access to the provided codebase context.
 
 
                   Question: Please review and analyze @src/animal.ts:1-6 ( @src/animal.ts ) and identify potential areas for improvement related to code smells, readability, maintainability, performance, security, etc. Do not list issues already addressed in the given code. Focus on providing up to 5 constructive suggestions that could make the code more robust, efficient, or align with best practices. For each suggestion, provide a brief explanation of the potential benefits. After listing any recommendations, summarize if you found notable opportunities to enhance the code quality overall or if the code generally follows sound design principles. If no issues found, reply 'There are no errors.'
-            model: mistral::v1::mixtral-8x7b-instruct
+            model: anthropic::2024-10-22::claude-3-5-sonnet-latest
             temperature: 0
             topK: -1
             topP: -1
@@ -2353,14 +2355,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=8&client-name=defaultclient&client-version=v1
       response:
-        bodySize: 5649
+        bodySize: 3146
         content:
           mimeType: text/event-stream
-          size: 5649
+          size: 3146
           text: >+
             event: completion
 
-            data: {"deltaText":"Based on my analysis of the provided code, here are some suggestions for potential improvements:\n\n1. **Add a type annotation for the `makeAnimalSound()` method return type.** Although the code does not include an implementation for this method, it would be a good practice to provide type annotations for all methods that return a value. This can help prevent errors and improve the maintainability of the code.\n\n```typescript\nmakeAnimalSound(): string\n```\n\n2. **Consider capitalizing the `isMammal` property name accordingly.** In TypeScript, property names should use camelCase, so it would be more appropriate to name this property `isMammal`.\n\n```typescript\ninterface Animal {\n    name: string\n    makeAnimalSound(): string\n    isMammal: boolean\n}\n```\n\n3. **Add a constructor to initialize the properties.** This can help ensure that instances of the `Animal` interface are always initialized with the correct values.\n\n```typescript\ninterface Animal {\n    name: string\n    makeAnimalSound(): string\n    isMammal: boolean\n\n    constructor(name: string, isMammal: boolean) {\n        this.name = name\n        this.isMammal = isMammal\n    }\n}\n```\n\n4. **Add JSDoc comments to provide more context for users of the `Animal` interface.** JSDoc comments can help developers understand how to use the interface and what its properties and methods are used for.\n\n```typescript\n/**\n * An interface representing an animal.\n */\ninterface Animal {\n    /**\n     * The animal's name.\n     */\n    name: string\n\n    /**\n     * A method that the animal uses to make a sound.\n     */\n    makeAnimalSound(): string\n\n    /**\n     * A boolean indicating whether the animal is a mammal.\n     */\n    isMammal: boolean\n\n    /**\n     * Constructs a new `Animal` instance.\n     *\n     * @param name The animal's name.\n     * @param isMammal A boolean indicating whether the animal is a mammal.\n     */\n    constructor(name: string, isMammal: boolean)\n}\n```\n\n5. **Consider separating the `Animal` interface into separate interfaces or classes.** Depending on the complexity of the application, it may be more appropriate to split the `Animal` interface into smaller, more focused interfaces or classes. This can help improve the modularity and maintainability of the code.\n\nOverall, the provided code is well-written and generally follows sound design principles. However, implementing these suggestions can help make the code more robust, efficient, and align with best practices."}
+            data: {"deltaText":"Here are 4 constructive suggestions to enhance the Animal interface:\n\n1. Add JSDoc documentation above the interface to describe its purpose and requirements. This would improve code maintainability and help other developers understand how to properly implement the interface:\n\n```typescript:src/animal.ts\n/**\n * Represents a generic animal with basic properties and behaviors\n */\nexport interface Animal {\n```\n\n2. Consider adding readonly modifier to name property since it's likely an immutable characteristic. This provides better type safety and communicates intent:\n\n```typescript:src/animal.ts\nexport interface Animal {\n    readonly name: string\n```\n\n3. Add optional age property since it's a common animal attribute that implementing classes may want to track:\n\n```typescript:src/animal.ts\nexport interface Animal {\n    name: string\n    age?: number\n```\n\n4. Consider splitting makeAnimalSound() into a separate behavior interface (ISoundMaker) to follow Interface Segregation Principle. This allows for more flexible composition of animal behaviors:\n\n```typescript:src/animal.ts\nexport interface ISoundMaker {\n    makeAnimalSound(): string\n}\n\nexport interface Animal extends ISoundMaker {\n```\n\nSummary: While the current interface provides a good basic structure, there are opportunities to improve type safety, documentation, and modularity. The suggestions aim to make the code more maintainable and aligned with SOLID principles while maintaining its simplicity. The existing code follows sound design principles by keeping the interface focused and using clear naming conventions.","stopReason":"end_turn"}
 
 
             event: done
@@ -2370,7 +2372,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 07 Mar 2025 18:54:38 GMT
+            value: Wed, 09 Apr 2025 14:17:11 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -2394,13 +2396,13 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1320
+        headersSize: 1368
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-03-07T18:54:36.836Z
-      time: 4182
+      startedDateTime: 2025-04-09T14:17:09.384Z
+      time: 7929
       timings:
         blocked: -1
         connect: -1
@@ -2408,7 +2410,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 4182
+        wait: 7929
     - _id: f1b1cde4cd57488b7f0137954f0302f5
       _order: 0
       cache: {}

--- a/agent/recordings/unauthed-stored_32929715/recording.har.yaml
+++ b/agent/recordings/unauthed-stored_32929715/recording.har.yaml
@@ -1,0 +1,976 @@
+log:
+  _recordingName: unauthed-stored
+  creator:
+    comment: persister:fs
+    name: Polly.JS
+    version: 6.0.6
+  entries:
+    - _id: 897d3731ab8e15a1549f29445eafd1e1
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 0
+        cookies: []
+        headers:
+          - _fromType: array
+            name: accept
+            value: application/json
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_fc324d3667e841181b0779375f26dedc911d26b303d23b29b1a2d7ee63dc77eb
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: unauthed-stored/v1 (Node.js v20.4.0)
+          - _fromType: array
+            name: x-requested-with
+            value: unauthed-stored v1
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: sourcegraph.com
+        headersSize: 419
+        httpVersion: HTTP/1.1
+        method: GET
+        queryString: []
+        url: https://sourcegraph.com/.api/client-config
+      response:
+        bodySize: 232
+        content:
+          encoding: base64
+          mimeType: text/plain; charset=utf-8
+          size: 232
+          text: "[\"H4sIAAAAAAAAA2yPsQrCQBBE+3zFcbU/YLoQLNIFAlpvvBUP7nbD7Rwq4r9bGLC5+s3MY\
+            96dc875q4bXSWhNHHzvUCofdnAnNAFV6Kh5SwxuN6tB86g5kwRrbwAlrhVR5c9vlKwR\
+            8L3zosJ+R5apYFQBP3GJEvTRVGQNnGyYp7YgEdiw1G3TAg77oahiCwpTHubpzMV+/mP\
+            36b4AAAD//wMAHntDBjABAAA=\"]"
+        cookies: []
+        headers:
+          - name: date
+            value: Mon, 14 Apr 2025 14:16:38 GMT
+          - name: content-type
+            value: text/plain; charset=utf-8
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+          - name: content-encoding
+            value: gzip
+        headersSize: 1406
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2025-04-14T14:16:36.802Z
+      time: 1853
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 1853
+    - _id: f1b1cde4cd57488b7f0137954f0302f5
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 136
+        cookies: []
+        headers:
+          - _fromType: array
+            name: accept
+            value: application/json
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_fc324d3667e841181b0779375f26dedc911d26b303d23b29b1a2d7ee63dc77eb
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: unauthed-stored/v1 (Node.js v20.4.0)
+          - _fromType: array
+            name: x-requested-with
+            value: unauthed-stored v1
+          - _fromType: array
+            name: content-length
+            value: "136"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: sourcegraph.com
+        headersSize: 453
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: >
+              
+              query CodeSearchEnabled {
+                  codeSearchEnabled: enterpriseLicenseHasFeature(feature:"code-search")
+              }
+            variables: {}
+        queryString:
+          - name: CodeSearchEnabled
+            value: null
+        url: https://sourcegraph.com/.api/graphql?CodeSearchEnabled
+      response:
+        bodySize: 35
+        content:
+          mimeType: application/json
+          size: 35
+          text: "{\"data\":{\"codeSearchEnabled\":true}}"
+        cookies: []
+        headers:
+          - name: date
+            value: Mon, 14 Apr 2025 15:26:59 GMT
+          - name: content-type
+            value: application/json
+          - name: content-length
+            value: "35"
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1365
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2025-04-14T15:26:58.229Z
+      time: 1619
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 1619
+    - _id: a376faab1c8a1993bb48c745757f0a4a
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 318
+        cookies: []
+        headers:
+          - _fromType: array
+            name: accept
+            value: application/json
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_fc324d3667e841181b0779375f26dedc911d26b303d23b29b1a2d7ee63dc77eb
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: unauthed-stored/v1 (Node.js v20.4.0)
+          - _fromType: array
+            name: x-requested-with
+            value: unauthed-stored v1
+          - _fromType: array
+            name: content-length
+            value: "318"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: sourcegraph.com
+        headersSize: 467
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |-
+              
+              query CurrentSiteCodyLlmConfiguration {
+                  site {
+                      codyLLMConfiguration {
+                          chatModel
+                          chatModelMaxTokens
+                          fastChatModel
+                          fastChatModelMaxTokens
+                          completionModel
+                          completionModelMaxTokens
+                      }
+                  }
+              }
+            variables: {}
+        queryString:
+          - name: CurrentSiteCodyLlmConfiguration
+            value: null
+        url: https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration
+      response:
+        bodySize: 255
+        content:
+          encoding: base64
+          mimeType: application/json
+          size: 255
+          text: "[\"H4sIAAAAAAAAA4TOTQ6CMBAF4LvMmmqDEA1btrLzAmM7QAN2SH+MhvTuBjYSNXH1ksmbL\
+            28GjQGhmsGbQEsq1s/zuanZtqaLDoNhu957DA1rGqECz9Ep6hxO/V6NGDWJw64Unq2l\
+            ANm72+DjwgNZD1VRSikzaNGH+g8lejRDhI/yxjqulOLbNNKy7xemiSZPNAjFmpy452I\
+            0gcQVPcHX78bOZXFKKaUXAAAA//8=\",\"AwAw4f3QGgEAAA==\"]"
+        cookies: []
+        headers:
+          - name: date
+            value: Mon, 14 Apr 2025 14:16:39 GMT
+          - name: content-type
+            value: application/json
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+          - name: content-encoding
+            value: gzip
+        headersSize: 1397
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2025-04-14T14:16:38.695Z
+      time: 331
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 331
+    - _id: 0484c4d780805faf3dd3ddabae814640
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 165
+        cookies: []
+        headers:
+          - _fromType: array
+            name: accept
+            value: application/json
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_fc324d3667e841181b0779375f26dedc911d26b303d23b29b1a2d7ee63dc77eb
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: unauthed-stored/v1 (Node.js v20.4.0)
+          - _fromType: array
+            name: x-requested-with
+            value: unauthed-stored v1
+          - _fromType: array
+            name: content-length
+            value: "165"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: sourcegraph.com
+        headersSize: 467
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |-
+              
+              query CurrentSiteCodyLlmConfiguration {
+                  site {
+                      codyLLMConfiguration {
+                          smartContextWindow
+                      }
+                  }
+              }
+            variables: {}
+        queryString:
+          - name: CurrentSiteCodyLlmConfiguration
+            value: null
+        url: https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration
+      response:
+        bodySize: 136
+        content:
+          encoding: base64
+          mimeType: application/json
+          size: 136
+          text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eWD53MSiE\
+            uf8vJLUipLwzLyU/HIlK6WUzOLEpJzUFKXa2tpaAAAAAP//AwArMNn0TAAAAA==\"]"
+          textDecoded:
+            data:
+              site:
+                codyLLMConfiguration:
+                  smartContextWindow: disabled
+        cookies: []
+        headers:
+          - name: date
+            value: Mon, 14 Apr 2025 14:16:39 GMT
+          - name: content-type
+            value: application/json
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+          - name: content-encoding
+            value: gzip
+        headersSize: 1397
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2025-04-14T14:16:38.739Z
+      time: 260
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 260
+    - _id: e141c56e63809042300db9bf8551d492
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 150
+        cookies: []
+        headers:
+          - _fromType: array
+            name: accept
+            value: application/json
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_fc324d3667e841181b0779375f26dedc911d26b303d23b29b1a2d7ee63dc77eb
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: unauthed-stored/v1 (Node.js v20.4.0)
+          - _fromType: array
+            name: x-requested-with
+            value: unauthed-stored v1
+          - _fromType: array
+            name: content-length
+            value: "150"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: sourcegraph.com
+        headersSize: 462
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |-
+              
+              query CurrentSiteCodyLlmProvider {
+                  site {
+                      codyLLMConfiguration {
+                          provider
+                      }
+                  }
+              }
+            variables: {}
+        queryString:
+          - name: CurrentSiteCodyLlmProvider
+            value: null
+        url: https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmProvider
+      response:
+        bodySize: 128
+        content:
+          encoding: base64
+          mimeType: application/json
+          size: 128
+          text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eSDxgqL8s\
+            syU1CIlK6Xi/NKi5NT0osSCDKXa2tpaAAAAAP//AwAfFAXARQAAAA==\"]"
+          textDecoded:
+            data:
+              site:
+                codyLLMConfiguration:
+                  provider: sourcegraph
+        cookies: []
+        headers:
+          - name: date
+            value: Mon, 14 Apr 2025 14:16:39 GMT
+          - name: content-type
+            value: application/json
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+          - name: content-encoding
+            value: gzip
+        headersSize: 1397
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2025-04-14T14:16:38.717Z
+      time: 309
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 309
+    - _id: 5b9030a4e18d1e000c71d6000a7cef6f
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 341
+        cookies: []
+        headers:
+          - _fromType: array
+            name: accept
+            value: application/json
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_fc324d3667e841181b0779375f26dedc911d26b303d23b29b1a2d7ee63dc77eb
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: unauthed-stored/v1 (Node.js v20.4.0)
+          - _fromType: array
+            name: x-requested-with
+            value: unauthed-stored v1
+          - _fromType: array
+            name: content-length
+            value: "341"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: sourcegraph.com
+        headersSize: 447
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |-
+              
+              query CurrentUser {
+                  currentUser {
+                      id
+                      hasVerifiedEmail
+                      displayName
+                      username
+                      avatarURL
+                      primaryEmail {
+                          email
+                      }
+                      organizations {
+                          nodes {
+                              id
+                              name
+                          }
+                      }
+                  }
+              }
+            variables: {}
+        queryString:
+          - name: CurrentUser
+            value: null
+        url: https://sourcegraph.com/.api/graphql?CurrentUser
+      response:
+        bodySize: 376
+        content:
+          encoding: base64
+          mimeType: application/json
+          size: 376
+          text: "[\"H4sIAAAAAAAAA2RPy07CQBT9l7tuaQ1R2klIFAQXaOMjNBjj4nZ6aaePmToPFJr+O2kwc\
+            eHunJzHvaeHHC0C64E7rUnarSE9UpEDg3SXNLxSp+T+5eqp4nPwoESTkhZ7QfmqRdEA\
+            s9qRB7kwXYPHBFsCBm/KaU6Fxq5cKOvHYRiCB86QlheD+TNkysa1v5ffrQMP8IAW9fb\
+            1ERiU1naGBUFTTieFUkVDYwNX0pK0E67aAIO7ZREpvlnjV/ZOblFn1XW+Xp1+omyXRj\
+            gTU5Nmm2XynM4eQnc81HMT3/gcPOi0aFEff0f0QBfw77PbYhTGazB4oHSBUpzQCiXNG\
+            JMqJwPs43MYhuEMAAD//wMASoyTP04BAAA=\"]"
+          textDecoded:
+            data:
+              currentUser:
+                avatarURL: https://lh3.googleusercontent.com/a/ACg8ocKFaqbYeuBkbj5dFEzx8bXV8a7i3sVbKCNPV7G0uyvk=s96-c
+                displayName: SourcegraphBot-9000
+                hasVerifiedEmail: true
+                id: VXNlcjozNDQ1Mjc=
+                organizations:
+                  nodes: []
+                primaryEmail:
+                  email: sourcegraphbot9k@gmail.com
+                username: sourcegraphbot9k-fnwmu
+        cookies: []
+        headers:
+          - name: date
+            value: Mon, 14 Apr 2025 14:16:36 GMT
+          - name: content-type
+            value: application/json
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+          - name: content-encoding
+            value: gzip
+        headersSize: 1397
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2025-04-14T14:16:35.905Z
+      time: 891
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 891
+    - _id: aef0c9fe7483280d9c05ac8e97e37571
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 268
+        cookies: []
+        headers:
+          - _fromType: array
+            name: accept
+            value: application/json
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_fc324d3667e841181b0779375f26dedc911d26b303d23b29b1a2d7ee63dc77eb
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: unauthed-stored/v1 (Node.js v20.4.0)
+          - _fromType: array
+            name: x-requested-with
+            value: unauthed-stored v1
+          - _fromType: array
+            name: content-length
+            value: "268"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: sourcegraph.com
+        headersSize: 463
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |-
+              
+              query CurrentUserCodySubscription {
+                  currentUser {
+                      codySubscription {
+                          status
+                          plan
+                          applyProRateLimits
+                          currentPeriodStartAt
+                          currentPeriodEndAt
+                      }
+                  }
+              }
+            variables: {}
+        queryString:
+          - name: CurrentUserCodySubscription
+            value: null
+        url: https://sourcegraph.com/.api/graphql?CurrentUserCodySubscription
+      response:
+        bodySize: 231
+        content:
+          encoding: base64
+          mimeType: application/json
+          size: 231
+          text: "[\"H4sIAAAAAAAAA1zMsQrCMBSF4Xc5c4U2rUu2Ih0EwdJWB7fYZAjUJNzcDKXk3UVBUMfz8\
+            3E2aMUKcsOciIzjSzT0nl6vY7rHmWxg692rRVacIiTaw3S8digQFuUg0Q9nFFAhLGtP\
+            flBsTvZhOUIyJVN8vntD1uuRFXHLkBCl2O/Kelc1kxCyqmQtbvjTndNftvm1Oef8BAA\
+            A//8=\",\"AwD1okHswgAAAA==\"]"
+        cookies: []
+        headers:
+          - name: date
+            value: Mon, 14 Apr 2025 14:16:39 GMT
+          - name: content-type
+            value: application/json
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+          - name: content-encoding
+            value: gzip
+        headersSize: 1397
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2025-04-14T14:16:38.762Z
+      time: 408
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 408
+    - _id: 4504fab53d7cb602861f73dc2aa883d2
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 101
+        cookies: []
+        headers:
+          - _fromType: array
+            name: accept
+            value: application/json
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_fc324d3667e841181b0779375f26dedc911d26b303d23b29b1a2d7ee63dc77eb
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: unauthed-stored/v1 (Node.js v20.4.0)
+          - _fromType: array
+            name: x-requested-with
+            value: unauthed-stored v1
+          - _fromType: array
+            name: content-length
+            value: "101"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: sourcegraph.com
+        headersSize: 454
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |-
+              
+              query SiteProductVersion {
+                  site {
+                      productVersion
+                  }
+              }
+            variables: {}
+        queryString:
+          - name: SiteProductVersion
+            value: null
+        url: https://sourcegraph.com/.api/graphql?SiteProductVersion
+      response:
+        bodySize: 136
+        content:
+          encoding: base64
+          mimeType: application/json
+          size: 136
+          text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSsZGRiYGlvFGB\
+            kamugYmuoYm8WZ6RrpppmZpycYpJsamSYZKtbW1AAAAAP//AwDuYthZSQAAAA==\"]"
+          textDecoded:
+            data:
+              site:
+                productVersion: 322409_2025-04-14_6.2-f56fc3d435b1
+        cookies: []
+        headers:
+          - name: date
+            value: Mon, 14 Apr 2025 14:16:39 GMT
+          - name: content-type
+            value: application/json
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+          - name: content-encoding
+            value: gzip
+        headersSize: 1397
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2025-04-14T14:16:38.666Z
+      time: 334
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 334
+    - _id: fd0fee4687419870bc82cba9d1023319
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 92
+        cookies: []
+        headers:
+          - _fromType: array
+            name: accept
+            value: application/json
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_fc324d3667e841181b0779375f26dedc911d26b303d23b29b1a2d7ee63dc77eb
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: unauthed-stored/v1 (Node.js v20.4.0)
+          - _fromType: array
+            name: x-requested-with
+            value: unauthed-stored v1
+          - _fromType: array
+            name: content-length
+            value: "92"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: sourcegraph.com
+        headersSize: 449
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |
+              
+              query ViewerSettings {
+                viewerSettings {
+                  final
+                }
+              }
+            variables: {}
+        queryString:
+          - name: ViewerSettings
+            value: null
+        url: https://sourcegraph.com/.api/graphql?ViewerSettings
+      response:
+        bodySize: 192
+        content:
+          encoding: base64
+          mimeType: application/json
+          size: 192
+          text: "[\"H4sIAAAAAAAAA2SMwQrCQAwF/yXnfsHeLfQmFm97CfapgTUt2awVlvy7FLx5nRmm08LOl\
+            Dq9BTtshrvoox7kLsqFEvVM+GwweUGdywj2ZqiZUs+k2Gew3Z4X1FZ8lOKwemZFyZTc\
+            Goa/qF6nn4sh07pBJz0t4qsdzwiKiC8AAAD//wMAV+4vNJkAAAA=\"]"
+          textDecoded:
+            data:
+              viewerSettings:
+                final: "{\"experimentalFeatures\":{\"newSearchResultFiltersPanel\":true,\"newSe\
+                  archResultsUI\":true},\"openInEditor\":{}}"
+        cookies: []
+        headers:
+          - name: date
+            value: Mon, 14 Apr 2025 15:26:59 GMT
+          - name: content-type
+            value: application/json
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+          - name: content-encoding
+            value: gzip
+        headersSize: 1397
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2025-04-14T15:26:58.176Z
+      time: 1649
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 1649
+  pages: []
+  version: "1.2"

--- a/agent/src/TestErrorReporter.ts
+++ b/agent/src/TestErrorReporter.ts
@@ -1,0 +1,38 @@
+import type { ErrorWithDiff, Reporter, TaskResultPack } from 'vitest'
+
+// Global flag to track if any tests have failed
+export let hasTestFailures = false
+
+class TestErrorReporter implements Reporter {
+    private failures: Array<ErrorWithDiff> = []
+
+    constructor() {
+        hasTestFailures = false
+    }
+
+    onTaskUpdate(packs: TaskResultPack[]): void {
+        for (const pack of packs) {
+            const result = pack[1]
+            if (result?.state === 'fail') {
+                // Set the global flag when a test fails
+                hasTestFailures = true
+                for (const error of result.errors ?? []) {
+                    this.failures.push(error)
+                }
+            }
+        }
+    }
+
+    hasFailures(): boolean {
+        return this.failures.length > 0
+    }
+
+    reset(): void {
+        this.failures = []
+        hasTestFailures = false
+    }
+}
+
+export const TEST_ERROR_REPORTER = new TestErrorReporter()
+
+export default TestErrorReporter

--- a/agent/src/__snapshots__/index.test.ts.snap
+++ b/agent/src/__snapshots__/index.test.ts.snap
@@ -54,61 +54,153 @@ export class Dog implements Animal {
 `;
 
 exports[`Agent > Commands > commands/explain 1`] = `
-"The Animal Interface (src/animal.ts)
+"The code is an interface named "Animal" written in TypeScript. An interface in TypeScript is a blueprint for an object, defining what an object should look like. An interface like this one in the code defines the structure for an animal object.
 
-This code defines a blueprint called \`Animal\` that acts as a template for creating different types of animals in the program. It's like a contract that says "any animal we create must have these specific characteristics and behaviors."
+The "Animal" interface has three properties:
 
-The interface specifies three required properties that any animal must have:
-1. A \`name\` property that holds the animal's name as text (string)
-2. A \`makeAnimalSound()\` method that, when called, will return a string representing the sound the animal makes (like "meow" or "woof")
-3. An \`isMammal\` property that is either true or false (boolean), indicating whether the animal is a mammal or not
+1. "name" of type string,
+2. "makeAnimalSound" of type function that returns a string,
+3. "isMammal" of type boolean.
 
-This interface doesn't contain any actual implementation - it's just a template. When someone wants to create a specific animal (like a cat or dog), they would need to create a new class that "implements" this Animal interface and provides actual values and code for all three of these requirements.
+This code does not actually do anything; it defines the shape of an animal object. It is used to ensure that any object that is claimed to be of type "Animal" has the required properties.
 
-For example, if someone wanted to create a Cat class using this interface, they would need to:
-- Give it a name property
-- Write code for the makeAnimalSound() method that returns "meow"
-- Set isMammal to true
+For example, if another piece of code creates an object called "myAnimal" and claims it is of type "Animal", this code will ensure that myAnimal has the required properties of name, makeAnimalSound, and isMammal.
 
-The purpose of this interface is to ensure consistency across different types of animals in the program and make sure they all have the same basic structure. It's like creating a standardized form that all animals must fill out to be part of the system."
+To sum up, this code is an interface named "Animal" that defines the structure of an animal object, including a name, a function to make an animal sound, and a boolean to indicate whether the animal is a mammal. It is used as a blueprint to ensure that any object that is claimed to be of type "Animal" has the required properties."
 `;
 
 exports[`Agent > Commands > commands/smell 1`] = `
-"Here are 4 constructive suggestions to enhance the Animal interface:
+"Based on the provided code, I've identified some potential areas for improvement. Here are my recommendations:
 
-1. Add JSDoc documentation above the interface to describe its purpose and requirements. This would improve code maintainability and help other developers understand how to properly implement the interface:
+1. Add docstrings for better code readability and self-documentation.
 
-\`\`\`typescript:src/animal.ts
+Benefit: Providing short explanations for the interface properties and methods will make it easier for any developer who encounters this code to understand its purpose and functionality.
+
+\`\`\`ts
 /**
- * Represents a generic animal with basic properties and behaviors
+ * Animal interface
  */
 export interface Animal {
-\`\`\`
+  /**
+   * The animal's name
+   */
+  name: string
 
-2. Consider adding readonly modifier to name property since it's likely an immutable characteristic. This provides better type safety and communicates intent:
+  /**
+   * The animal's sound
+   */
+  makeAnimalSound(): string
 
-\`\`\`typescript:src/animal.ts
-export interface Animal {
-    readonly name: string
-\`\`\`
-
-3. Add optional age property since it's a common animal attribute that implementing classes may want to track:
-
-\`\`\`typescript:src/animal.ts
-export interface Animal {
-    name: string
-    age?: number
-\`\`\`
-
-4. Consider splitting makeAnimalSound() into a separate behavior interface (ISoundMaker) to follow Interface Segregation Principle. This allows for more flexible composition of animal behaviors:
-
-\`\`\`typescript:src/animal.ts
-export interface ISoundMaker {
-    makeAnimalSound(): string
+  /**
+   * A boolean to indicate whether the animal is a mammal
+   */
+  isMammal: boolean
 }
-
-export interface Animal extends ISoundMaker {
 \`\`\`
 
-Summary: While the current interface provides a good basic structure, there are opportunities to improve type safety, documentation, and modularity. The suggestions aim to make the code more maintainable and aligned with SOLID principles while maintaining its simplicity. The existing code follows sound design principles by keeping the interface focused and using clear naming conventions."
+2. Make the method \`makeAnimalSound()\` abstract, as it should be implemented by inheriting classes.
+
+Benefit: Defining this method as abstract will enforce concrete implementations in derived classes, ensuring proper customization and emphasizing their responsibilities.
+
+\`\`\`ts
+/**
+ * Animal interface
+ */
+export interface Animal {
+  /**
+   * The animal's name
+   */
+  name: string
+
+  /**
+   * Abstract method for making an animal sound
+   */
+  makeAnimalSound(): abstract;
+
+  /**
+   * A boolean to indicate whether the animal is a mammal
+   */
+  isMammal: boolean
+}
+\`\`\`
+
+3. Add typing information for the return type of \`makeAnimalSound()\`.
+
+Benefit: By specifying the return type, you make it clear to developers what they can expect when utilizing this method, enhancing code maintainability and consistency.
+
+\`\`\`ts
+/**
+ * Animal interface
+ */
+export interface Animal {
+  /**
+   * The animal's name
+   */
+  name: string
+
+  /**
+   * Abstract method for making an animal sound
+   */
+  makeAnimalSound(): string;
+
+  /**
+   * A boolean to indicate whether the animal is a mammal
+   */
+  isMammal: boolean
+}
+\`\`\`
+
+4. Add the property \`readonly\` to the \`name\` attribute, as it is unlikely to be modified after the instance creation.
+
+Benefit: Declaring the property readonly increases code readability, clarity, and safety, preventing accidental changes.
+
+\`\`\`ts
+/**
+ * Animal interface
+ */
+export interface Animal {
+  /**
+   * The animal's name (read-only)
+   */
+  readonly name: string
+
+  /**
+   * Abstract method for making an animal sound
+   */
+  makeAnimalSound(): string;
+
+  /**
+   * A boolean to indicate whether the animal is a mammal
+   */
+  isMammal: boolean
+}
+\`\`\`
+
+5. Consider renaming the \`isMammal\` attribute to \`isMammalian\`.
+
+Benefit: This change will make the name more consistent with English grammar rules, improving the code's readability and adherence to best practices.
+
+\`\`\`ts
+/**
+ * Animal interface
+ */
+export interface Animal {
+  /**
+   * The animal's name (read-only)
+   */
+  readonly name: string
+
+  /**
+   * Abstract method for making an animal sound
+   */
+  makeAnimalSound(): string;
+
+  /**
+   * A boolean to indicate whether the animal is mammalian
+   */
+  isMammalian: boolean
+}
+\`\`\`
+
+Overall, the code you provided follows good design principles. However, implementing the suggestions above would enhance its readability, maintainability, and consistency."
 `;

--- a/agent/src/__snapshots__/index.test.ts.snap
+++ b/agent/src/__snapshots__/index.test.ts.snap
@@ -54,99 +54,61 @@ export class Dog implements Animal {
 `;
 
 exports[`Agent > Commands > commands/explain 1`] = `
-"Sure! This is the TypeScript code for defining an interface named \`Animal\`. Here's an explanation for it:
+"The Animal Interface (src/animal.ts)
 
-The Animal Interface
--------------------
+This code defines a blueprint called \`Animal\` that acts as a template for creating different types of animals in the program. It's like a contract that says "any animal we create must have these specific characteristics and behaviors."
 
-The \`Animal\` interface defines the required properties and methods for an object that represents an animal. In simple terms, it outlines what an animal **should have** or **should do**. In this case, an animal has a \`name\` property (a string), a \`makeAnimalSound()\` method (returns a string), and an \`isMammal\` property (a boolean value). Interfaces in TypeScript are used to ensure consistency and cohesion in object-oriented programming. Here, the \`Animal\` interface can be used for type checking and ensuring that any objects implementing this interface will have the essential properties and methods of an animal.
+The interface specifies three required properties that any animal must have:
+1. A \`name\` property that holds the animal's name as text (string)
+2. A \`makeAnimalSound()\` method that, when called, will return a string representing the sound the animal makes (like "meow" or "woof")
+3. An \`isMammal\` property that is either true or false (boolean), indicating whether the animal is a mammal or not
 
-Purpose, Inputs, and Outputs
-----------------------------
+This interface doesn't contain any actual implementation - it's just a template. When someone wants to create a specific animal (like a cat or dog), they would need to create a new class that "implements" this Animal interface and provides actual values and code for all three of these requirements.
 
-The \`Animal\` interface doesn't have any specific inputs or outputs, as it deals with defining the structure for object types. When using this interface in your code, if you create an object implementing it, the object would be expected to provide a \`name\`, implement the \`makeAnimalSound()\` method, and set the \`isMammal\` property.
+For example, if someone wanted to create a Cat class using this interface, they would need to:
+- Give it a name property
+- Write code for the makeAnimalSound() method that returns "meow"
+- Set isMammal to true
 
-The primary purpose of this \`Animal\` interface is to give guidance and maintain consistency in the code and between objects representing animals. This aids in better code organization, code understanding, and developer communication.
-
-In essence, this interface gives us a blueprint for creating structurally consistent animal objects. It helps ensure that wherever we use this \`Animal\` interface, the core traits of an animal (its \`name\`, \`makeAnimalSound()\` method, and \`isMammal\` property) will be properly addressed.
-
-Achieving the Purpose
---------------------
-
-By declaring the \`Animal\` interface, you create a pattern that other parts of the codebase can adhere to when building objects intended to emulate animal entities. This enables developers to manage and visualize all animal objects with similar structures, ensuring every animal object shares the same building blocks.
-
-Using this interface, you can create an instance of an object representing a specific animal and ensure it has the required properties and methods (\`name\`, \`makeAnimalSound()\`, and \`isMammal\`). This consistency guarantees clear and predictable functionality while dealing with the animal objects throughout the codebase.
-
-To sum up, the \`Animal\` interface, as shown in the code, lays the foundation for declaring the necessary structure and functionality of an animal object. It doesn't produce any specific outputs or handle particular inputs but rather guides developers to build objects that fit a common animal pattern, enhancing communication, manageability, and functionality."
+The purpose of this interface is to ensure consistency across different types of animals in the program and make sure they all have the same basic structure. It's like creating a standardized form that all animals must fill out to be part of the system."
 `;
 
 exports[`Agent > Commands > commands/smell 1`] = `
-"Based on my analysis of the provided code, here are some suggestions for potential improvements:
+"Here are 4 constructive suggestions to enhance the Animal interface:
 
-1. **Add a type annotation for the \`makeAnimalSound()\` method return type.** Although the code does not include an implementation for this method, it would be a good practice to provide type annotations for all methods that return a value. This can help prevent errors and improve the maintainability of the code.
+1. Add JSDoc documentation above the interface to describe its purpose and requirements. This would improve code maintainability and help other developers understand how to properly implement the interface:
 
-\`\`\`typescript
-makeAnimalSound(): string
-\`\`\`
-
-2. **Consider capitalizing the \`isMammal\` property name accordingly.** In TypeScript, property names should use camelCase, so it would be more appropriate to name this property \`isMammal\`.
-
-\`\`\`typescript
-interface Animal {
-    name: string
-    makeAnimalSound(): string
-    isMammal: boolean
-}
-\`\`\`
-
-3. **Add a constructor to initialize the properties.** This can help ensure that instances of the \`Animal\` interface are always initialized with the correct values.
-
-\`\`\`typescript
-interface Animal {
-    name: string
-    makeAnimalSound(): string
-    isMammal: boolean
-
-    constructor(name: string, isMammal: boolean) {
-        this.name = name
-        this.isMammal = isMammal
-    }
-}
-\`\`\`
-
-4. **Add JSDoc comments to provide more context for users of the \`Animal\` interface.** JSDoc comments can help developers understand how to use the interface and what its properties and methods are used for.
-
-\`\`\`typescript
+\`\`\`typescript:src/animal.ts
 /**
- * An interface representing an animal.
+ * Represents a generic animal with basic properties and behaviors
  */
-interface Animal {
-    /**
-     * The animal's name.
-     */
-    name: string
-
-    /**
-     * A method that the animal uses to make a sound.
-     */
-    makeAnimalSound(): string
-
-    /**
-     * A boolean indicating whether the animal is a mammal.
-     */
-    isMammal: boolean
-
-    /**
-     * Constructs a new \`Animal\` instance.
-     *
-     * @param name The animal's name.
-     * @param isMammal A boolean indicating whether the animal is a mammal.
-     */
-    constructor(name: string, isMammal: boolean)
-}
+export interface Animal {
 \`\`\`
 
-5. **Consider separating the \`Animal\` interface into separate interfaces or classes.** Depending on the complexity of the application, it may be more appropriate to split the \`Animal\` interface into smaller, more focused interfaces or classes. This can help improve the modularity and maintainability of the code.
+2. Consider adding readonly modifier to name property since it's likely an immutable characteristic. This provides better type safety and communicates intent:
 
-Overall, the provided code is well-written and generally follows sound design principles. However, implementing these suggestions can help make the code more robust, efficient, and align with best practices."
+\`\`\`typescript:src/animal.ts
+export interface Animal {
+    readonly name: string
+\`\`\`
+
+3. Add optional age property since it's a common animal attribute that implementing classes may want to track:
+
+\`\`\`typescript:src/animal.ts
+export interface Animal {
+    name: string
+    age?: number
+\`\`\`
+
+4. Consider splitting makeAnimalSound() into a separate behavior interface (ISoundMaker) to follow Interface Segregation Principle. This allows for more flexible composition of animal behaviors:
+
+\`\`\`typescript:src/animal.ts
+export interface ISoundMaker {
+    makeAnimalSound(): string
+}
+
+export interface Animal extends ISoundMaker {
+\`\`\`
+
+Summary: While the current interface provides a good basic structure, there are opportunities to improve type safety, documentation, and modularity. The suggestions aim to make the code more maintainable and aligned with SOLID principles while maintaining its simplicity. The existing code follows sound design principles by keeping the interface focused and using clear naming conventions."
 `;

--- a/agent/src/auth.test.ts
+++ b/agent/src/auth.test.ts
@@ -11,7 +11,8 @@ import { TestWorkspace } from './TestWorkspace'
 describe(
     'Auth',
     {
-        timeout: 5000,
+        // Set SIMULATE_SYSTEM_DELAYS to true to simulate system delays, e.g. during accessing system storage
+        timeout: process.env.SIMULATE_SYSTEM_DELAYS === 'true' ? 12000 : 5000,
         // Repeat to find race conditions. Set to 0 when recording for faster execution.
         repeats: process.env.CODY_RECORDING_MODE ? 0 : 10,
     },
@@ -45,6 +46,7 @@ describe(
             workspaceRootUri: workspace.rootUri,
             name: 'auth',
             credentials: INITIAL_CREDENTIALS,
+            simulateSystemDelays: process.env.SIMULATE_SYSTEM_DELAYS === 'true',
         })
 
         beforeAll(async () => {

--- a/agent/src/unauthed.test.ts
+++ b/agent/src/unauthed.test.ts
@@ -7,7 +7,7 @@ import { TestWorkspace } from './TestWorkspace'
 describe(
     'Initializing the agent without credentials',
     {
-        timeout: 5000,
+        timeout: 8000,
     },
     () => {
         const workspace = new TestWorkspace(path.join(__dirname, '__tests__', 'auth'))

--- a/agent/src/unauthed.test.ts
+++ b/agent/src/unauthed.test.ts
@@ -36,7 +36,7 @@ describe(
         it('starts up with default endpoint and credentials if they are present in the secure store', async () => {
             const newClient = TestClient.create({
                 workspaceRootUri: workspace.rootUri,
-                name: 'unauthed',
+                name: 'unauthed-stored',
                 credentials: TESTING_CREDENTIALS.dotcomUnauthed,
                 secretStorageEntries: {
                     [TESTING_CREDENTIALS.dotcom.serverEndpoint]:
@@ -48,7 +48,8 @@ describe(
             const authStatus = await newClient.request('extensionConfiguration/status', null)
             expect(authStatus?.authenticated).toBe(true)
             expect(authStatus?.endpoint).toBe(TESTING_CREDENTIALS.dotcom.serverEndpoint)
-            newClient.afterAll()
+
+            await newClient.afterAll()
         })
 
         it('authenticates to same endpoint using valid credentials', async () => {

--- a/agent/src/unauthed.test.ts
+++ b/agent/src/unauthed.test.ts
@@ -4,8 +4,6 @@ import { TESTING_CREDENTIALS } from '../../vscode/src/testutils/testing-credenti
 import { TestClient } from './TestClient'
 import { TestWorkspace } from './TestWorkspace'
 
-// TODO: fix the flakiness and reenabled it back
-// https://linear.app/sourcegraph/issue/CODY-4546/fix-the-flaky-agentsrcunauthedteststs-and-reenabled-it-back
 describe(
     'Initializing the agent without credentials',
     {

--- a/agent/src/unauthed.test.ts
+++ b/agent/src/unauthed.test.ts
@@ -6,7 +6,7 @@ import { TestWorkspace } from './TestWorkspace'
 
 // TODO: fix the flakiness and reenabled it back
 // https://linear.app/sourcegraph/issue/CODY-4546/fix-the-flaky-agentsrcunauthedteststs-and-reenabled-it-back
-describe.skip(
+describe(
     'Initializing the agent without credentials',
     {
         timeout: 5000,
@@ -35,17 +35,16 @@ describe.skip(
             expect(authStatus?.endpoint).toBe(TESTING_CREDENTIALS.dotcomUnauthed.serverEndpoint)
         })
 
-        it('starts up with default andpoint and credentials if they are present in the secure store', async () => {
+        it('starts up with default endpoint and credentials if they are present in the secure store', async () => {
             const newClient = TestClient.create({
                 workspaceRootUri: workspace.rootUri,
                 name: 'unauthed',
                 credentials: TESTING_CREDENTIALS.dotcomUnauthed,
+                secretStorageEntries: {
+                    [TESTING_CREDENTIALS.dotcom.serverEndpoint]:
+                        TESTING_CREDENTIALS.dotcom.token ?? TESTING_CREDENTIALS.dotcom.redactedToken,
+                },
             })
-
-            newClient.secrets.store(
-                TESTING_CREDENTIALS.dotcom.serverEndpoint,
-                TESTING_CREDENTIALS.dotcom.token ?? 'invalid'
-            )
 
             await newClient.beforeAll({ serverEndpoint: undefined }, { expectAuthenticated: true })
             const authStatus = await newClient.request('extensionConfiguration/status', null)

--- a/agent/vitest.config.ts
+++ b/agent/vitest.config.ts
@@ -2,6 +2,7 @@ import { statSync } from 'node:fs'
 import { resolve } from 'node:path'
 
 import { defineProjectWithDefaults } from '../.config/viteShared'
+import { TEST_ERROR_REPORTER } from './src/TestErrorReporter'
 
 const shimFromAgentDirectory = resolve(process.cwd(), 'src', 'vscode-shim')
 const shimFromRootDirectory = resolve(process.cwd(), 'agent', 'src', 'vscode-shim')
@@ -18,13 +19,24 @@ function shimDirectory(): string {
     return shimFromAgentDirectory
 }
 
-export default defineProjectWithDefaults(__dirname, {
-    resolve: {
-        alias: { vscode: shimDirectory() },
-    },
+const errorReporterConfig = {
     test: {
-        env: {
-            CODY_SHIM_TESTING: 'true',
+        reporters: ['default', TEST_ERROR_REPORTER],
+        globals: true,
+    },
+}
+
+export default defineProjectWithDefaults(
+    __dirname,
+    {
+        resolve: {
+            alias: { vscode: shimDirectory() },
+        },
+        test: {
+            env: {
+                CODY_SHIM_TESTING: 'true',
+            },
         },
     },
-})
+    errorReporterConfig
+)

--- a/jetbrains/src/integrationTest/resources/recordings/autocompleteEdit_3787598409/recording.har.yaml
+++ b/jetbrains/src/integrationTest/resources/recordings/autocompleteEdit_3787598409/recording.har.yaml
@@ -24,7 +24,7 @@ log:
             value: application/json; charset=utf-8
           - _fromType: array
             name: user-agent
-            value: jetbrains/6.0-localbuild (Node.js v20.12.2)
+            value: jetbrains/6.0-localbuild (Node.js v22.14.0)
           - _fromType: array
             name: x-requested-with
             value: jetbrains 6.0-localbuild
@@ -39,19 +39,19 @@ log:
         queryString: []
         url: https://demo.sourcegraph.com/.api/client-config
       response:
-        bodySize: 219
+        bodySize: 235
         content:
           encoding: base64
           mimeType: text/plain; charset=utf-8
-          size: 219
-          text: "[\"H4sIAAAAAAAAA2zOsQrDMAwE0D1fYTL3A0q2EDpkCwTaWakFNVhSsM40pfTfu2T0/O6O+\
-            3YhhNA/\",\"LX5uSlvm2A8BpfLlhBehCVRhk8meGdxuVofJZCKk0dsbQElbRTJtugs\
-            VTKbgA4+k0d7NmFjk7OMyNzUT2LHWfbcCjufnZOorCpOMy3zn4sm0H8K1+3V/AAAA//\
-            8DAHnaXXATAQAA\"]"
+          size: 235
+          text: "[\"H4sIAAAAAAAAA4SPOwrDMBBEe59CqM4F4s6YFO4MhqSWo4UItFqhHeVDyN1TRKUg9Zt5z\
+            LwHY4yx\",\"V/GvU3J7JG9Hg1Lp0MDNoQtchczCORKo36wK4VmYXfLadwAl7BVB0j9\
+            uR2MzFQ6q4U62BZRdwSwJ9MQlJC+ProfFU9RpXbo0OpBiqzlLAfl2KkjSDYUcT+typq\
+            K/EcfhM3wBAAD//wMA+qjbzTQBAAA=\"]"
         cookies: []
         headers:
           - name: date
-            value: Tue, 01 Apr 2025 16:20:12 GMT
+            value: Tue, 15 Apr 2025 13:48:16 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: transfer-encoding
@@ -82,8 +82,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-04-01T16:20:11.748Z
-      time: 277
+      startedDateTime: 2025-04-15T13:48:16.096Z
+      time: 332
       timings:
         blocked: -1
         connect: -1
@@ -91,7 +91,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 277
+        wait: 332
     - _id: a912810c5ce98c83aaf52f85bf5a6254
       _order: 0
       cache: {}
@@ -114,7 +114,7 @@ log:
             value: application/json; charset=utf-8
           - _fromType: array
             name: user-agent
-            value: jetbrains/6.0-localbuild (Node.js v20.12.2)
+            value: jetbrains/6.0-localbuild (Node.js v22.14.0)
           - _fromType: array
             name: x-requested-with
             value: jetbrains 6.0-localbuild
@@ -197,10 +197,10 @@ log:
             value: 6.0-localbuild
         url: https://demo.sourcegraph.com/.api/completions/code?client-name=jetbrains&client-version=6.0-localbuild
       response:
-        bodySize: 878
+        bodySize: 858
         content:
           mimeType: text/event-stream
-          size: 878
+          size: 858
           text: >+
             event: completion
 
@@ -214,7 +214,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 01 Apr 2025 16:20:12 GMT
+            value: Tue, 15 Apr 2025 13:48:17 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -243,8 +243,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-04-01T16:20:12.042Z
-      time: 631
+      startedDateTime: 2025-04-15T13:48:16.515Z
+      time: 677
       timings:
         blocked: -1
         connect: -1
@@ -252,7 +252,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 631
+        wait: 677
     - _id: da433e61285ffe93e70168bc8ce8e1ed
       _order: 0
       cache: {}
@@ -275,7 +275,7 @@ log:
             value: application/json; charset=utf-8
           - _fromType: array
             name: user-agent
-            value: jetbrains/6.0-localbuild (Node.js v20.12.2)
+            value: jetbrains/6.0-localbuild (Node.js v22.14.0)
           - _fromType: array
             name: x-requested-with
             value: jetbrains 6.0-localbuild
@@ -350,14 +350,14 @@ log:
             value: 6.0-localbuild
         url: https://demo.sourcegraph.com/.api/completions/code?client-name=jetbrains&client-version=6.0-localbuild
       response:
-        bodySize: 626
+        bodySize: 667
         content:
           mimeType: text/event-stream
-          size: 626
+          size: 667
           text: >+
             event: completion
 
-            data: {"completion":"    val list = listOf(1, 2, 3, 4, 5)\n    for (i in list) {\n        println(i)\n    }\n}\n","stopReason":"stop"}
+            data: {"completion":"    val list = listOf(1, 2, 3, 4, 5)\n    for (item in list) {\n        println(item)\n    }\n}\n","stopReason":"stop"}
 
 
             event: done
@@ -367,7 +367,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 01 Apr 2025 16:20:13 GMT
+            value: Tue, 15 Apr 2025 13:48:17 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -396,8 +396,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-04-01T16:20:13.041Z
-      time: 529
+      startedDateTime: 2025-04-15T13:48:17.390Z
+      time: 553
       timings:
         blocked: -1
         connect: -1
@@ -405,7 +405,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 529
+        wait: 553
     - _id: 404a28d2461ea66da470804476c21f26
       _order: 0
       cache: {}
@@ -425,7 +425,7 @@ log:
             value: application/json; charset=utf-8
           - _fromType: array
             name: user-agent
-            value: jetbrains/6.0-localbuild (Node.js v20.12.2)
+            value: jetbrains/6.0-localbuild (Node.js v22.14.0)
           - _fromType: array
             name: x-requested-with
             value: jetbrains 6.0-localbuild
@@ -463,7 +463,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 01 Apr 2025 16:20:12 GMT
+            value: Tue, 15 Apr 2025 13:48:16 GMT
           - name: content-type
             value: application/json
           - name: content-length
@@ -492,8 +492,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-04-01T16:20:12.088Z
-      time: 235
+      startedDateTime: 2025-04-15T13:48:16.465Z
+      time: 305
       timings:
         blocked: -1
         connect: -1
@@ -501,7 +501,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 235
+        wait: 305
     - _id: 8f874601be80bbe63d0652f1110280e3
       _order: 0
       cache: {}
@@ -521,7 +521,7 @@ log:
             value: application/json; charset=utf-8
           - _fromType: array
             name: user-agent
-            value: jetbrains/6.0-localbuild (Node.js v20.12.2)
+            value: jetbrains/6.0-localbuild (Node.js v22.14.0)
           - _fromType: array
             name: x-requested-with
             value: jetbrains 6.0-localbuild
@@ -565,7 +565,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 01 Apr 2025 16:20:12 GMT
+            value: Tue, 15 Apr 2025 13:48:16 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -596,8 +596,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-04-01T16:20:11.725Z
-      time: 295
+      startedDateTime: 2025-04-15T13:48:16.067Z
+      time: 360
       timings:
         blocked: -1
         connect: -1
@@ -605,7 +605,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 295
+        wait: 360
     - _id: c094940ca4210fcb4809cd04c9d916db
       _order: 0
       cache: {}
@@ -625,7 +625,7 @@ log:
             value: application/json; charset=utf-8
           - _fromType: array
             name: user-agent
-            value: jetbrains/6.0-localbuild (Node.js v20.12.2)
+            value: jetbrains/6.0-localbuild (Node.js v22.14.0)
           - _fromType: array
             name: x-requested-with
             value: jetbrains 6.0-localbuild
@@ -676,7 +676,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 01 Apr 2025 16:20:12 GMT
+            value: Tue, 15 Apr 2025 13:48:16 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -707,8 +707,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-04-01T16:20:11.640Z
-      time: 371
+      startedDateTime: 2025-04-15T13:48:15.963Z
+      time: 427
       timings:
         blocked: -1
         connect: -1
@@ -716,7 +716,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 371
+        wait: 427
     - _id: 6d678ba98ff2e3959de5001c07326f28
       _order: 0
       cache: {}
@@ -736,7 +736,7 @@ log:
             value: application/json; charset=utf-8
           - _fromType: array
             name: user-agent
-            value: jetbrains/6.0-localbuild (Node.js v20.12.2)
+            value: jetbrains/6.0-localbuild (Node.js v22.14.0)
           - _fromType: array
             name: x-requested-with
             value: jetbrains 6.0-localbuild
@@ -781,7 +781,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 01 Apr 2025 16:20:12 GMT
+            value: Tue, 15 Apr 2025 13:48:16 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -812,8 +812,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-04-01T16:20:11.682Z
-      time: 328
+      startedDateTime: 2025-04-15T13:48:16.026Z
+      time: 372
       timings:
         blocked: -1
         connect: -1
@@ -821,7 +821,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 328
+        wait: 372
     - _id: 6f796c152fe09bf6f9bca1fc88478f87
       _order: 0
       cache: {}
@@ -841,7 +841,7 @@ log:
             value: application/json; charset=utf-8
           - _fromType: array
             name: user-agent
-            value: jetbrains/6.0-localbuild (Node.js v20.12.2)
+            value: jetbrains/6.0-localbuild (Node.js v22.14.0)
           - _fromType: array
             name: x-requested-with
             value: jetbrains 6.0-localbuild
@@ -885,7 +885,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 01 Apr 2025 16:20:12 GMT
+            value: Tue, 15 Apr 2025 13:48:16 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -916,8 +916,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-04-01T16:20:11.662Z
-      time: 350
+      startedDateTime: 2025-04-15T13:48:15.996Z
+      time: 399
       timings:
         blocked: -1
         connect: -1
@@ -925,7 +925,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 350
+        wait: 399
     - _id: 2717d54335f4500a7f7edd3c1b77c615
       _order: 0
       cache: {}
@@ -945,7 +945,7 @@ log:
             value: application/json; charset=utf-8
           - _fromType: array
             name: user-agent
-            value: jetbrains/6.0-localbuild (Node.js v20.12.2)
+            value: jetbrains/6.0-localbuild (Node.js v22.14.0)
           - _fromType: array
             name: x-requested-with
             value: jetbrains 6.0-localbuild
@@ -1002,7 +1002,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 01 Apr 2025 16:20:11 GMT
+            value: Tue, 15 Apr 2025 13:48:15 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -1033,8 +1033,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-04-01T16:20:10.955Z
-      time: 286
+      startedDateTime: 2025-04-15T13:48:14.640Z
+      time: 630
       timings:
         blocked: -1
         connect: -1
@@ -1042,7 +1042,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 286
+        wait: 630
     - _id: 7c8561ba03f1b53b0087b29b8c3519cb
       _order: 0
       cache: {}
@@ -1062,7 +1062,7 @@ log:
             value: application/json; charset=utf-8
           - _fromType: array
             name: user-agent
-            value: jetbrains/6.0-localbuild (Node.js v20.12.2)
+            value: jetbrains/6.0-localbuild (Node.js v22.14.0)
           - _fromType: array
             name: x-requested-with
             value: jetbrains 6.0-localbuild
@@ -1098,11 +1098,11 @@ log:
         content:
           mimeType: application/json
           size: 47
-          text: "{\"data\":{\"site\":{\"productVersion\":\"6.1.5633\"}}}"
+          text: "{\"data\":{\"site\":{\"productVersion\":\"6.2.1106\"}}}"
         cookies: []
         headers:
           - name: date
-            value: Tue, 01 Apr 2025 16:20:11 GMT
+            value: Tue, 15 Apr 2025 13:48:15 GMT
           - name: content-type
             value: application/json
           - name: content-length
@@ -1131,8 +1131,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-04-01T16:20:11.411Z
-      time: 307
+      startedDateTime: 2025-04-15T13:48:15.433Z
+      time: 628
       timings:
         blocked: -1
         connect: -1
@@ -1140,7 +1140,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 307
+        wait: 628
     - _id: 18db51344af131baf45ba049965cba0f
       _order: 0
       cache: {}
@@ -1160,7 +1160,7 @@ log:
             value: application/json; charset=utf-8
           - _fromType: array
             name: user-agent
-            value: jetbrains/6.0-localbuild (Node.js v20.12.2)
+            value: jetbrains/6.0-localbuild (Node.js v22.14.0)
           - _fromType: array
             name: x-requested-with
             value: jetbrains 6.0-localbuild
@@ -1192,56 +1192,57 @@ log:
             value: null
         url: https://demo.sourcegraph.com/.api/graphql?ViewerSettings
       response:
-        bodySize: 1812
+        bodySize: 1852
         content:
           encoding: base64
           mimeType: application/json
-          size: 1812
-          text: "[\"H4sIAAAAAAAA/7RYbVPcOBL+KyrXVh3sYTPM8Dau2spxXOByR3YhkNoPmFTJUttWRpYcS\
-            R7gOPa3X0nyvNvDTG6TqoCxWt1PP93qbg==\",\"+SWg2OAgfgnGDB5B3YIxTOTavsm\
-            YwDyIg5ckIJLCB2GAR1yzLAlio2rY8+9vDTb6g9AsL4yOmH+IOBb5Z41zSIL4JQmkKU\
-            DdFQp0ITlNgrgX9QZ7SaCgkpoZqZ6TIE6CnJmiTiMiy30ta0UgV7gq5p+TYC8JDDMc3\
-            IYrLHLU2HltBdRmud8q+a2GBoZFFX/xYJIkSdYB+skhsixSmd+CGjMCH3EV4Yr9G7w6\
-            QrMezY4H/aPhQf8An5z000Gf9gjBlAyGeNipoeKMYMOkmGjqDwbZMYX+8BRTQnvp8Sn\
-            up0PaywaUQHY0pENyMugf9Do0Eqn0mXh+LEDBZ8WdysKYSsf78y6FFEoZWuEQN9JRAU\
-            qOalxZJWWHehBjp5LCODzwMkzjlMNZbeQlM58rig3oWfpQpkumNUtdNJuX8FSBYiUIg\
-            /kFYFMrt+UlCVJsSHFeYJGDfv8EpLbULCbjJJjnsqxqA4uLH6WwqcZE/juk/5RyNAdF\
-            A1akOJfCwJPRN00qTBYL+dhotL+kAGGa1VeH2IDQTIoG53ym4Aqe5hTNrVhERI7bFxt\
-            ywxKMYkSvF9I+BGGJq3bBr3iM21dkBSJkItR1yllp+cow111SY21Bt2vyBIbwVEll1o\
-            o0JaLDKW8jhCejsJ7gsSxPtkWYc1c2GrKd0pX6UykYDI7uQBv7/++YjDLGOagL4Oxps\
-            lMxl1r3L0kgcOkrSmYFUD86HKGDgXZZPCsMfnH+nxPQRsmR3z7GaicMJQmZoCyX4cmu\
-            LUwrBjI0PB12Gcg2MmDpAq//YaEm3lcKwkE0OAoNaPOALAEonTKAvBO+Xm7J3m/iXxL\
-            4Ovq+SuAo4zjXSAoEY3QQHY2WnHQyRNbCxJhzZBGwMdD4GTTKpBrZh+15nbecZdZ0f3\
-            jaZnlqT0hvTsgZmk67BjDvYhtZtlE721IgZ3Ut33brteP8gmPTVKF1NBMvEv/N6t7Xi\
-            oRaEeu9WfL4DcH1nu61mcy5TLFj2qAKGwNKmOcKYs4MKMw77M/t2j6jHadTnp1lMuHo\
-            DVY/Qa5A2+J891zZ6l0yc7G+AjhviJNEmRVdcKht9Q1n9rq0KxiDWo5Yh8A2Oen4UlP\
-            P36EV0K8LFZViXaQSK9rU1Nnx/12q0ezIM+rUHx5lJ7Q3JCE+OuqHh4eHhyE+PO2HZI\
-            iHkPYG/cEBdZgbAx+c3vvvrdXfX6a2PnCLNF7Pn2z0KNUI3VvFDw1/XPrpzM9R0gZ4a\
-            jGaTbaXStZVwyyFisvncGGgddmnIHeDQhJ86RiCV7dGPzeR/x51fvPs9ESayGr1MPwq\
-            vfcZ401RHmNe+7XQvozt8nKS/yb4MyrBFJIub9LAgZhYP5ep5JGXWd5+O8OJpjyyFft\
-            2KbfkxgsELOqaW0ICHhGuTYEqJceMgkLe9xa9G4//LUrt3Se+lJPgtGcgZQqITY9IAS\
-            bmohbE5tJ0vvzIcjXJrpe5i1JTsDa7K3n7bUVuYg+RicHlUaSp7bZsxi6dKlt0tbGMa\
-            Pvj8a+xe975ZB1wRO2+W/Fj2zZzzrHWW6Fy4zfVq1h2rmsFu+/ehjI/UzjKDFSe9lIK\
-            U1jyBq8LpWEaHWQkcjZR1sbomu4EfbiT9lLdaLIlTP/gqL8XNDQyBEHdqd4k5FiDG8w\
-            sp+kOM/+1G3ftXzsoi/dhqtFWFMu7qwfuQf/UyXjFxKgl+LNuvX9z9mdBnDXCrSBKZS\
-            +aLSBtn7EMslnsvg+qx/CpFg1UW02/UBjv59+4Vbi//RB8zhkI8/9DW2VxTmUbjd33l\
-            MUhZXa0HgHcBfxw8WT9WpepHZszNEstNNZtLq05XH7cjOwNOcUa5r5E/Q==\",\"2Uf\
-            qE1C2TK+avmsjRAFtidy11CZXcHtztRwrv9CtL+V1W5re3lwxA0vK9Dc+edmmijxjsS\
-            5W/cVY/aOhF9WzL3BdAbE83lzZjPvRRe5DWUll7C0QSU7R5c1V9LObgN88BYuHwCW5x\
-            r6xXDZx2TygczDsiOBgf+OhrMA7rzfDNHcy91d1/GWDrGgP5fGahmbxXvqAobvbCc41\
-            0S0nuy+ULN/r4zt5ppR8nAwDeoNAf2bX2BT7ZyX+j50ehADiG/aqjFSkAG0UNlKFQlL\
-            4qjskschrjlU435LfnomWYxLf//Fl0t0fUHyfiT/8/POwE0XR7sItWBtVE1NPLsKbp4\
-            sjDHVBcJPXgmn0C/LWf0mSutcbwLYwuurydOTpd2WIDTJ6f3tsU2UJ9vrPHNrOu6mUo\
-            0slH03xY45/0wKntjZtgJmbZj3Gpqs9/eS7IabU9cFNv1y82eRup+DyhonX1+D19fV/\
-            AQAA//+ZzwGojxkAAA==\"]"
+          size: 1852
+          text: "[\"H4sIAAAJbogA/7RYe2/bOBL/KoRQ4JJuJTt2Xhaw6OV6Ta536W7SpNg/ohSgxJHEmiJVk\
+            rKdy2U/+2H0sGVbdpzsboHWqjic+fE3Tw==\",\"6tFh1FLHf3QmHKagb8BaLhODb2I\
+            uqXB85zFwIsXgk7QgPGF4HDi+1QW8q97fWGrNJ2l4klrj8erBE1QmXw1NIHD8x8BRNg\
+            V9m2owqRIscPy+1x++CxwNuTLcKv0QOH7gJNymRehFKusZVegIEk3ztP0cOO8Cx3IrU\
+            HHgXFKZkNrOUyegLsuDTskfBdQwEJX/rQITBEGwDdCbEhGyyFRyA3rCI/hMc4/m/D9Q\
+            qYtY3Gfx8XBwNDoYHNCTk0E4HLB+FFEWDUd0tFFDLnhELVey0TQYDuNjBoPRKWUR64f\
+            Hp3QQjlg/HrII4qMRG0Unw8FBf4PGSGlzJh+mKWj4qkWpMrU2N36vfSSXQaZcFHZpLe\
+            2loNW4oDkqyTaoBzkpVTKYuAeVDDc0FHBWWHXB7decUQtmET6Mm4wbw0MBi5iCWQ6aZ\
+            yAtFedAbaHLLY+BE1IbpR9SKhMwH2cQFUjNcjA2cfhBZXlhW1rR3Z+VxFDjMvkNwn8p\
+            NW5BMUB1lH5Q0sLMmus6FOowN6ma1hrxR0mQtt6KQQczC9JwJWucLSp7NIdZy0prBRF\
+            FatK9WJPrZmA1j8x2IVNFnZvRvFvwO53Q7hWVg3S5dE0RCp4hXzEVZpPUxCDobk0VgS\
+            7McqUbcrpF6hKx4VCVDRdmVlPT4EGWm20eFQITtCG7tLtWf3INw+HRLRiLf/9Bo3HMh\
+            QB9DoLPmp2al6F19xg4kpanD5wYBcjAOxyTg6Epo3hRGKrF9p9SwFitxtX2CdV7rqsi\
+            l0vGE+We7AfO07s1AzEZnY42GYgX6rcYQE6h0n+/VBPvcg3u0BseuRaMvSdIAAnnDJA\
+            SAEFYL2bvV/lvBWIbfd8VCBILmhiiJIEJOfCOxissljKRKqT1qRAE/ccnwPwHMCRWeo\
+            wPL+e1bTmO0fRgdNpleW5PqsqcVAs0G+1aoGIT2wTZJt1sK0lKq1v5xq1XZcSeC2rrK\
+            rSN5qgS8f+OuntGR67REfJuV078jOD2ky7FbaMpESqkJdOW5NRa0NI+5OALbkFTscF+\
+            a9fLI7rkdM4znpLUaJ5l9QskGgwW59uHHKt3xu359gpQniYqJUnMZysH6lp95jBLNLb\
+            3a5iAXvXYBoHtnlquACVfen7y96StswT9tFRRGTVpqKhmdU1dFM/flB4vUp7j5BY4h0\
+            fxCeuPIpceHQ3cw8PDQ5ceng7caERHEPaHg+EBKzHX5eRTqffutbX69WXqxQm3TONVE\
+            3GYnmSq9JjcIRn3NX9CVdNZKZyqDFoWvcVke6FVkdfMMsiFenBbDa+OPg1JOSgETj13\
+            rs2c61u9t7XnX6Ou2rzIHs9EKl9vh7+o6vQxF3VRnlBRVGsuvvRxebXH/SrFA8nApoq\
+            tbjIgILK+echCJbxKZnX7zQInmfPI1+zjUoLk+ksELOtqLREJU0ILm5JcqwlnoEkVHh\
+            16dx7/O5Ti3ce/UI1zugcUxjVEGB6eBhrZ80JGOM7O58vPPNFNdD22Lkp1wdrtrlTZ7\
+            2ogjT0SNQZXZ526tmPZ9MtwyrHoGosXIoP/TH/y8cfsfcED4KO3/37tHC9tMx8ENeZF\
+            qMrxm5l1LHtXhYb9989Dac9qJWUWcJJ+DJxMSZsiecOnpdIw9w6xipQ2SVyffAn7lu4\
+            EA7hVeKmuNWEJM3+x1z9K5lrlgmRlVu/icmoA5zGC9IZ73P4PN+7j//ZI7PdgrhErCv\
+            KO69WDebPR+TmX4w7nL7p17/rsz4K4aIQvgqg0XjQ7QGKDQgb5wnevg1rR9KWQNZtYT\
+            b8xmPSSHwIV9nYK2JXs4SDtH4e27uiWyi4ayY5DyiK1pgDlBfxwObN+KQ==\",\"shA\
+            0UTFZhBaZmK4jbUmuatz08BodUgOtL1F/diH9Aoyv0qvn77oI0cA6oupKGZtouLm+XF\
+            GWVwubb0ShKLrC9Ob6kltYUWZ+iOZlF7Togcptvhos++qfNb2kWHyB29DuygZ8fYl1+\
+            68ucp8y/ASBt0CiBCMX15fe23ICfjYLlpPgLca2oVVjubi+3Mhat0NbMHBEKGH/EK7K\
+            oYpisxumVmb21nX8bYeo6E6742VXzn2CDQ3xXqCt60tye9Pg3JJuWbP7XKvsozm+VWd\
+            aq2kzDJgdUu8rv6I27Z1l9L84PUgJUTU7rMsoHaVgrKZWaVcqBt/NBkkqk0JQ7bZb8v\
+            Mz0apP/LvfvzXd/Z74d7H8HWNi+tP9nud5+0u3YGN1EdmiuQjvHi4lYWQThHLyWjJNf\
+            iaV9Z+DoOj3h/BSGJvq8nzkGWyKEHQy+XhzjKGyAnv7Zw6D826o1PhCq6lNd4iKVxTk\
+            ugXObe3am+Nymq0w1vPL7A3Bp5Ayhr97u1z2d2pyN3NwSc3E05Pz9PT0/wEAmc8BqI8\
+            ZAAA=\"]"
         cookies: []
         headers:
           - name: date
-            value: Tue, 01 Apr 2025 16:20:12 GMT
+            value: Tue, 15 Apr 2025 13:48:16 GMT
           - name: content-type
             value: application/json
           - name: content-length
-            value: "1812"
+            value: "1852"
           - name: connection
             value: close
           - name: access-control-allow-credentials
@@ -1268,8 +1269,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-04-01T16:20:12.066Z
-      time: 263
+      startedDateTime: 2025-04-15T13:48:16.435Z
+      time: 348
       timings:
         blocked: -1
         connect: -1
@@ -1277,7 +1278,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 263
+        wait: 348
     - _id: ceee2078500ebaad09c6a34055ed9d99
       _order: 0
       cache: {}
@@ -1291,7 +1292,7 @@ log:
               REDACTED_69e9f79ce29352d014eeb80b56510341844eb82ad9abac7cab3631c7e873e4ce
           - _fromType: array
             name: user-agent
-            value: jetbrains/6.0-localbuild (Node.js v20.12.2)
+            value: jetbrains/6.0-localbuild (Node.js v22.14.0)
           - _fromType: array
             name: x-requested-with
             value: jetbrains 6.0-localbuild
@@ -1309,58 +1310,71 @@ log:
         queryString: []
         url: https://demo.sourcegraph.com/.api/modelconfig/supported-models.json
       response:
-        bodySize: 1897
+        bodySize: 3426
         content:
           encoding: base64
           mimeType: text/plain; charset=utf-8
-          size: 1897
-          text: "[\"H4sIAAAAAAAA/+ydUXPaOBCA3/MrNDy1cxWxTQgpT5em7V3nmkvmkknn5qYPwl5Agy15Z\
-            JmQ6eS/39gGE7DAMsGAgw==\",\"80Twale2P69Xu5L4dYIQQo3AHoJHHkAElLNGFzX\
-            MptH4kBwTMKazr42m0TR+c2A8O+gLPqYOiKDRRf/FX0V/v9JPsRB1oraEyaHgPrWnbd\
-            PDDg18lzz9TTyI5C5TuVTs+cN61X0q4JGLUZCj+msqp616wPnAhRy9fyRC2kq5D4zQH\
-            KU3PrDLb/pKPRpIQdwcrddTKW21P7gYgQguv+UonssVvLZYF4zkKiMVH/Gnn1MmPe6A\
-            uxbIWOIf6C9g2e1ahnWGTQNbVrdruyR0ALdwBwecMZDYJRICmdPHq7gZajU76C5utiw\
-            fm55J6xqxiU961KWSwuJ5zSWGZLkVSh5eEnBG2aCxcOxnxoCEARdP8QWx7VAQ+2m5E4\
-            EkMozMR5962WdCUhDRUWAShC9okJGwOZMwkT8oc/hjo7t0V5LLQybfmB/Kez4CFhk7a\
-            xuGoTgxj0xuQrkgaRjGgtzzknkIJPWIBOc6ugdXPJDqPoSMyviBknykuqY07eAtMJbc\
-            kpayk3zew7mo2V7up8YDsxGxMJHAHHCwHFI2iiAoCC/6MtWA7ldo2DHO0zeR4ojk3F1\
-            2/2hPT4AveI3+XtBvb+as24WcdY6RfLrBoUq6N6V+Z2D3BdROfRdkt7Bxjg3zBdncD/\
-            Oi2xnO6EYhq0Y50oqjJ8mwrI9bBlmbSi6HIFYj6YAvIJJ3an87Q00Xy075DndI6Cgs7\
-            G//jFrputt1JvIhJaHkNvd8F+Sy80KbeOOCPjfwIUtu7XCVaF9og31Wsrsdqvhc5W8L\
-            wJygHHvcltHZMczbYjbfI2+L204lsLXa2mGC1S4T2+YsNK0D36KB7+6YrogvPqTgNwU\
-            vdpznllEy36vM1ITXhE/7uWXCC7ntQlC/RLrKg7wazt3Bab6E02qaelwqBFVIKsSODs\
-            JqxLUX+gxaWx+QLTGo+cpXCKoZ3Pa7vWaw+gym0wi63bHZ7QaSCJs72bu1hN6dJOJKJ\
-            bdA3kptBQf92qAdROLJMs4utCCz2ud7Y8zSR2yrgDkAfgAwwjEXeGxhl0rAPZItnS8h\
-            9xnAvwMYoQcLfacS0CdFmwX8iG3zkMngNOChsGEgiD88TWZKnBboRw1rGbDqgqrNaTm\
-            YjlvaWGYk1TCmljIoZm1pzhqoR8xvib3Im0RxV4Ad6JPQzRsiX4aSf4nkUTrXD31Wt1\
-            yMC7nzhONvcGQSJzbTzqyyvid3CBMfBPWAyex8v22jaVo1mrloTp1W/NrUBzVujVKnG\
-            ceQ6MFa7zqLWd0ToD2QpORqfc2lPpcho30KDh4IwkKXCOzQfr8sQNcEmvOujVvYpQyw\
-            C2NwscvZAEsQXtpTJ4jC0CgCxYBNv11zfXxcJ9PDE6gH4FFGsdlsY8V1Xp4oHgsjs9l\
-            Gt1nhBVrX691VTqhHXMLs/Q+AKpIbN/UL7q9NjSsYtJoG7rskGGKY+HokWk0DfY2aoC\
-            9rIjcVmGuNHXA58mBmkOwR6V4RpA11N1dNfioR64JIF6L47RD85h1yRelNRkO+gDGFR\
-            2xY2MjEjjlA4ziheptoKOaj821XF/hd5hwqgn2nwEzsVlnU+4JHsUFR1DUD41wLBwx0\
-            flStw3T1FxdUY1hXIPaIBnbascdK3bsa3NWh8CF71emq+QRHj06if/DFpNPDlAVShHZ\
-            eIvc6aYMuJp1PGxa9tMxuu/x1MFhWYx5KW5vJdilAWtYGRFrW65FcZ7ieM5XKHRKrpv\
-            6EFvOVM1oWaJ2n92f4jDO1gpX12hm1WykvMBhgwzetPra516MMnDVdqou4RxR9JlvvT\
-            FezRiOaKAr1JT7LLSrc3iuEFiNOpZ4DHiHVG10UW+an7w==\",\"Vl8blq7GFEejGi1\
-            WlZIKYJVyB0ztsWdmi20WoIvs+faB5a0YLTykg7yR/VQUqUQXkJ0Kbjg6UlyMUvYHOo\
-            7EUiEQTf0CwVl5KHrg0NDThFEt/EZxPDbHuF8e4/mmEQPzcpGRt8wu2RAS8ZxVdjqad\
-            z+X+pFQ6dLspgFH6g0L5DjPS4slsQxFT2vcg+5VktlYUq2xMmmiLUFYkSxRgZp9qywG\
-            W822NoWtZluTw5VaK1PzOSoSC6x1f+0Sz+Uth7vdsXL/yIJbE2c2HEHf4y1y0LsxJSj\
-            ZuPj0AYSEyfv1b+9MT8bW79FDYxrWBonL3U5D3e7Ov3HOclN6C2Kxgod0P6U5CLj3lA\
-            G7GA3p/tXo0783fxXF4ThZuDA/WrshId3GPClpuC7xCG41TXyhXX97l+p4j7TaL9xyr\
-            Rb13Z7e7Y/rF+LaLgUm76gDV5z16UDdAR4PrK645xNJo7Psol/P26RoWiXDL8r7eGw0\
-            84pjL0HSVbHAkm6jGqfDxmlNRksvlVViDmuLOQKdNNUBvldOXpx5Y7oO83r2GxTzXiS\
-            X61W/ONHok0BeKdXk7hjdsHmEbVzEnv6aS4HtKE6SM30++T8AAP//12d8ZDFmAAA=\"\
-            ]"
+          size: 3426
+          text: "[\"H4sIAAAJbogA/+xdX3PaOhZ/51NoeLp3NqK2CCHhaWlu281su+1usuns7NwHYQvQYCyvL\
+            dNkOv0=\",\"7jsyf4JBtiRsAgT5KYSjI1n++Xf+6Aj9bAAAQDPxxmSKH0mcUBY2e6D\
+            ptpzmxfy7mMzo8t9Oy2k5f/HJbPllFLMZ9UmcNHvgv5m8uH6u/hJXk/pCJQ75OGYR9Z\
+            oX+a99mkQBfv4HnhIh11/JrbT8uihXPaQx+cHiSaJQ/XElp616xNgoIAq9n+ZC2uNlE\
+            QkxVSj9GpGwf6evdEoTHuNAofXLQkpb7XcWT0ic9O8Uil/ktB/bfG6hLjDmswxk+Mi0\
+            /7nA5JT5JCgFZCbxLzLMwbLXQw66hK4DEer1vACnPoFt2IUJC0PCYYA5SbhiFm6zZqD\
+            d6oL7rNmmfNb1Ulq3Ew9HeEADyinJ39fyanpjvNlq8fLihIU0HL08lbWpWl5ND3MyYv\
+            GzuAXseWmMvecNdc2EY56K7sVfg+13glMSi29JyEkcxTTZkvBYyMkT/05Dn/1o9jZgL\
+            K7mFD/dhVHKH9iEhKKzy47jOBdSwa8pz0k6jpOTW2MNcTVJwukUc+J/Ec/gliVcPoY0\
+            pOKb5pSzycYtiKtJVwP8RsJw/kja0kGylG+Luh3FODOI3LJwSEf9IHigc3aVTNYwJkR\
+            6C5qzbTzritm/aBTIZ8/13wmJ889WzITTkIgvXuiShykuYXz2c/tuG0lRV3L/V8oG9d\
+            //2pt2LNNw7d4gYxhcG0xDQ/5pbXrq4HryxEnoEx/yMQ0ngj4NaR98WGgADwUaXtkQL\
+            Hw4yTecsSA5Etsh3uiLhiGAtemrgLZy/VmjYY3Gbkbjpm16++4uRgNVNJr7Nhrm03C1\
+            EwyOxmh0dgsQOkYBgqITtV0gPpUGCLvai9z//7zIfaw1nMj4ytoEaxNO0SbYQOIcAok\
+            2dK6g464ljViUqnKRy0wR+CqRlRsBoRWKJJWD0E3NJkCbzxkfk7jYv/dJFBPB/35Rfu\
+            i8fHxBTbqE3t0i9EqwlLkqY0wnaYETUQDQVgf8TbTSw2h5F2o/BaeceWwaBYRvRok7+\
+            TGG3koSEeLvGr2ematyrQ3sS8UobcbTZjxtxnP/Gc9tR2UsY/YiT8XADGR6575K2+m+\
+            shnQjk0VbK/2Zepi/O5JED7q6HoyLuo05G/32lu9O2xby3SIJnJtsmWVbHk9TJ+Ig14\
+            p4dKQjHh3WL9k+TLivELLGhwVM++K76JuTjqdaBF+xAg3om0jUC/y4yefHjmzIPKg9O\
+            uuZ+1Qy9VzhCWCMkhKxCryqvaay9GA8DT82mt9DKKtVEZD8tZUwKCmyZcIyjHoWAxaD\
+            G5gcFUu3evN3F4v4Tj2mE9iBfTuOY5vZXI55BVqU5NfLujXBtpRpGyRc3mtBTLUucqJ\
+            vaatRfoQq0ZyGwDzCYkSQiYwQxmcIRhQTuAAJ0TBdn8QEt0TMgGPCHymnID3kjY5+GH\
+            PY2nIk3cJS2OPjGIcjd9lEsk7g3FYsJ49WGdthSl+AWdbD5KrnrYAOWubA9DMHB9T3O\
+            yikwhNbrTp8qZWukymOOYQR1HwDP/3g4TQJ0OcBqqo+V40A33RDPzzBwnBH/JmeWut2\
+            ZeaDzNNWe+1mW7yFJGYTknIcbBvA66PyUzyYLR4NKBsowEUFARnrikw2+g9eHRLcVlm\
+            xueDiMY4IdBj0wENif8ypplrsWuxm8OuiCtE/WuiyaT9lLMPQh6sNoxqkanH/GeY/Qe\
+            KLuG8zxW7786tewmMjpNdD5oIcnUNvlunvV+H5yJAyeISPbPfX7YGK380C9LBIyq1/I\
+            a9HiggGhCOi+izpkLCE/FGjwabaUiHlPhwFOMwDXAMfToc7gukZW7AamizNgxoSGBAZ\
+            iSAAQtHkJN4uhqpn4icg0g3QALdqA==\",\"Y7F9ntie/97A3J8dkSkNKXRbHSjhkQ2\
+            O/ZQJA7fVAd9iVorYcr1qFq0n+T7AAQ69w2eaTqQGxNWvbNpag7SlrLaU1ZayvkIpq4\
+            S9UcuBwwAnY0ieIj0ORy0HfBRNwIeS+EdG6aWdVST2fVZMKbyQsyiXGhikfV1HSh9yc\
+            yDMVrVcRRms9dySFaSNUPx2EPzmN+UYotcAu6XDtLty7K4cuytnH7tySl0ZkfvTi0dX\
+            xA8/S9qU+zCyXtROjNmas8LzKOfttT3pFw1DKGkTybGxd1c7Dm1vQNWStyVvS94HJO8\
+            oZiIwhA6CTkcvnyj4WzOfqOzhiANQdTJSZylSlk19u4Zg14y4deGtC29d+MO48GItyS\
+            BtI1aTPsrEZY57oe6KvF9XDsZmETeyiNaTt5689eSP25NfnJgwJ/EpfRIf4PVTdwBpm\
+            PA49biCyb/M24Drp+77UhZf1bGsigGXxaxa3apJvtbEzOuR+Wnszes4ulze2RhkQ+Jz\
+            mQMSoR0QiVB1SCJUBZP1lLLYvcxGe5ld/X1TbsWNUzn6fKnGW8JnhhRYfSmzXqK2lmr\
+            AkIygE7lo+LI5oHhIahTb2us3VXs9P3pp8fuYIpMm4reIw0umYNZP3x4kQvlYTaqnIl\
+            HuMzOn3hRYvkZz+jk5EzcA6fsBrupNOoKgTm7PSpz5rcnfdnMk7+L+U2xd4zt5ixk28\
+            1nY//ETDfmnqkwNRUpM4QjP6VoqKeFsqdwRE3ellfW6HOIToW1XOxN3ZTnbcrbl7Jo5\
+            m7UzdoVjOhorshcLUSATzbH2QtCcsYtqVfdy1tl5LGubuNCuq+1CX16WD9N60PV50Ff\
+            Xx8dDB3Chd5gGx1E2qTgPDfmntfkpSdGV8fGU+DSdKvLJC2EgF36jnHxuDrIlZUvKlp\
+            QPS8quYmGPueXk62a/fA1dBN0djtuwbvFh3WKDQ8KuVAO1HGw52HLwDhycLd9BnsYDp\
+            qiyyJLL4EEmmXOJSzRWTC5r03Hl8oma1vjklKBDBa9KxI6jnaBobw20IRmyoR8gENNu\
+            dbRRKI5+0cNhodbXQmLlCuKzQqLBuRhVfw5+XsoO1w4PnUnPN9+UU5SibR1OBD5nx2m\
+            B32YUg0+ZsnePJObk6fdSFt0+HmmG/iqI23UQMkezWalk1V9SWlv2rQG7LnIOxqNGv0\
+            KgS6LVinkKILs6Hu4F03DwzCaKfRnlgO0vVYH3//n6d1PEnidc5Rs5X8PoHyFYv7N4Q\
+            uKkfzevNw8CPMWw3XLhtXZ1728rHb8DrfY5VGq1UHsDp8yfBoC8KT+nwwsoCfk99cl8\
+            k718AMLF69/dsmmEORWvXQ/8/HVmQF+UCcO1bRVw5rSQAdZ1VeTgrtvIIt4iviLiS5b\
+            ZFCgvkMoBuUCmbtyqi4F11s4OxtebQdBJ8WpjzYw2F7/7nQ00v3w2f6J5x1d4ltB1IF\
+            qP2bqFJxg3hzjht1I126d1sihN1tuKc5OEMQsIpyyUnBJRdtJTAwAAfjV+Nf4/ACwsC\
+            M90mgAA\"]"
         cookies: []
         headers:
           - name: date
-            value: Tue, 01 Apr 2025 16:20:12 GMT
+            value: Tue, 15 Apr 2025 13:48:17 GMT
           - name: content-type
             value: text/plain; charset=utf-8
-          - name: content-length
-            value: "1897"
+          - name: transfer-encoding
+            value: chunked
           - name: connection
             value: close
           - name: access-control-allow-credentials
@@ -1382,13 +1396,13 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1267
+        headersSize: 1273
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-04-01T16:20:12.349Z
-      time: 283
+      startedDateTime: 2025-04-15T13:48:16.794Z
+      time: 326
       timings:
         blocked: -1
         connect: -1
@@ -1396,6 +1410,6 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 283
+        wait: 326
   pages: []
   version: "1.2"

--- a/jetbrains/src/integrationTest/resources/recordings/autocomplete_2136217965/recording.har.yaml
+++ b/jetbrains/src/integrationTest/resources/recordings/autocomplete_2136217965/recording.har.yaml
@@ -37,7 +37,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 01 Apr 2025 16:20:08 GMT
+            value: Tue, 15 Apr 2025 13:48:11 GMT
           - name: content-type
             value: application/json
           - name: content-length
@@ -56,13 +56,13 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1218
+        headersSize: 1266
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-04-01T16:20:08.465Z
-      time: 236
+      startedDateTime: 2025-04-15T13:48:11.160Z
+      time: 262
       timings:
         blocked: -1
         connect: -1
@@ -70,7 +70,76 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 236
+        wait: 262
+    - _id: 6e977d3842ddb417bf941a0f568426d9
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 20
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: authorization
+            value: token
+              REDACTED_fc324d3667e841181b0779375f26dedc911d26b303d23b29b1a2d7ee63dc77eb
+          - name: user-agent
+            value: OTel-OTLP-Exporter-JavaScript/0.45.1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 253
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            resourceSpans: []
+        queryString: []
+        url: https://sourcegraph.com/-/debug/otlp/v1/traces
+      response:
+        bodySize: 21
+        content:
+          mimeType: application/json
+          size: 21
+          text: "{\"partialSuccess\":{}}"
+        cookies: []
+        headers:
+          - name: date
+            value: Tue, 15 Apr 2025 13:48:11 GMT
+          - name: content-type
+            value: application/json
+          - name: content-length
+            value: "21"
+          - name: connection
+            value: keep-alive
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1266
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2025-04-15T13:48:11.203Z
+      time: 282
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 282
     - _id: 897d3731ab8e15a1549f29445eafd1e1
       _order: 0
       cache: {}
@@ -90,7 +159,7 @@ log:
             value: application/json; charset=utf-8
           - _fromType: array
             name: user-agent
-            value: jetbrains/6.0-localbuild (Node.js v20.12.2)
+            value: jetbrains/6.0-localbuild (Node.js v22.14.0)
           - _fromType: array
             name: x-requested-with
             value: jetbrains 6.0-localbuild
@@ -117,7 +186,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 01 Apr 2025 16:20:03 GMT
+            value: Tue, 15 Apr 2025 13:48:06 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: transfer-encoding
@@ -143,13 +212,13 @@ log:
             value: max-age=31536000; includeSubDomains; preload
           - name: content-encoding
             value: gzip
-        headersSize: 1358
+        headersSize: 1406
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-04-01T16:20:03.149Z
-      time: 297
+      startedDateTime: 2025-04-15T13:48:05.864Z
+      time: 281
       timings:
         blocked: -1
         connect: -1
@@ -157,7 +226,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 297
+        wait: 281
     - _id: 7fe6e3115a056381182831bdd6bf2007
       _order: 0
       cache: {}
@@ -180,7 +249,7 @@ log:
             value: application/json; charset=utf-8
           - _fromType: array
             name: user-agent
-            value: jetbrains/6.0-localbuild (Node.js v20.12.2)
+            value: jetbrains/6.0-localbuild (Node.js v22.14.0)
           - _fromType: array
             name: x-requested-with
             value: jetbrains 6.0-localbuild
@@ -231,10 +300,10 @@ log:
             value: 6.0-localbuild
         url: https://sourcegraph.com/.api/completions/code?client-name=jetbrains&client-version=6.0-localbuild
       response:
-        bodySize: 249
+        bodySize: 196
         content:
           mimeType: text/event-stream
-          size: 249
+          size: 196
           text: |+
             event: completion
             data: {"completion":"x in list) {","stopReason":"stop"}
@@ -245,7 +314,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 01 Apr 2025 16:20:06 GMT
+            value: Tue, 15 Apr 2025 13:48:09 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -269,13 +338,13 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1315
+        headersSize: 1363
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-04-01T16:20:05.447Z
-      time: 651
+      startedDateTime: 2025-04-15T13:48:08.530Z
+      time: 641
       timings:
         blocked: -1
         connect: -1
@@ -283,7 +352,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 651
+        wait: 641
     - _id: 84ab639f870b7d4bbc24f8001ccdb201
       _order: 0
       cache: {}
@@ -306,7 +375,7 @@ log:
             value: application/json; charset=utf-8
           - _fromType: array
             name: user-agent
-            value: jetbrains/6.0-localbuild (Node.js v20.12.2)
+            value: jetbrains/6.0-localbuild (Node.js v22.14.0)
           - _fromType: array
             name: x-requested-with
             value: jetbrains 6.0-localbuild
@@ -365,21 +434,24 @@ log:
             value: 6.0-localbuild
         url: https://sourcegraph.com/.api/completions/code?client-name=jetbrains&client-version=6.0-localbuild
       response:
-        bodySize: 208
+        bodySize: 352
         content:
           mimeType: text/event-stream
-          size: 208
-          text: |+
+          size: 352
+          text: >+
             event: completion
-            data: {"completion":"the result vector","stopReason":"stop"}
+
+            data: {"completion":"the result vector\n    // todo: print the result vector","stopReason":"stop"}
+
 
             event: done
+
             data: {}
 
         cookies: []
         headers:
           - name: date
-            value: Tue, 01 Apr 2025 16:20:07 GMT
+            value: Tue, 15 Apr 2025 13:48:10 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -403,13 +475,13 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1315
+        headersSize: 1363
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-04-01T16:20:06.761Z
-      time: 657
+      startedDateTime: 2025-04-15T13:48:09.368Z
+      time: 849
       timings:
         blocked: -1
         connect: -1
@@ -417,7 +489,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 657
+        wait: 849
     - _id: 7bf892c6e90add7f738e1eccbc33540b
       _order: 0
       cache: {}
@@ -440,7 +512,7 @@ log:
             value: application/json; charset=utf-8
           - _fromType: array
             name: user-agent
-            value: jetbrains/6.0-localbuild (Node.js v20.12.2)
+            value: jetbrains/6.0-localbuild (Node.js v22.14.0)
           - _fromType: array
             name: x-requested-with
             value: jetbrains 6.0-localbuild
@@ -512,10 +584,10 @@ log:
             value: 6.0-localbuild
         url: https://sourcegraph.com/.api/completions/code?client-name=jetbrains&client-version=6.0-localbuild
       response:
-        bodySize: 377
+        bodySize: 308
         content:
           mimeType: text/event-stream
-          size: 377
+          size: 308
           text: >+
             event: completion
 
@@ -529,7 +601,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 01 Apr 2025 16:20:08 GMT
+            value: Tue, 15 Apr 2025 13:48:11 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -553,13 +625,13 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1315
+        headersSize: 1363
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-04-01T16:20:07.665Z
-      time: 760
+      startedDateTime: 2025-04-15T13:48:10.663Z
+      time: 766
       timings:
         blocked: -1
         connect: -1
@@ -567,7 +639,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 760
+        wait: 766
     - _id: f1b1cde4cd57488b7f0137954f0302f5
       _order: 0
       cache: {}
@@ -587,7 +659,7 @@ log:
             value: application/json; charset=utf-8
           - _fromType: array
             name: user-agent
-            value: jetbrains/6.0-localbuild (Node.js v20.12.2)
+            value: jetbrains/6.0-localbuild (Node.js v22.14.0)
           - _fromType: array
             name: x-requested-with
             value: jetbrains 6.0-localbuild
@@ -625,7 +697,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 01 Apr 2025 16:20:05 GMT
+            value: Tue, 15 Apr 2025 13:48:08 GMT
           - name: content-type
             value: application/json
           - name: content-length
@@ -649,13 +721,13 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1317
+        headersSize: 1365
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-04-01T16:20:04.706Z
-      time: 309
+      startedDateTime: 2025-04-15T13:48:07.761Z
+      time: 257
       timings:
         blocked: -1
         connect: -1
@@ -663,7 +735,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 309
+        wait: 257
     - _id: a376faab1c8a1993bb48c745757f0a4a
       _order: 0
       cache: {}
@@ -683,7 +755,7 @@ log:
             value: application/json; charset=utf-8
           - _fromType: array
             name: user-agent
-            value: jetbrains/6.0-localbuild (Node.js v20.12.2)
+            value: jetbrains/6.0-localbuild (Node.js v22.14.0)
           - _fromType: array
             name: x-requested-with
             value: jetbrains 6.0-localbuild
@@ -744,7 +816,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 01 Apr 2025 16:20:04 GMT
+            value: Tue, 15 Apr 2025 13:48:07 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -770,13 +842,13 @@ log:
             value: max-age=31536000; includeSubDomains; preload
           - name: content-encoding
             value: gzip
-        headersSize: 1349
+        headersSize: 1397
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-04-01T16:20:04.043Z
-      time: 317
+      startedDateTime: 2025-04-15T13:48:07.025Z
+      time: 386
       timings:
         blocked: -1
         connect: -1
@@ -784,7 +856,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 317
+        wait: 386
     - _id: 0484c4d780805faf3dd3ddabae814640
       _order: 0
       cache: {}
@@ -804,7 +876,7 @@ log:
             value: application/json; charset=utf-8
           - _fromType: array
             name: user-agent
-            value: jetbrains/6.0-localbuild (Node.js v20.12.2)
+            value: jetbrains/6.0-localbuild (Node.js v22.14.0)
           - _fromType: array
             name: x-requested-with
             value: jetbrains 6.0-localbuild
@@ -853,7 +925,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 01 Apr 2025 16:20:04 GMT
+            value: Tue, 15 Apr 2025 13:48:07 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -879,13 +951,13 @@ log:
             value: max-age=31536000; includeSubDomains; preload
           - name: content-encoding
             value: gzip
-        headersSize: 1349
+        headersSize: 1397
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-04-01T16:20:04.111Z
-      time: 253
+      startedDateTime: 2025-04-15T13:48:07.083Z
+      time: 384
       timings:
         blocked: -1
         connect: -1
@@ -893,7 +965,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 253
+        wait: 384
     - _id: e141c56e63809042300db9bf8551d492
       _order: 0
       cache: {}
@@ -913,7 +985,7 @@ log:
             value: application/json; charset=utf-8
           - _fromType: array
             name: user-agent
-            value: jetbrains/6.0-localbuild (Node.js v20.12.2)
+            value: jetbrains/6.0-localbuild (Node.js v22.14.0)
           - _fromType: array
             name: x-requested-with
             value: jetbrains 6.0-localbuild
@@ -947,22 +1019,17 @@ log:
             value: null
         url: https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmProvider
       response:
-        bodySize: 128
+        bodySize: 131
         content:
           encoding: base64
           mimeType: application/json
-          size: 128
+          size: 131
           text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eSDxgqL8s\
-            syU1CIlK6Xi/NKi5NT0osSCDKXa2tpaAAAAAP//AwAfFAXARQAAAA==\"]"
-          textDecoded:
-            data:
-              site:
-                codyLLMConfiguration:
-                  provider: sourcegraph
+            syU1CIlK6Xi/NKi5NT0osSCDKXa2tpaAAAAAP//\",\"AwAfFAXARQAAAA==\"]"
         cookies: []
         headers:
           - name: date
-            value: Tue, 01 Apr 2025 16:20:04 GMT
+            value: Tue, 15 Apr 2025 13:48:07 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -988,13 +1055,13 @@ log:
             value: max-age=31536000; includeSubDomains; preload
           - name: content-encoding
             value: gzip
-        headersSize: 1349
+        headersSize: 1397
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-04-01T16:20:04.085Z
-      time: 273
+      startedDateTime: 2025-04-15T13:48:07.054Z
+      time: 360
       timings:
         blocked: -1
         connect: -1
@@ -1002,7 +1069,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 273
+        wait: 360
     - _id: 5b9030a4e18d1e000c71d6000a7cef6f
       _order: 0
       cache: {}
@@ -1022,7 +1089,7 @@ log:
             value: application/json; charset=utf-8
           - _fromType: array
             name: user-agent
-            value: jetbrains/6.0-localbuild (Node.js v20.12.2)
+            value: jetbrains/6.0-localbuild (Node.js v22.14.0)
           - _fromType: array
             name: x-requested-with
             value: jetbrains 6.0-localbuild
@@ -1093,7 +1160,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 01 Apr 2025 16:20:03 GMT
+            value: Tue, 15 Apr 2025 13:48:05 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -1119,13 +1186,13 @@ log:
             value: max-age=31536000; includeSubDomains; preload
           - name: content-encoding
             value: gzip
-        headersSize: 1349
+        headersSize: 1397
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-04-01T16:20:02.875Z
-      time: 255
+      startedDateTime: 2025-04-15T13:48:04.251Z
+      time: 1587
       timings:
         blocked: -1
         connect: -1
@@ -1133,7 +1200,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 255
+        wait: 1587
     - _id: aef0c9fe7483280d9c05ac8e97e37571
       _order: 0
       cache: {}
@@ -1153,7 +1220,7 @@ log:
             value: application/json; charset=utf-8
           - _fromType: array
             name: user-agent
-            value: jetbrains/6.0-localbuild (Node.js v20.12.2)
+            value: jetbrains/6.0-localbuild (Node.js v22.14.0)
           - _fromType: array
             name: x-requested-with
             value: jetbrains 6.0-localbuild
@@ -1196,23 +1263,23 @@ log:
           encoding: base64
           mimeType: application/json
           size: 224
-          text: "[\"H4sIAAAAAAAAA1zMsQrCMBSF4Xc5c4U2rUu2Ih0EwdJWB7fYZAjUJNzcDKXk3UVBUMfz8\
+          text: "[\"H4sIAAAAAAAAA1zMsQrCMBSF4Xc5c4U2tku2Ih0EwdJWB7fYZAjUJNzcDKXk3UVBUMfz8\
             3E2aMUKcsOciIzjSzT0nl6vY7rHmWxg692rRVacIiTaw3S8digQFuUg0Q9nFFAhLGtP\
-            flBsTvZhOUIyJVN8vntD1uuRFXHLkBCl2O/Kelc1kxCyqmQtbvjTndNftvm1Oef8BAA\
-            A//8DAPWiQezCAAAA\"]"
+            flBsTvZhOUIyJVN8vntD1uuRFXHLkBClaHZlvavqSQhZVXIvbvjTndNftvm1Oef8BAA\
+            A//8DAPgwylPCAAAA\"]"
           textDecoded:
             data:
               currentUser:
                 codySubscription:
                   applyProRateLimits: true
-                  currentPeriodEndAt: 2025-04-14T22:11:32Z
-                  currentPeriodStartAt: 2025-03-14T22:11:32Z
+                  currentPeriodEndAt: 2025-05-14T22:11:32Z
+                  currentPeriodStartAt: 2025-04-14T22:11:32Z
                   plan: PRO
                   status: ACTIVE
         cookies: []
         headers:
           - name: date
-            value: Tue, 01 Apr 2025 16:20:04 GMT
+            value: Tue, 15 Apr 2025 13:48:07 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -1238,13 +1305,13 @@ log:
             value: max-age=31536000; includeSubDomains; preload
           - name: content-encoding
             value: gzip
-        headersSize: 1349
+        headersSize: 1397
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-04-01T16:20:04.155Z
-      time: 359
+      startedDateTime: 2025-04-15T13:48:07.116Z
+      time: 510
       timings:
         blocked: -1
         connect: -1
@@ -1252,7 +1319,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 359
+        wait: 510
     - _id: 4504fab53d7cb602861f73dc2aa883d2
       _order: 0
       cache: {}
@@ -1272,7 +1339,7 @@ log:
             value: application/json; charset=utf-8
           - _fromType: array
             name: user-agent
-            value: jetbrains/6.0-localbuild (Node.js v20.12.2)
+            value: jetbrains/6.0-localbuild (Node.js v22.14.0)
           - _fromType: array
             name: x-requested-with
             value: jetbrains 6.0-localbuild
@@ -1304,18 +1371,21 @@ log:
             value: null
         url: https://sourcegraph.com/.api/graphql?SiteProductVersion
       response:
-        bodySize: 143
+        bodySize: 136
         content:
           encoding: base64
           mimeType: application/json
-          size: 143
-          text: "[\"H4sIAAAAAAAAAwAAAP//\",\"qlZKSSxJVLKqVirOLEkF0QVF+SmlySVhqUXFmfl5SlZK\
-            xoaWpuZm8UYGRqa6Bsa6xobxZnqGukmWhhbGpuampsaGaUq1tbUAAAAA//8DAO3ZfHp\
-            JAAAA\"]"
+          size: 136
+          text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSsZGRiZGRvFGB\
+            kamugYmuoYm8WZ6RromxpaGJqmmFkkGBsZKtbW1AAAAAP//AwCB0HjwSQAAAA==\"]"
+          textDecoded:
+            data:
+              site:
+                productVersion: 322422_2025-04-14_6.2-43914e58b003
         cookies: []
         headers:
           - name: date
-            value: Tue, 01 Apr 2025 16:20:04 GMT
+            value: Tue, 15 Apr 2025 13:48:07 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -1341,13 +1411,13 @@ log:
             value: max-age=31536000; includeSubDomains; preload
           - name: content-encoding
             value: gzip
-        headersSize: 1349
+        headersSize: 1397
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-04-01T16:20:04.131Z
-      time: 253
+      startedDateTime: 2025-04-15T13:48:06.988Z
+      time: 430
       timings:
         blocked: -1
         connect: -1
@@ -1355,7 +1425,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 253
+        wait: 430
     - _id: fd0fee4687419870bc82cba9d1023319
       _order: 0
       cache: {}
@@ -1375,7 +1445,7 @@ log:
             value: application/json; charset=utf-8
           - _fromType: array
             name: user-agent
-            value: jetbrains/6.0-localbuild (Node.js v20.12.2)
+            value: jetbrains/6.0-localbuild (Node.js v22.14.0)
           - _fromType: array
             name: x-requested-with
             value: jetbrains 6.0-localbuild
@@ -1407,28 +1477,23 @@ log:
             value: null
         url: https://sourcegraph.com/.api/graphql?ViewerSettings
       response:
-        bodySize: 280
+        bodySize: 192
         content:
           encoding: base64
           mimeType: application/json
-          size: 280
-          text: "[\"H4sIAAAAAAAAA4zPwUoDQRAE0H/pc75gbyoGAwrikttcOkk529D2LD292cRl/l0WAsGD4\
-            LXqUVALnTiYuoXOghneI0Is1zX5FGOljpZEuIxw+YIF6xYck6Mm6tbG+KB45e/ro5ZD\
-            f7Xgy4vkQSUP61KiLnzCJpFh7sF+HD5QJ42taMDrOxv0T1T3u3s3euFjyBm/xEPOjsw\
-            hxerd1n+Qocxvk4ao2G3yqVgtiptpm0RlhO3s+SRRfD3cGrXWfgAAAP//AwDHP3NmNg\
-            EAAA==\"]"
+          size: 192
+          text: "[\"H4sIAAAAAAAAA2SMwQrCQAwF/yXnfsHeLfQmFm97CfapgTUt2awVlvy7FLx5nRmm08LOl\
+            Dq9BTtshrvoox7kLsqFEvVM+GwweUGdywj2ZqiZUs+k2Gew3Z4X1FZ8lOKwemZFyZTc\
+            Goa/qF6nn4sh07pBJz0t4qsdzwiKiC8AAAD//wMAV+4vNJkAAAA=\"]"
           textDecoded:
             data:
               viewerSettings:
-                final: "{\"experimentalFeatures\":{\"enableLazyBlobSyntaxHighlighting\":true,\"\
-                  newSearchResultFiltersPanel\":true,\"newSearchResultsUI\":tru\
-                  e,\"proactiveSearchResultsAggregations\":true,\"searchResults\
-                  Aggregations\":true,\"showMultilineSearchConsole\":true},\"op\
-                  enInEditor\":{}}"
+                final: "{\"experimentalFeatures\":{\"newSearchResultFiltersPanel\":true,\"newSe\
+                  archResultsUI\":true},\"openInEditor\":{}}"
         cookies: []
         headers:
           - name: date
-            value: Tue, 01 Apr 2025 16:20:05 GMT
+            value: Tue, 15 Apr 2025 13:48:08 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -1454,13 +1519,13 @@ log:
             value: max-age=31536000; includeSubDomains; preload
           - name: content-encoding
             value: gzip
-        headersSize: 1349
+        headersSize: 1397
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-04-01T16:20:04.663Z
-      time: 374
+      startedDateTime: 2025-04-15T13:48:07.731Z
+      time: 292
       timings:
         blocked: -1
         connect: -1
@@ -1468,7 +1533,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 374
+        wait: 292
     - _id: fbb23499ae0eec5c2e188687b429531b
       _order: 0
       cache: {}
@@ -1482,7 +1547,7 @@ log:
               REDACTED_fc324d3667e841181b0779375f26dedc911d26b303d23b29b1a2d7ee63dc77eb
           - _fromType: array
             name: user-agent
-            value: jetbrains/6.0-localbuild (Node.js v20.12.2)
+            value: jetbrains/6.0-localbuild (Node.js v22.14.0)
           - _fromType: array
             name: x-requested-with
             value: jetbrains 6.0-localbuild
@@ -1500,60 +1565,62 @@ log:
         queryString: []
         url: https://sourcegraph.com/.api/modelconfig/supported-models.json
       response:
-        bodySize: 2987
+        bodySize: 3127
         content:
           encoding: base64
           mimeType: text/plain; charset=utf-8
-          size: 2987
-          text: "[\"H4sIAAAJbogA/+xd33ObOhZ+569geN3IBRHHid/S3LZ7Z2633W22+7BzH2Q4tjXBiAXhO\
-            nOn//uOsE2MLSNhbAc34ikORz8QH98555MEf1m2bdtOFkxhRr5DmlEWO0Pb8Xquc7U8\
-            l8Kcrv/t9tye+7cQ5uuTScrmNIQ0c4b2fwt7cfxV/iUOh4aiShLzacoSGjhX1dMhzZK\
-            IPP+DzEDY3Zd2ZS0/r+qrHtMUfrD0KVNU/bG00656wtgkAkW9n5ZG2v1lCcSEKir9kk\
-            B8/7t+pTOa8ZREilo/r6xeqi3++nN1P2cshKj2ZhYW/4Jx5ZYOh9jF18hzEcbDYRCRP\
-            ATkowHKWBwDRxHhkHFF1x6KYrbfG9jfimLb9kXTa2vdRgKSkBGNKKdQva714QRTsl1K\
-            HM4K9pIznLEoexnCjQFcH05AOExY+iwujARBnpLgeasqJ+OE56JT4q/RLso4hVScHae\
-            wcy5gMYcF/w+NQ/bDGW5BQhzOjCx+j5OcP7IniEUz133Xda+khl9yXrF0Xbdit/EEis\
-            OBjNMZ4RB+FvfkgWVc3oc8puKMM+PsaesSxOHQsoNfIY6Xt8iXdpLlfNfU6yv6WUDmg\
-            cVjOrmPoke6ZCrJYBVjLLsEzdFuPOqK0b+y9tgX9/XfGaTVeytGwrUk5qsHvOZmikMQ\
-            +Wku3/OxFHU113+jLHD864eYQ5qkNIPODMOtd4cbw+C2wTBY8l8bw1N9HA7jflhwiEM\
-            IEZ/S+InGE4X/33ED9odVDfbjnho65hgkRVIgGYvFxVfO/XlV+XlUryGeaOM0jNO4RK\
-            dx5ze9fO8Qp4FbOs1TO43mw3BzEAw64zT6hyUM/UYJg6IRtV+AkEoTBpNImETCJBImk\
-            TCJxOGJhI/cG+R6GyISS3KVrrdOGewvElu5ExC1IpG4uBjfHdkFaIf4jE8h3a8KhZCk\
-            IFKCcJ8y9LZifBGu6gb5g50g35JEsq1ClSmhT/meIGIPQHt9+++ilB5G65tQxykk5yx\
-            gsyQCvu32D4pjGkYrWQIQGs1TS/O81Qb29TaujeJpFE+jeJ5d8dwNVKYyZt8XqTRwA0\
-            W9y1jFdwdndgPacqWC7dWxzLEYfyB9+PZkR1bNU3LSSS7c141kPNy35E/3xlN9OGx7a\
-            zlEE7lGbCnFlvNh+kKimFYzt5akx4fD+kXlK4jzBq/Xs6iY+VB872vmouVEg/AOI7wR\
-            bTcC9Uofv3h55I0lka9Kv96maod7nl4gLDGUQVJi1pJXtafhOwPCy4hrb/UxiHekDEv\
-            y1LTAoKbLlxjKMegaDBoMbmGwXHo8HM694TDjJA1YCKkCet84SR9kdhXk7a1NTX6VpF\
-            8baJ2QbLF7fasFMty/qZid09difYi1I7ktgIUASQbwhAqUoTlGEeWARiQDBdv9BpB8A\
-            3iyv2P7D8rBfi8pU4EfCQKWxzx7l7E8DWCSkmT6rrDI3jXohwHrmwfr3NcGp68HybKl\
-            HUDO/eYAbOaOu5Q3e/giUpM7bbq8OypdZjOSckSSJHpG//sBMQphTPJIlTV/E8Xse1H\
-            M/ucPiO3f5MWq3lqzLTUfFjUVrR/NdcMigZTOIOYkOrUD18dkYflqtNgZUPp4hAQFob\
-            nXFJg+fm9/92pxWefGl51IpiQDFLDZiMYQvvRp7hnsGuxWsCvyCrH+NdNk0vucsw/C3\
-            i43X2qRacDCZ1T8B4km0bLNkt0P59aTJEbdZNdXFYI8XYfvHdPfb8JzlaAUeYme279f\
-            l7bLZKlI0u3vuNbzN2z1lRKiEXCyjz6PtJDwQqLRzmAzj+mYQogmKYnziKQopOPxqUA=\
-            \",\"WhcGlF2b+yiiMaAI5hChiMUTxCGdlT0NM6E5CLkBAfKSvsH228T28r0Iy3h2Aj\
-            MaU+T1+kjCI1sc+6kwtr1e3/6aslrE1terZtHjiO8jEpE4eH2l6ULWgHj6K5t25iDNU\
-            lazlNUsZT3DUlYJe+Oei8YRyaYIFokeh+Oea38URewPNfmPjNJrG2tJ7KdcMaWIQt7E\
-            cqlRA9nXc6X0IXcHwm210yrqYK0XlpSQboTiXwfBv/ymnIbobYDd2m6a7cNm+7DZPny\
-            K7cO1oYzQ/vTy0ZL40R+SMvUxjKyVkwUxhulPwPQD7ZzVV/TSEL0hekP0ZyT6JGUiiU\
-            QuRm5fT3sUXK+pPSpb6HCyqhYudaYtZcqrEpbapNS5kF/XD2zNDBkvYLyA8QKv4wXEv\
-            FMDiUfMPH2UmcuC/L11t+T9Y+k1RnHcUhxNJG8ieRPJdzuSX32pYEniM7oQP9DtYjBC\
-            NM54mgdcweSfl2Xs28XgfS2Ll2teyoWD64WvWs2qSb7ZxoHOkPll7OPru7pc3t/qpCW\
-            JuWqCij2AxPgARGLcHpIYt8HkcZa9mH3PjfY9e/p7rLyWm6wqaH1ZubeGzxwrsPqyJH\
-            uN2qOsHIxhgtzEw+OXjQT7u6RGsVmn/Uut015+8mj1nSChpIn8LeHomimY9dPXR4lRN\
-            VeT1tOSKE+pzKk3ENbPw1++JtckDMD6cYCnepI6kNTJ/VlNML8z+LthjuRZPL3ENmh8\
-            Jb+iwtZ8FE7/qQpL/qstUyMhiSkC4SVdSy0lnC216zBxKxK4etY+VkB8IbTtaStxN4a\
-            zDWcbzj4yZzO/YFc0g5DmM4V+sTK25cYV5l6ZNmftfWtbT/JttHPuyL0UQva04+jra0\
-            PJ56Lkm1spemqu5PRk9Apx9AHD4LrKIi3HwZL/2hifGp1OSsqeQkhmXj35esVbWZGHk\
-            XfAq+A7R8FvS8lo8gGbm22YGg42HGw4+AgcXMjFiOfpiClm9Qoxw36UWe6KGfIaW4oZ\
-            2nTcerruSEwsD8t0wrGzErGrT8T+TkctSZcPwKDf62ujUHyWQA+He2s9FxJbL3J4U0h\
-            s8M72mlcVWxuz+c7qXUdFBlldsra8k+pvLsq+CeOMScYf9MrvfApJvM4LHpYvNKIslr\
-            wTr+69tpZt2/ZP66f1/wEAdvMbd66GAAA=\"]"
+          size: 3127
+          text: "[\"H4sIAAAJbogA/+xdS3OjOhbe+1dQbCdyg4jjxLt0bnfPrbo93TOd6VlM3YUMx7YqGDEgn\
+            KRu9X+fEraJsWUkDHZwIlZxOHogPr7z0uOvnmVZlp36M5iTn5CklEX2yLLdvmNfLO8l\
+            sKDrfzt9p+/8LYDF+macsAUNIEntkfXfXF5cfxV/icumgaiSRHyWsJj69kX5dkDTOCT\
+            P/yBzEHK3hVxRy6+L6qonNIFHljykiqo/F3LaVU8Zm4agqPfLUki7vyyGiFBFpd9iiG\
+            5/1690TlOekFBR69eV1Eu1+V9/rt7nnAUQVr7MXOJfMCm90tEIO/gSuQ7CeDTyQ5IFg\
+            Dw0RCmLIuAoJBxSrujaXV7M8vpD60debFs+b3otrduIT2IypiHlFMrPtb5sf0a2S4nL\
+            XsFecoczFqYvQ7gxgOvL9gmHKUuexYMR388S4j9vVWWnnPBMdEr8Nd5FGaeQiLuTBHb\
+            u+Szi8MT/Q6OAPdqjLUiIy56Tp9+jOOP37AEi0czlwHGcC6ngt4yXJB3HKcltfIHisi\
+            HldE44BF/FO7ljKZf3IYuouGPPOXvYegRx2bTo4HeIouUr8qSdZBnfFXUHin7mkLlj0\
+            YROb8Pwni6ZSjJY+RjLHkFztGuPumL0L3p75PP3+u8UkvK7FSPh9CTiqw+84mWKSxD5\
+            cR7f9bAUdRXPf6Us0P7zQ8QhiROaQmeG4dq9wbVhcF1jGHryXxvDU/4cDuN+eOIQBRA\
+            gPqPRA42mCv2/owasT6sarPs9NXRMMUiKJEBSFomHL93786L0s1WtIb5oozSM0jhHpX\
+            Hj1X189xClgRsqzWMrjfrDcHUQDDqjNAaHOQyDWg6DohG1XoCASh0G40gYR8I4EsaRM\
+            I7E4Y6Eh5wr5LgbQSQWZ6q43tplsL5JZOVKQNSKhOPiYHzTsgrQNvEZn0GyPyoUQJyA\
+            cAmCfZGh92XjC3NV18gf7hj5PYkl28hUmRH6kO0xIvYAtD+w/i5K6WG0ugm1nUIyznw\
+            2j0Pg22r/IDumprWSxgCBiXlqxTyvtYF9uY1rE/E0EU8T8Tx5xHPXUJnJmH2fpVJDDe\
+            T1Lm0VzxmeWA1ohysVbK+2Zdpi/KH049vjHfUqvpKjJrnwQNeScfGgJ/+6N77qw2HbX\
+            4dDNJFrgi1FsOV0mD4TK6ZR5rYn6fHhsH6J8uXEeYXX81lUzHwovvc1c9bhRIPwDiO8\
+            Fm3XAvUqPn724ZF35kS+Kv26m1E73Hf1DGGJoAySErGGvKqdhu8MCM/Drr3WxyDeCWX\
+            0JF9NAwxqqnyJoByDjsGgweAWBoupx6PRwh2NUk4SnwWQKKD3g5PkTiZXQt7e2tTkV3\
+            L6tYHWiZAtdi6vtUCGB1clsVPqWqwPsWYktwWwACBOAR5QjjK0wCikHNCYpKBgu98A4\
+            h8AD9ZPbP1BOVgfJWVK8CO+z7KIpx9SliU+TBMSzz7kEumHGv0wYH33YF142uD09CBZ\
+            tLQDyIVXH4D11HGX/GYXn4VrcqNNlzet0mU6JwlHJI7DZ/S/R4hQABOShSqv+YcoZt2\
+            KYtY/HyGyfpMXK2trzbbUfJjXlLfemuqGpxgSOoeIk/DYClwfk7nkq9FiZ0Dp4TESFI\
+            QWbl1gevij9dOtxGWVGl92Ip6RFJDP5mMaQfDSp4VrsGuwW8Ku8CvE/NdUk0lvM84+C\
+            XmrWHypRaY+C55R/h8kmkTLNgt2P5xbj+IYdZNdXzUQ5OoqfLdNfb8Jz5WDkvslemr/\
+            dl0=\",\"2iqcpdxJt37iSs1fs9VXcojGwMk++mxpIuGZWKOdwWYW0QmFAE0TEmUhSV\
+            BAJ5NjgbTKDCi6tvBQSCNAISwgRCGLpohDMi96GqQi5iDCDQiQGw8Mtt8ntpf7Iizt2\
+            SnMaUSR2x8gCY9sceyXXNhy+wPre8IqEVtdr5pF2wm+j0lIIh8CkyXXzpK7+rObdvKQ\
+            Zjqrmc5qprOeYDrrfgZHjoOPxeKyurvD5GZNwsaaBMPihsUNi58fi+O+gyYhSWcInmI\
+            9Hsd9x/osilifKiJZMlqvbKwhsR9z7qvCn3wXJv24RgLPdaT0ITfqhdpqFnWWGCcF0v\
+            QczALStVD8dhD85k2Zmuitgd3KbpqNIMxGEGYjiGNsBFHF+Xk+RS+yWBA/+kNSptqGk\
+            bVyNCPGMP0RmH6o7bN6il4aojdEb4j+hEQfJ0w4kcjByBnoZZEE12tmkZQtdNhZbSMF\
+            JcugKUGpTUmdM/h1tcBWht/oAKMDjA54LR2wzD7FCSwoPCLHQ1hbD+SzCazvy6J6Rr9\
+            Ga2etE3QmJZ6/VqgzabZGRgsPjHdgvAPjHXTCOxBzB6Th+f1zyz7LxGXBn711N+T+tu\
+            L4JhO1lYkyER4T4TERnrOL8BQ8W292WX0ef80ZZobLDZcbLjdc/pa4fHWu5NIgn9Mn8\
+            QNdPw3HiEYpTzKfK6zyr8sy1vXT8GOlRV6sUCqWea6XKWs1qyb5ets8dIbMz2PXpYGj\
+            a5dvh1Z6ku+1PiAxPgCRGDeHJMZNMNmO4WF2qau1S52rvyOO23BLnBJ9vqyzXMNnoVp\
+            p8bKAfo3aVtZ5RjBFTuziycu2D/u7pEaxWVX/plbVLw+oXp3qLLLlIhYXc3TJFGj98v\
+            1eIlSOu0nraUiUx8y0qLd7qp5r+75yLFjfDnBVX1IHAnRyfVYRmNkZ/F0zR/ItHt89G\
+            9Z+krfondUfheMfLNqT/2rK1EiExRTGxZKupZISzpbKdZi4FQ5cNWu3ZRCfCW272pG4\
+            K8PZhrMNZ7fM2czL2RXNIaDZXOETroQtuXCJuVei9Vl73/q1o5xkf8r9086FkF1tO/r\
+            y0lDyqSj56lqKnoonOT4ZvYIdfcAwOI6ySMNx6Ml/bYxPRZxOSsquIjjH3GrydfMzdJ\
+            CLkXvAwX2do+B3Nlu0xnHDV9swNRxsONhwcAscnIeLEc+SMVNkSvJghnUvk9wNZshrb\
+            BjM0Kbjxum6lphYbpbpmGMnJWLH0baFvZ2O9iRdPgCDXn+gjUJxiKQeDvfWeiokNp7k\
+            8K6QWOOEvYqDpXob2Xx7tTN17kGWpx8v36Qw3qoPgpSd4GtPSMrv9MrvHFwtNl+Hu+X\
+            205RFkhMMqk4h6lmWZf3q/er9fwDzUAZMXJgAAA==\"]"
         cookies: []
         headers:
           - name: date
-            value: Tue, 01 Apr 2025 16:20:05 GMT
+            value: Tue, 15 Apr 2025 13:48:08 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: transfer-encoding
@@ -1579,13 +1646,13 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1358
+        headersSize: 1406
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-04-01T16:20:05.055Z
-      time: 299
+      startedDateTime: 2025-04-15T13:48:08.040Z
+      time: 384
       timings:
         blocked: -1
         connect: -1
@@ -1593,6 +1660,6 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 299
+        wait: 384
   pages: []
   version: "1.2"

--- a/jetbrains/src/integrationTest/resources/recordings/documentCode_2994921345/recording.har.yaml
+++ b/jetbrains/src/integrationTest/resources/recordings/documentCode_2994921345/recording.har.yaml
@@ -37,7 +37,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 01 Apr 2025 16:19:55 GMT
+            value: Tue, 15 Apr 2025 13:47:39 GMT
           - name: content-type
             value: application/json
           - name: content-length
@@ -56,13 +56,13 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1218
+        headersSize: 1266
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-04-01T16:19:55.616Z
-      time: 205
+      startedDateTime: 2025-04-15T13:47:39.069Z
+      time: 259
       timings:
         blocked: -1
         connect: -1
@@ -70,7 +70,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 205
+        wait: 259
     - _id: 6e977d3842ddb417bf941a0f568426d9
       _order: 0
       cache: {}
@@ -106,7 +106,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 01 Apr 2025 16:19:56 GMT
+            value: Tue, 15 Apr 2025 13:47:39 GMT
           - name: content-type
             value: application/json
           - name: content-length
@@ -125,13 +125,13 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1218
+        headersSize: 1266
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-04-01T16:19:55.934Z
-      time: 223
+      startedDateTime: 2025-04-15T13:47:39.110Z
+      time: 273
       timings:
         blocked: -1
         connect: -1
@@ -139,7 +139,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 223
+        wait: 273
     - _id: 897d3731ab8e15a1549f29445eafd1e1
       _order: 0
       cache: {}
@@ -159,7 +159,7 @@ log:
             value: application/json; charset=utf-8
           - _fromType: array
             name: user-agent
-            value: jetbrains/6.0-localbuild (Node.js v20.12.2)
+            value: jetbrains/6.0-localbuild (Node.js v22.14.0)
           - _fromType: array
             name: x-requested-with
             value: jetbrains 6.0-localbuild
@@ -174,19 +174,19 @@ log:
         queryString: []
         url: https://sourcegraph.com/.api/client-config
       response:
-        bodySize: 239
+        bodySize: 232
         content:
           encoding: base64
           mimeType: text/plain; charset=utf-8
-          size: 239
+          size: 232
           text: "[\"H4sIAAAAAAAAA2yPsQrCQBBE+3zFcbU/YLoQLNIFAlpvvBUP7nbD7Rwq4r9bGLC5+s3MY\
             96dc875q4bXSWhNHHzvUCofdnAnNAFV6Kh5SwxuN6tB86g5kwRrbwAlrhVR5c9vlKwR\
             8L3zosJ+R5apYFQBP3GJEvTRVGQNnGyYp7YgEdiw1G3TAg77oahiCwpTHubpzMV+/mP\
-            36b4AAAD//w==\",\"AwAee0MGMAEAAA==\"]"
+            36b4AAAD//wMAHntDBjABAAA=\"]"
         cookies: []
         headers:
           - name: date
-            value: Tue, 01 Apr 2025 16:19:50 GMT
+            value: Tue, 15 Apr 2025 13:47:34 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: transfer-encoding
@@ -212,13 +212,13 @@ log:
             value: max-age=31536000; includeSubDomains; preload
           - name: content-encoding
             value: gzip
-        headersSize: 1358
+        headersSize: 1406
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-04-01T16:19:50.327Z
-      time: 256
+      startedDateTime: 2025-04-15T13:47:33.642Z
+      time: 410
       timings:
         blocked: -1
         connect: -1
@@ -226,7 +226,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 256
+        wait: 410
     - _id: d339f9e066a991b97bfa2860eeb610bc
       _order: 0
       cache: {}
@@ -244,9 +244,9 @@ log:
           - name: content-type
             value: application/json
           - name: traceparent
-            value: 00-651ab9dc0f36b013747d0c3c69158824-acc8dfc66c2b8685-01
+            value: 00-10615581105ab8037f8088ff361832b3-e4a18d39f22daa57-01
           - name: user-agent
-            value: jetbrains/6.0-localbuild (Node.js v20.12.2)
+            value: jetbrains/6.0-localbuild (Node.js v22.14.0)
           - name: x-requested-with
             value: jetbrains 6.0-localbuild
           - name: host
@@ -353,14 +353,14 @@ log:
             value: 6.0-localbuild
         url: https://sourcegraph.com/.api/completions/stream?api-version=9&client-name=jetbrains&client-version=6.0-localbuild
       response:
-        bodySize: 1158
+        bodySize: 1589
         content:
           mimeType: text/event-stream
-          size: 1158
+          size: 1589
           text: >+
             event: completion
 
-            data: {"deltaText":"\n    /**\n     * Generates and prints the first 10 Fibonacci numbers.\n     * \n     * This method creates a list of Fibonacci numbers starting with 0 and 1,\n     * then calculates the subsequent 8 numbers by adding the two previous numbers.\n     * It then prints each number in the sequence.\n     */\n","stopReason":"stop_sequence"}
+            data: {"deltaText":"\n    /**\n     * Generates and prints the first 10 Fibonacci numbers.\n     * Creates a list starting with 0 and 1, then calculates subsequent\n     * Fibonacci numbers by adding the two previous numbers.\n     * Prints each number in the sequence to the console.\n     */\n","stopReason":"stop_sequence"}
 
 
             event: done
@@ -370,7 +370,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 01 Apr 2025 16:19:54 GMT
+            value: Tue, 15 Apr 2025 13:47:44 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -394,13 +394,13 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1320
+        headersSize: 1368
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-04-01T16:19:52.576Z
-      time: 3111
+      startedDateTime: 2025-04-15T13:47:36.208Z
+      time: 9215
       timings:
         blocked: -1
         connect: -1
@@ -408,7 +408,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 3111
+        wait: 9215
     - _id: f1b1cde4cd57488b7f0137954f0302f5
       _order: 0
       cache: {}
@@ -428,7 +428,7 @@ log:
             value: application/json; charset=utf-8
           - _fromType: array
             name: user-agent
-            value: jetbrains/6.0-localbuild (Node.js v20.12.2)
+            value: jetbrains/6.0-localbuild (Node.js v22.14.0)
           - _fromType: array
             name: x-requested-with
             value: jetbrains 6.0-localbuild
@@ -466,7 +466,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 01 Apr 2025 16:19:52 GMT
+            value: Tue, 15 Apr 2025 13:47:35 GMT
           - name: content-type
             value: application/json
           - name: content-length
@@ -490,13 +490,13 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1317
+        headersSize: 1365
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-04-01T16:19:51.870Z
-      time: 238
+      startedDateTime: 2025-04-15T13:47:35.597Z
+      time: 270
       timings:
         blocked: -1
         connect: -1
@@ -504,7 +504,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 238
+        wait: 270
     - _id: a376faab1c8a1993bb48c745757f0a4a
       _order: 0
       cache: {}
@@ -524,7 +524,7 @@ log:
             value: application/json; charset=utf-8
           - _fromType: array
             name: user-agent
-            value: jetbrains/6.0-localbuild (Node.js v20.12.2)
+            value: jetbrains/6.0-localbuild (Node.js v22.14.0)
           - _fromType: array
             name: x-requested-with
             value: jetbrains 6.0-localbuild
@@ -585,7 +585,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 01 Apr 2025 16:19:51 GMT
+            value: Tue, 15 Apr 2025 13:47:35 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -611,13 +611,13 @@ log:
             value: max-age=31536000; includeSubDomains; preload
           - name: content-encoding
             value: gzip
-        headersSize: 1349
+        headersSize: 1397
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-04-01T16:19:51.228Z
-      time: 349
+      startedDateTime: 2025-04-15T13:47:34.722Z
+      time: 620
       timings:
         blocked: -1
         connect: -1
@@ -625,7 +625,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 349
+        wait: 620
     - _id: 0484c4d780805faf3dd3ddabae814640
       _order: 0
       cache: {}
@@ -645,7 +645,7 @@ log:
             value: application/json; charset=utf-8
           - _fromType: array
             name: user-agent
-            value: jetbrains/6.0-localbuild (Node.js v20.12.2)
+            value: jetbrains/6.0-localbuild (Node.js v22.14.0)
           - _fromType: array
             name: x-requested-with
             value: jetbrains 6.0-localbuild
@@ -679,22 +679,18 @@ log:
             value: null
         url: https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration
       response:
-        bodySize: 136
+        bodySize: 143
         content:
           encoding: base64
           mimeType: application/json
-          size: 136
-          text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eWD53MSiE\
-            uf8vJLUipLwzLyU/HIlK6WUzOLEpJzUFKXa2tpaAAAAAP//AwArMNn0TAAAAA==\"]"
-          textDecoded:
-            data:
-              site:
-                codyLLMConfiguration:
-                  smartContextWindow: disabled
+          size: 143
+          text: "[\"H4sIAAAAAAAAAwAAAP//\",\"qlZKSSxJVLKqVirOLEkF0cn5KZU+Pr7O+XlpmemlRYkl\
+            mfl5YPncxKIS5/y8ktSKkvDMvJT8ciUrpZTM4sSknNQUpdra2loAAAAA//8DACsw2fR\
+            MAAAA\"]"
         cookies: []
         headers:
           - name: date
-            value: Tue, 01 Apr 2025 16:19:51 GMT
+            value: Tue, 15 Apr 2025 13:47:35 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -720,13 +716,13 @@ log:
             value: max-age=31536000; includeSubDomains; preload
           - name: content-encoding
             value: gzip
-        headersSize: 1349
+        headersSize: 1397
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-04-01T16:19:51.293Z
-      time: 260
+      startedDateTime: 2025-04-15T13:47:34.783Z
+      time: 292
       timings:
         blocked: -1
         connect: -1
@@ -734,7 +730,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 260
+        wait: 292
     - _id: e141c56e63809042300db9bf8551d492
       _order: 0
       cache: {}
@@ -754,7 +750,7 @@ log:
             value: application/json; charset=utf-8
           - _fromType: array
             name: user-agent
-            value: jetbrains/6.0-localbuild (Node.js v20.12.2)
+            value: jetbrains/6.0-localbuild (Node.js v22.14.0)
           - _fromType: array
             name: x-requested-with
             value: jetbrains 6.0-localbuild
@@ -803,7 +799,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 01 Apr 2025 16:19:51 GMT
+            value: Tue, 15 Apr 2025 13:47:35 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -829,13 +825,13 @@ log:
             value: max-age=31536000; includeSubDomains; preload
           - name: content-encoding
             value: gzip
-        headersSize: 1349
+        headersSize: 1397
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-04-01T16:19:51.267Z
-      time: 287
+      startedDateTime: 2025-04-15T13:47:34.753Z
+      time: 539
       timings:
         blocked: -1
         connect: -1
@@ -843,7 +839,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 287
+        wait: 539
     - _id: 5b9030a4e18d1e000c71d6000a7cef6f
       _order: 0
       cache: {}
@@ -863,7 +859,7 @@ log:
             value: application/json; charset=utf-8
           - _fromType: array
             name: user-agent
-            value: jetbrains/6.0-localbuild (Node.js v20.12.2)
+            value: jetbrains/6.0-localbuild (Node.js v22.14.0)
           - _fromType: array
             name: x-requested-with
             value: jetbrains 6.0-localbuild
@@ -934,7 +930,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 01 Apr 2025 16:19:50 GMT
+            value: Tue, 15 Apr 2025 13:47:33 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -960,13 +956,13 @@ log:
             value: max-age=31536000; includeSubDomains; preload
           - name: content-encoding
             value: gzip
-        headersSize: 1349
+        headersSize: 1397
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-04-01T16:19:50.021Z
-      time: 278
+      startedDateTime: 2025-04-15T13:47:32.013Z
+      time: 1605
       timings:
         blocked: -1
         connect: -1
@@ -974,7 +970,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 278
+        wait: 1605
     - _id: aef0c9fe7483280d9c05ac8e97e37571
       _order: 0
       cache: {}
@@ -994,7 +990,7 @@ log:
             value: application/json; charset=utf-8
           - _fromType: array
             name: user-agent
-            value: jetbrains/6.0-localbuild (Node.js v20.12.2)
+            value: jetbrains/6.0-localbuild (Node.js v22.14.0)
           - _fromType: array
             name: x-requested-with
             value: jetbrains 6.0-localbuild
@@ -1037,23 +1033,23 @@ log:
           encoding: base64
           mimeType: application/json
           size: 224
-          text: "[\"H4sIAAAAAAAAA1zMsQrCMBSF4Xc5c4U2rUu2Ih0EwdJWB7fYZAjUJNzcDKXk3UVBUMfz8\
+          text: "[\"H4sIAAAAAAAAA1zMsQrCMBSF4Xc5c4U2tku2Ih0EwdJWB7fYZAjUJNzcDKXk3UVBUMfz8\
             3E2aMUKcsOciIzjSzT0nl6vY7rHmWxg692rRVacIiTaw3S8digQFuUg0Q9nFFAhLGtP\
-            flBsTvZhOUIyJVN8vntD1uuRFXHLkBCl2O/Kelc1kxCyqmQtbvjTndNftvm1Oef8BAA\
-            A//8DAPWiQezCAAAA\"]"
+            flBsTvZhOUIyJVN8vntD1uuRFXHLkBClaHZlvavqSQhZVXIvbvjTndNftvm1Oef8BAA\
+            A//8DAPgwylPCAAAA\"]"
           textDecoded:
             data:
               currentUser:
                 codySubscription:
                   applyProRateLimits: true
-                  currentPeriodEndAt: 2025-04-14T22:11:32Z
-                  currentPeriodStartAt: 2025-03-14T22:11:32Z
+                  currentPeriodEndAt: 2025-05-14T22:11:32Z
+                  currentPeriodStartAt: 2025-04-14T22:11:32Z
                   plan: PRO
                   status: ACTIVE
         cookies: []
         headers:
           - name: date
-            value: Tue, 01 Apr 2025 16:19:51 GMT
+            value: Tue, 15 Apr 2025 13:47:35 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -1079,13 +1075,13 @@ log:
             value: max-age=31536000; includeSubDomains; preload
           - name: content-encoding
             value: gzip
-        headersSize: 1349
+        headersSize: 1397
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-04-01T16:19:51.337Z
-      time: 348
+      startedDateTime: 2025-04-15T13:47:34.818Z
+      time: 443
       timings:
         blocked: -1
         connect: -1
@@ -1093,7 +1089,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 348
+        wait: 443
     - _id: 4504fab53d7cb602861f73dc2aa883d2
       _order: 0
       cache: {}
@@ -1113,7 +1109,7 @@ log:
             value: application/json; charset=utf-8
           - _fromType: array
             name: user-agent
-            value: jetbrains/6.0-localbuild (Node.js v20.12.2)
+            value: jetbrains/6.0-localbuild (Node.js v22.14.0)
           - _fromType: array
             name: x-requested-with
             value: jetbrains 6.0-localbuild
@@ -1145,18 +1141,21 @@ log:
             value: null
         url: https://sourcegraph.com/.api/graphql?SiteProductVersion
       response:
-        bodySize: 139
+        bodySize: 136
         content:
           encoding: base64
           mimeType: application/json
-          size: 139
-          text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSsaGlqbmZvFGB\
-            kamugbGusaG8WZ6hrpJloYWxqbmpqbGhmlKtbW1AAAAAP//\",\"AwDt2Xx6SQAAAA==\
-            \"]"
+          size: 136
+          text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSsZGRiZGRvFGB\
+            kamugYmuoYm8WZ6RromxpaGJqmmFkkGBsZKtbW1AAAAAP//AwCB0HjwSQAAAA==\"]"
+          textDecoded:
+            data:
+              site:
+                productVersion: 322422_2025-04-14_6.2-43914e58b003
         cookies: []
         headers:
           - name: date
-            value: Tue, 01 Apr 2025 16:19:51 GMT
+            value: Tue, 15 Apr 2025 13:47:35 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -1182,13 +1181,13 @@ log:
             value: max-age=31536000; includeSubDomains; preload
           - name: content-encoding
             value: gzip
-        headersSize: 1349
+        headersSize: 1397
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-04-01T16:19:51.314Z
-      time: 282
+      startedDateTime: 2025-04-15T13:47:34.691Z
+      time: 616
       timings:
         blocked: -1
         connect: -1
@@ -1196,7 +1195,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 282
+        wait: 616
     - _id: fd0fee4687419870bc82cba9d1023319
       _order: 0
       cache: {}
@@ -1216,7 +1215,7 @@ log:
             value: application/json; charset=utf-8
           - _fromType: array
             name: user-agent
-            value: jetbrains/6.0-localbuild (Node.js v20.12.2)
+            value: jetbrains/6.0-localbuild (Node.js v22.14.0)
           - _fromType: array
             name: x-requested-with
             value: jetbrains 6.0-localbuild
@@ -1248,28 +1247,23 @@ log:
             value: null
         url: https://sourcegraph.com/.api/graphql?ViewerSettings
       response:
-        bodySize: 280
+        bodySize: 192
         content:
           encoding: base64
           mimeType: application/json
-          size: 280
-          text: "[\"H4sIAAAAAAAAA4zPwUoDQRAE0H/pc75gbyoGAwrikttcOkk529D2LD292cRl/l0WAsGD4\
-            LXqUVALnTiYuoXOghneI0Is1zX5FGOljpZEuIxw+YIF6xYck6Mm6tbG+KB45e/ro5ZD\
-            f7Xgy4vkQSUP61KiLnzCJpFh7sF+HD5QJ42taMDrOxv0T1T3u3s3euFjyBm/xEPOjsw\
-            hxerd1n+Qocxvk4ao2G3yqVgtiptpm0RlhO3s+SRRfD3cGrXWfgAAAP//AwDHP3NmNg\
-            EAAA==\"]"
+          size: 192
+          text: "[\"H4sIAAAAAAAAA2SMwQrCQAwF/yXnfsHeLfQmFm97CfapgTUt2awVlvy7FLx5nRmm08LOl\
+            Dq9BTtshrvoox7kLsqFEvVM+GwweUGdywj2ZqiZUs+k2Gew3Z4X1FZ8lOKwemZFyZTc\
+            Goa/qF6nn4sh07pBJz0t4qsdzwiKiC8AAAD//wMAV+4vNJkAAAA=\"]"
           textDecoded:
             data:
               viewerSettings:
-                final: "{\"experimentalFeatures\":{\"enableLazyBlobSyntaxHighlighting\":true,\"\
-                  newSearchResultFiltersPanel\":true,\"newSearchResultsUI\":tru\
-                  e,\"proactiveSearchResultsAggregations\":true,\"searchResults\
-                  Aggregations\":true,\"showMultilineSearchConsole\":true},\"op\
-                  enInEditor\":{}}"
+                final: "{\"experimentalFeatures\":{\"newSearchResultFiltersPanel\":true,\"newSe\
+                  archResultsUI\":true},\"openInEditor\":{}}"
         cookies: []
         headers:
           - name: date
-            value: Tue, 01 Apr 2025 16:19:52 GMT
+            value: Tue, 15 Apr 2025 13:47:35 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -1295,13 +1289,13 @@ log:
             value: max-age=31536000; includeSubDomains; preload
           - name: content-encoding
             value: gzip
-        headersSize: 1349
+        headersSize: 1397
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-04-01T16:19:51.846Z
-      time: 274
+      startedDateTime: 2025-04-15T13:47:35.568Z
+      time: 283
       timings:
         blocked: -1
         connect: -1
@@ -1309,7 +1303,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 274
+        wait: 283
     - _id: fbb23499ae0eec5c2e188687b429531b
       _order: 0
       cache: {}
@@ -1323,7 +1317,7 @@ log:
               REDACTED_fc324d3667e841181b0779375f26dedc911d26b303d23b29b1a2d7ee63dc77eb
           - _fromType: array
             name: user-agent
-            value: jetbrains/6.0-localbuild (Node.js v20.12.2)
+            value: jetbrains/6.0-localbuild (Node.js v22.14.0)
           - _fromType: array
             name: x-requested-with
             value: jetbrains 6.0-localbuild
@@ -1341,60 +1335,62 @@ log:
         queryString: []
         url: https://sourcegraph.com/.api/modelconfig/supported-models.json
       response:
-        bodySize: 2987
+        bodySize: 3127
         content:
           encoding: base64
           mimeType: text/plain; charset=utf-8
-          size: 2987
-          text: "[\"H4sIAAAJbogA/+xd33ObOhZ+569geN3IBRHHid/S3LZ7Z2633W22+7BzH2Q4tjXBiAXhO\
-            nOn//uOsE2MLSNhbAc34ikORz8QH98555MEf1m2bdtOFkxhRr5DmlEWO0Pb8Xquc7U8\
-            l8Kcrv/t9tye+7cQ5uuTScrmNIQ0c4b2fwt7cfxV/iUOh4aiShLzacoSGjhX1dMhzZK\
-            IPP+DzEDY3Zd2ZS0/r+qrHtMUfrD0KVNU/bG00656wtgkAkW9n5ZG2v1lCcSEKir9kk\
-            B8/7t+pTOa8ZREilo/r6xeqi3++nN1P2cshKj2ZhYW/4Jx5ZYOh9jF18hzEcbDYRCRP\
-            ATkowHKWBwDRxHhkHFF1x6KYrbfG9jfimLb9kXTa2vdRgKSkBGNKKdQva714QRTsl1K\
-            HM4K9pIznLEoexnCjQFcH05AOExY+iwujARBnpLgeasqJ+OE56JT4q/RLso4hVScHae\
-            wcy5gMYcF/w+NQ/bDGW5BQhzOjCx+j5OcP7IniEUz133Xda+khl9yXrF0Xbdit/EEis\
-            OBjNMZ4RB+FvfkgWVc3oc8puKMM+PsaesSxOHQsoNfIY6Xt8iXdpLlfNfU6yv6WUDmg\
-            cVjOrmPoke6ZCrJYBVjLLsEzdFuPOqK0b+y9tgX9/XfGaTVeytGwrUk5qsHvOZmikMQ\
-            +Wku3/OxFHU113+jLHD864eYQ5qkNIPODMOtd4cbw+C2wTBY8l8bw1N9HA7jflhwiEM\
-            IEZ/S+InGE4X/33ED9odVDfbjnho65hgkRVIgGYvFxVfO/XlV+XlUryGeaOM0jNO4RK\
-            dx5ze9fO8Qp4FbOs1TO43mw3BzEAw64zT6hyUM/UYJg6IRtV+AkEoTBpNImETCJBImk\
-            TCJxOGJhI/cG+R6GyISS3KVrrdOGewvElu5ExC1IpG4uBjfHdkFaIf4jE8h3a8KhZCk\
-            IFKCcJ8y9LZifBGu6gb5g50g35JEsq1ClSmhT/meIGIPQHt9+++ilB5G65tQxykk5yx\
-            gsyQCvu32D4pjGkYrWQIQGs1TS/O81Qb29TaujeJpFE+jeJ5d8dwNVKYyZt8XqTRwA0\
-            W9y1jFdwdndgPacqWC7dWxzLEYfyB9+PZkR1bNU3LSSS7c141kPNy35E/3xlN9OGx7a\
-            zlEE7lGbCnFlvNh+kKimFYzt5akx4fD+kXlK4jzBq/Xs6iY+VB872vmouVEg/AOI7wR\
-            bTcC9Uofv3h55I0lka9Kv96maod7nl4gLDGUQVJi1pJXtafhOwPCy4hrb/UxiHekDEv\
-            y1LTAoKbLlxjKMegaDBoMbmGwXHo8HM694TDjJA1YCKkCet84SR9kdhXk7a1NTX6VpF\
-            8baJ2QbLF7fasFMty/qZid09difYi1I7ktgIUASQbwhAqUoTlGEeWARiQDBdv9BpB8A\
-            3iyv2P7D8rBfi8pU4EfCQKWxzx7l7E8DWCSkmT6rrDI3jXohwHrmwfr3NcGp68HybKl\
-            HUDO/eYAbOaOu5Q3e/giUpM7bbq8OypdZjOSckSSJHpG//sBMQphTPJIlTV/E8Xse1H\
-            M/ucPiO3f5MWq3lqzLTUfFjUVrR/NdcMigZTOIOYkOrUD18dkYflqtNgZUPp4hAQFob\
-            nXFJg+fm9/92pxWefGl51IpiQDFLDZiMYQvvRp7hnsGuxWsCvyCrH+NdNk0vucsw/C3\
-            i43X2qRacDCZ1T8B4km0bLNkt0P59aTJEbdZNdXFYI8XYfvHdPfb8JzlaAUeYme279f\
-            l7bLZKlI0u3vuNbzN2z1lRKiEXCyjz6PtJDwQqLRzmAzj+mYQogmKYnziKQopOPxqUA=\
-            \",\"WhcGlF2b+yiiMaAI5hChiMUTxCGdlT0NM6E5CLkBAfKSvsH228T28r0Iy3h2Aj\
-            MaU+T1+kjCI1sc+6kwtr1e3/6aslrE1terZtHjiO8jEpE4eH2l6ULWgHj6K5t25iDNU\
-            lazlNUsZT3DUlYJe+Oei8YRyaYIFokeh+Oea38URewPNfmPjNJrG2tJ7KdcMaWIQt7E\
-            cqlRA9nXc6X0IXcHwm210yrqYK0XlpSQboTiXwfBv/ymnIbobYDd2m6a7cNm+7DZPny\
-            K7cO1oYzQ/vTy0ZL40R+SMvUxjKyVkwUxhulPwPQD7ZzVV/TSEL0hekP0ZyT6JGUiiU\
-            QuRm5fT3sUXK+pPSpb6HCyqhYudaYtZcqrEpbapNS5kF/XD2zNDBkvYLyA8QKv4wXEv\
-            FMDiUfMPH2UmcuC/L11t+T9Y+k1RnHcUhxNJG8ieRPJdzuSX32pYEniM7oQP9DtYjBC\
-            NM54mgdcweSfl2Xs28XgfS2Ll2teyoWD64WvWs2qSb7ZxoHOkPll7OPru7pc3t/qpCW\
-            JuWqCij2AxPgARGLcHpIYt8HkcZa9mH3PjfY9e/p7rLyWm6wqaH1ZubeGzxwrsPqyJH\
-            uN2qOsHIxhgtzEw+OXjQT7u6RGsVmn/Uut015+8mj1nSChpIn8LeHomimY9dPXR4lRN\
-            VeT1tOSKE+pzKk3ENbPw1++JtckDMD6cYCnepI6kNTJ/VlNML8z+LthjuRZPL3ENmh8\
-            Jb+iwtZ8FE7/qQpL/qstUyMhiSkC4SVdSy0lnC216zBxKxK4etY+VkB8IbTtaStxN4a\
-            zDWcbzj4yZzO/YFc0g5DmM4V+sTK25cYV5l6ZNmftfWtbT/JttHPuyL0UQva04+jra0\
-            PJ56Lkm1spemqu5PRk9Apx9AHD4LrKIi3HwZL/2hifGp1OSsqeQkhmXj35esVbWZGHk\
-            XfAq+A7R8FvS8lo8gGbm22YGg42HGw4+AgcXMjFiOfpiClm9Qoxw36UWe6KGfIaW4oZ\
-            2nTcerruSEwsD8t0wrGzErGrT8T+TkctSZcPwKDf62ujUHyWQA+He2s9FxJbL3J4U0h\
-            s8M72mlcVWxuz+c7qXUdFBlldsra8k+pvLsq+CeOMScYf9MrvfApJvM4LHpYvNKIslr\
-            wTr+69tpZt2/ZP66f1/wEAdvMbd66GAAA=\"]"
+          size: 3127
+          text: "[\"H4sIAAAJbogA/+xdS3OjOhbe+1dQbCdyg4jjxLt0bnfPrbo93TOd6VlM3YUMx7YqGDEgn\
+            KRu9X+fEraJsWUkDHZwIlZxOHogPr7z0uOvnmVZlp36M5iTn5CklEX2yLLdvmNfLO8l\
+            sKDrfzt9p+/8LYDF+macsAUNIEntkfXfXF5cfxV/icumgaiSRHyWsJj69kX5dkDTOCT\
+            P/yBzEHK3hVxRy6+L6qonNIFHljykiqo/F3LaVU8Zm4agqPfLUki7vyyGiFBFpd9iiG\
+            5/1690TlOekFBR69eV1Eu1+V9/rt7nnAUQVr7MXOJfMCm90tEIO/gSuQ7CeDTyQ5IFg\
+            Dw0RCmLIuAoJBxSrujaXV7M8vpD60debFs+b3otrduIT2IypiHlFMrPtb5sf0a2S4nL\
+            XsFecoczFqYvQ7gxgOvL9gmHKUuexYMR388S4j9vVWWnnPBMdEr8Nd5FGaeQiLuTBHb\
+            u+Szi8MT/Q6OAPdqjLUiIy56Tp9+jOOP37AEi0czlwHGcC6ngt4yXJB3HKcltfIHisi\
+            HldE44BF/FO7ljKZf3IYuouGPPOXvYegRx2bTo4HeIouUr8qSdZBnfFXUHin7mkLlj0\
+            YROb8Pwni6ZSjJY+RjLHkFztGuPumL0L3p75PP3+u8UkvK7FSPh9CTiqw+84mWKSxD5\
+            cR7f9bAUdRXPf6Us0P7zQ8QhiROaQmeG4dq9wbVhcF1jGHryXxvDU/4cDuN+eOIQBRA\
+            gPqPRA42mCv2/owasT6sarPs9NXRMMUiKJEBSFomHL93786L0s1WtIb5oozSM0jhHpX\
+            Hj1X189xClgRsqzWMrjfrDcHUQDDqjNAaHOQyDWg6DohG1XoCASh0G40gYR8I4EsaRM\
+            I7E4Y6Eh5wr5LgbQSQWZ6q43tplsL5JZOVKQNSKhOPiYHzTsgrQNvEZn0GyPyoUQJyA\
+            cAmCfZGh92XjC3NV18gf7hj5PYkl28hUmRH6kO0xIvYAtD+w/i5K6WG0ugm1nUIyznw\
+            2j0Pg22r/IDumprWSxgCBiXlqxTyvtYF9uY1rE/E0EU8T8Tx5xHPXUJnJmH2fpVJDDe\
+            T1Lm0VzxmeWA1ohysVbK+2Zdpi/KH049vjHfUqvpKjJrnwQNeScfGgJ/+6N77qw2HbX\
+            4dDNJFrgi1FsOV0mD4TK6ZR5rYn6fHhsH6J8uXEeYXX81lUzHwovvc1c9bhRIPwDiO8\
+            Fm3XAvUqPn724ZF35kS+Kv26m1E73Hf1DGGJoAySErGGvKqdhu8MCM/Drr3WxyDeCWX\
+            0JF9NAwxqqnyJoByDjsGgweAWBoupx6PRwh2NUk4SnwWQKKD3g5PkTiZXQt7e2tTkV3\
+            L6tYHWiZAtdi6vtUCGB1clsVPqWqwPsWYktwWwACBOAR5QjjK0wCikHNCYpKBgu98A4\
+            h8AD9ZPbP1BOVgfJWVK8CO+z7KIpx9SliU+TBMSzz7kEumHGv0wYH33YF142uD09CBZ\
+            tLQDyIVXH4D11HGX/GYXn4VrcqNNlzet0mU6JwlHJI7DZ/S/R4hQABOShSqv+YcoZt2\
+            KYtY/HyGyfpMXK2trzbbUfJjXlLfemuqGpxgSOoeIk/DYClwfk7nkq9FiZ0Dp4TESFI\
+            QWbl1gevij9dOtxGWVGl92Ip6RFJDP5mMaQfDSp4VrsGuwW8Ku8CvE/NdUk0lvM84+C\
+            XmrWHypRaY+C55R/h8kmkTLNgt2P5xbj+IYdZNdXzUQ5OoqfLdNfb8Jz5WDkvslemr/\
+            dl0=\",\"2iqcpdxJt37iSs1fs9VXcojGwMk++mxpIuGZWKOdwWYW0QmFAE0TEmUhSV\
+            BAJ5NjgbTKDCi6tvBQSCNAISwgRCGLpohDMi96GqQi5iDCDQiQGw8Mtt8ntpf7Iizt2\
+            SnMaUSR2x8gCY9sceyXXNhy+wPre8IqEVtdr5pF2wm+j0lIIh8CkyXXzpK7+rObdvKQ\
+            Zjqrmc5qprOeYDrrfgZHjoOPxeKyurvD5GZNwsaaBMPihsUNi58fi+O+gyYhSWcInmI\
+            9Hsd9x/osilifKiJZMlqvbKwhsR9z7qvCn3wXJv24RgLPdaT0ITfqhdpqFnWWGCcF0v\
+            QczALStVD8dhD85k2Zmuitgd3KbpqNIMxGEGYjiGNsBFHF+Xk+RS+yWBA/+kNSptqGk\
+            bVyNCPGMP0RmH6o7bN6il4aojdEb4j+hEQfJ0w4kcjByBnoZZEE12tmkZQtdNhZbSMF\
+            JcugKUGpTUmdM/h1tcBWht/oAKMDjA54LR2wzD7FCSwoPCLHQ1hbD+SzCazvy6J6Rr9\
+            Ga2etE3QmJZ6/VqgzabZGRgsPjHdgvAPjHXTCOxBzB6Th+f1zyz7LxGXBn711N+T+tu\
+            L4JhO1lYkyER4T4TERnrOL8BQ8W292WX0ef80ZZobLDZcbLjdc/pa4fHWu5NIgn9Mn8\
+            QNdPw3HiEYpTzKfK6zyr8sy1vXT8GOlRV6sUCqWea6XKWs1qyb5ets8dIbMz2PXpYGj\
+            a5dvh1Z6ku+1PiAxPgCRGDeHJMZNMNmO4WF2qau1S52rvyOO23BLnBJ9vqyzXMNnoVp\
+            p8bKAfo3aVtZ5RjBFTuziycu2D/u7pEaxWVX/plbVLw+oXp3qLLLlIhYXc3TJFGj98v\
+            1eIlSOu0nraUiUx8y0qLd7qp5r+75yLFjfDnBVX1IHAnRyfVYRmNkZ/F0zR/ItHt89G\
+            9Z+krfondUfheMfLNqT/2rK1EiExRTGxZKupZISzpbKdZi4FQ5cNWu3ZRCfCW272pG4\
+            K8PZhrMNZ7fM2czL2RXNIaDZXOETroQtuXCJuVei9Vl73/q1o5xkf8r9086FkF1tO/r\
+            y0lDyqSj56lqKnoonOT4ZvYIdfcAwOI6ySMNx6Ml/bYxPRZxOSsquIjjH3GrydfMzdJ\
+            CLkXvAwX2do+B3Nlu0xnHDV9swNRxsONhwcAscnIeLEc+SMVNkSvJghnUvk9wNZshrb\
+            BjM0Kbjxum6lphYbpbpmGMnJWLH0baFvZ2O9iRdPgCDXn+gjUJxiKQeDvfWeiokNp7k\
+            8K6QWOOEvYqDpXob2Xx7tTN17kGWpx8v36Qw3qoPgpSd4GtPSMrv9MrvHFwtNl+Hu+X\
+            205RFkhMMqk4h6lmWZf3q/er9fwDzUAZMXJgAAA==\"]"
         cookies: []
         headers:
           - name: date
-            value: Tue, 01 Apr 2025 16:19:52 GMT
+            value: Tue, 15 Apr 2025 13:47:36 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: transfer-encoding
@@ -1420,13 +1416,13 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1358
+        headersSize: 1406
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-04-01T16:19:52.128Z
-      time: 274
+      startedDateTime: 2025-04-15T13:47:35.873Z
+      time: 310
       timings:
         blocked: -1
         connect: -1
@@ -1434,6 +1430,6 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 274
+        wait: 310
   pages: []
   version: "1.2"

--- a/lib/shared/src/models/modelsService.ts
+++ b/lib/shared/src/models/modelsService.ts
@@ -9,14 +9,16 @@ import { FeatureFlag, featureFlagProvider } from '../experimentation/FeatureFlag
 import { logDebug } from '../logger'
 import {
     type StoredLastValue,
-    type Unsubscribable,
     combineLatest,
     distinctUntilChanged,
     shareReplay,
     storeLastValue,
-    tap,
 } from '../misc/observable'
-import { firstResultFromOperation, pendingOperation } from '../misc/observableOperation'
+import {
+    firstResultFromOperation,
+    pendingOperation,
+    skipPendingOperation,
+} from '../misc/observableOperation'
 import { ClientConfigSingleton } from '../sourcegraph-api/clientConfig'
 import {
     type UserProductSubscription,
@@ -264,8 +266,6 @@ export class ModelsService {
     private storage: LocalStorageForModelPreferences | undefined
 
     private storedValue: StoredLastValue<ModelsData>
-    private syncPreferencesSubscription?: Unsubscribable
-
     constructor(testing__mockModelsChanges?: ModelsService['modelsChanges']) {
         if (testing__mockModelsChanges) {
             this.modelsChanges = testing__mockModelsChanges
@@ -277,78 +277,10 @@ export class ModelsService {
 
     public setStorage(storage: LocalStorageForModelPreferences): void {
         this.storage = storage
-
-        this.syncPreferencesSubscription = combineLatest(
-            this.modelsChanges,
-            featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyEditDefaultToGpt4oMini),
-            featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyDeepSeekChat)
-        )
-            .pipe(
-                tap(async ([data, shouldEditDefaultToGpt4oMini, shouldChatDefaultToDeepSeek]) => {
-                    if (data === pendingOperation) {
-                        return
-                    }
-
-                    // Ensures we only change user preferences once
-                    // when they join the A/B test.
-                    const isEnrolled = this.storage?.getEnrollmentHistory(
-                        FeatureFlag.CodyEditDefaultToGpt4oMini
-                    )
-
-                    // Check if this user has already been enrolled in the deepseek chat feature flag experiment.
-                    // We only want to change their default model ONCE when they first join the A/B test.
-                    // This ensures that:
-                    // 1. New users in the test group get deepseek as their default model
-                    // 2. If they later explicitly choose a different model (e.g., sonnet), we respect that choice
-                    // 3. Their chosen preference persists across sessions and new chats
-                    // 4. We don't override their preference every time they load the app
-                    const isEnrolledDeepSeekChat = this.storage?.getEnrollmentHistory(
-                        FeatureFlag.CodyDeepSeekChat
-                    )
-
-                    // Ensures that we have the gpt-4o-mini model
-                    // we want to default to in this A/B test.
-                    const gpt4oMini = data.primaryModels.find(
-                        model => model?.modelRef?.modelId === 'gpt-4o-mini'
-                    )
-
-                    // Ensures that we have the deepseek model
-                    // we want to default to in this A/B test
-                    // The model is defined at https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/cody-gateway-config/dotcom_models.go?L323
-                    const deepseekModel = data.primaryModels.find(
-                        model => model?.id === 'fireworks::v1::deepseek-v3'
-                    )
-
-                    const allSitePrefs = this.storage?.getModelPreferences()
-                    const currentAccountPrefs = { ...data.preferences }
-
-                    if (!isEnrolled && shouldEditDefaultToGpt4oMini && gpt4oMini) {
-                        // For users enrolled in the A/B test, we'll default
-                        // to the gpt-4-mini model when using the Edit command.
-                        // They still can switch back to other models if they want.
-                        currentAccountPrefs.selected.edit = gpt4oMini.id
-                    }
-
-                    if (!isEnrolledDeepSeekChat && shouldChatDefaultToDeepSeek && deepseekModel) {
-                        // For users enrolled in the A/B test, we'll default
-                        // to the deepseek model when using the Chat command.
-                        // They still can switch back to other models if they want.
-                        currentAccountPrefs.selected.chat = deepseekModel.id
-                    }
-
-                    const updated: DefaultsAndUserPreferencesByEndpoint = {
-                        ...allSitePrefs,
-                        [currentAuthStatus().endpoint]: currentAccountPrefs,
-                    }
-                    await this.storage?.setModelPreferences(updated)
-                })
-            )
-            .subscribe({})
     }
 
     public dispose(): void {
         this.storedValue.subscription.unsubscribe()
-        this.syncPreferencesSubscription?.unsubscribe()
     }
 
     /**
@@ -373,6 +305,62 @@ export class ModelsService {
         clientConfig: ClientConfigSingleton.getInstance().changes,
         userProductSubscription,
     })
+
+    private modelPreferences: Observable<DefaultsAndUserPreferencesByEndpoint> = combineLatest(
+        this.modelsChanges.pipe(skipPendingOperation(), distinctUntilChanged()),
+        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyEditDefaultToGpt4oMini),
+        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyDeepSeekChat)
+    ).pipe(
+        map(async ([data, shouldEditDefaultToGpt4oMini, shouldChatDefaultToDeepSeek]) => {
+            // Ensures we only change user preferences once
+            // when they join the A/B test.
+            const isEnrolled = this.storage?.getEnrollmentHistory(FeatureFlag.CodyEditDefaultToGpt4oMini)
+
+            // Check if this user has already been enrolled in the deepseek chat feature flag experiment.
+            // We only want to change their default model ONCE when they first join the A/B test.
+            // This ensures that:
+            // 1. New users in the test group get deepseek as their default model
+            // 2. If they later explicitly choose a different model (e.g., sonnet), we respect that choice
+            // 3. Their chosen preference persists across sessions and new chats
+            // 4. We don't override their preference every time they load the app
+            const isEnrolledDeepSeekChat = this.storage?.getEnrollmentHistory(
+                FeatureFlag.CodyDeepSeekChat
+            )
+
+            // Ensures that we have the gpt-4o-mini model
+            // we want to default to in this A/B test.
+            const gpt4oMini = data.primaryModels.find(
+                model => model?.modelRef?.modelId === 'gpt-4o-mini'
+            )
+
+            // Ensures that we have the deepseek model
+            // we want to default to in this A/B test
+            // The model is defined at https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/cody-gateway-config/dotcom_models.go?L323
+            const deepseekModel = data.primaryModels.find(
+                model => model?.id === 'fireworks::v1::deepseek-v3'
+            )
+
+            const currentAccountPrefs = { ...data.preferences }
+
+            if (!isEnrolled && shouldEditDefaultToGpt4oMini && gpt4oMini) {
+                // For users enrolled in the A/B test, we'll default
+                // to the gpt-4-mini model when using the Edit command.
+                // They still can switch back to other models if they want.
+                currentAccountPrefs.selected.edit = gpt4oMini.id
+            }
+
+            if (!isEnrolledDeepSeekChat && shouldChatDefaultToDeepSeek && deepseekModel) {
+                // For users enrolled in the A/B test, we'll default
+                // to the deepseek model when using the Chat command.
+                // They still can switch back to other models if they want.
+                currentAccountPrefs.selected.chat = deepseekModel.id
+            }
+
+            return {
+                [currentAuthStatus().endpoint]: currentAccountPrefs,
+            }
+        })
+    )
 
     /**
      * The list of models.
@@ -538,7 +526,7 @@ export class ModelsService {
             throw new Error('ModelsService.storage is not set')
         }
         const serverEndpoint = currentAuthStatus().endpoint
-        const currentPrefs = deepClone(this.storage.getModelPreferences())
+        const currentPrefs = await firstResultFromOperation(this.modelPreferences)
         if (!currentPrefs[serverEndpoint]) {
             currentPrefs[serverEndpoint] = modelsData.preferences
         }
@@ -703,8 +691,4 @@ export function mockModelsService({
     modelsService.setStorage(storage)
     mockAuthStatus(authStatus)
     return { storage, modelsService }
-}
-
-function deepClone<T>(value: T): T {
-    return JSON.parse(JSON.stringify(value)) as T
 }

--- a/lib/shared/src/models/modelsService.ts
+++ b/lib/shared/src/models/modelsService.ts
@@ -284,7 +284,7 @@ export class ModelsService {
             featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyDeepSeekChat)
         )
             .pipe(
-                tap(([data, shouldEditDefaultToGpt4oMini, shouldChatDefaultToDeepSeek]) => {
+                tap(async ([data, shouldEditDefaultToGpt4oMini, shouldChatDefaultToDeepSeek]) => {
                     if (data === pendingOperation) {
                         return
                     }
@@ -340,7 +340,7 @@ export class ModelsService {
                         ...allSitePrefs,
                         [currentAuthStatus().endpoint]: currentAccountPrefs,
                     }
-                    this.storage?.setModelPreferences(updated)
+                    await this.storage?.setModelPreferences(updated)
                 })
             )
             .subscribe({})

--- a/lib/shared/src/models/sync.test.ts
+++ b/lib/shared/src/models/sync.test.ts
@@ -151,6 +151,7 @@ describe('server sent models', async () => {
 
     it('allows updating the selected model', async () => {
         vi.spyOn(modelsService, 'modelsChanges', 'get').mockReturnValue(Observable.of(result))
+        vi.spyOn(modelsService, 'modelPreferences', 'get').mockReturnValue(Observable.of({}))
         await modelsService.setSelectedModel(ModelUsage.Chat, titan)
         expect(storage.data?.[AUTH_STATUS_FIXTURE_AUTHED.endpoint]!.selected.chat).toBe(titan.id)
     })

--- a/vscode/src/chat/chat-view/ChatController.test.ts
+++ b/vscode/src/chat/chat-view/ChatController.test.ts
@@ -140,7 +140,7 @@ describe('ChatController', () => {
         expect(addBotMessageSpy).not.toHaveBeenCalled()
     })
 
-    test('verifies interactionId is passed through chat requests', { timeout: 3000 }, async () => {
+    test('verifies interactionId is passed through chat requests', { timeout: 10000 }, async () => {
         const mockRequestID = '0'
         mockContextRetriever.retrieveContext.mockResolvedValue([])
 

--- a/vscode/src/chat/chat-view/prompt.test.ts
+++ b/vscode/src/chat/chat-view/prompt.test.ts
@@ -40,7 +40,7 @@ describe('DefaultPrompter', () => {
                 serverEndpoint: 'https://sourcegraph.com/.api/graphql',
             },
         })
-        vi.spyOn(localStorage, 'getEnrollmentHistory').mockReturnValue(false)
+        vi.spyOn(localStorage, 'tryToEnroll').mockReturnValue(true)
         vi.spyOn(contextFiltersProvider, 'isUriIgnored').mockResolvedValue(false)
         mockAuthStatus(AUTH_STATUS_FIXTURE_AUTHED)
         mockClientCapabilities(CLIENT_CAPABILITIES_FIXTURE)

--- a/vscode/src/completions/inline-completion-item-provider-e2e.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider-e2e.test.ts
@@ -407,7 +407,7 @@ describe.skip('InlineCompletionItemProvider E2E', () => {
     })
 })
 
-describe('InlineCompletionItemProvider preloading', () => {
+describe('InlineCompletionItemProvider preloading', { timeout: 10000 }, () => {
     const autocompleteConfig = {
         autocompleteAdvancedProvider: 'fireworks',
     } satisfies Partial<ClientConfiguration>

--- a/vscode/src/edit/input/get-input.ts
+++ b/vscode/src/edit/input/get-input.ts
@@ -226,7 +226,7 @@ export const getInput = async (
                     return
                 }
 
-                modelsService.setSelectedModel(ModelUsage.Edit, acceptedItem.model)
+                await modelsService.setSelectedModel(ModelUsage.Edit, acceptedItem.model)
                 activeModelItem = acceptedItem
                 activeModel = acceptedItem.model
                 activeModelContextWindow = getContextWindowOnModelChange(acceptedItem.model)

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -717,11 +717,13 @@ async function registerTestCommands(
             }
         }),
         // Access token - this is only used in configuration tests
-        vscode.commands.registerCommand('cody.test.token', async (serverEndpoint, token) =>
-            authProvider.validateAndStoreCredentials(
-                { credentials: { token }, serverEndpoint },
-                'always-store'
-            )
+        vscode.commands.registerCommand(
+            'cody.test.token',
+            async (serverEndpoint, token) =>
+                await authProvider.validateAndStoreCredentials(
+                    { credentials: { token }, serverEndpoint },
+                    'always-store'
+                )
         )
     )
 }

--- a/vscode/src/repository/repo-name-resolver.test.ts
+++ b/vscode/src/repository/repo-name-resolver.test.ts
@@ -27,7 +27,11 @@ describe('getRepoNamesContainingUri', () => {
     function prepareEnterpriseMocks(resolvedValue: string | null) {
         const repoNameResolver = new RepoNameResolver()
         mockAuthStatus(AUTH_STATUS_FIXTURE_AUTHED)
-        mockResolvedConfig({ auth: {} })
+        mockResolvedConfig({
+            auth: {
+                serverEndpoint: 'https://example.com',
+            },
+        })
         mockClientCapabilities(CLIENT_CAPABILITIES_FIXTURE)
 
         vi.spyOn(remoteUrlsFromParentDirs, 'gitRemoteUrlsForUri').mockResolvedValue([

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -170,10 +170,13 @@ class AuthProvider implements vscode.Disposable {
 
         // Keep context updated with auth status.
         this.subscriptions.push(
-            authStatus.subscribe(authStatus => {
+            authStatus.subscribe(async authStatus => {
                 try {
                     this.lastEndpoint = authStatus.endpoint
-                    vscode.commands.executeCommand('authStatus.update', authStatus)
+                    // if has command:
+                    if ((await vscode.commands.getCommands(true)).includes('authStatus.update')) {
+                        vscode.commands.executeCommand('authStatus.update', authStatus)
+                    }
                     vscode.commands.executeCommand(
                         'setContext',
                         'cody.activated',

--- a/vscode/src/services/LocalStorageProvider.ts
+++ b/vscode/src/services/LocalStorageProvider.ts
@@ -261,15 +261,13 @@ class LocalStorage implements LocalStorageForModelPreferences {
     }
 
     /**
-     * Gets the enrollment history for a feature from the storage.
-     *
      * Checks if the given feature name exists in the stored enrollment
      * history array.
      *
-     * If not, add the feature to the memory, but return false after adding the feature
+     * If not, add the feature to the memory, but return true after adding the feature
      * so that the caller can log the first enrollment event.
      */
-    public getEnrollmentHistory(featureName: string): boolean {
+    public tryToEnroll(featureName: string): boolean {
         const history = this.storage.get<string[]>(this.CODY_ENROLLMENT_HISTORY, []) || []
         const hasEnrolled = history?.includes(featureName) || false
         // Log the first enrollment event
@@ -277,7 +275,7 @@ class LocalStorage implements LocalStorageForModelPreferences {
             history.push(featureName)
             this.set(this.CODY_ENROLLMENT_HISTORY, history)
         }
-        return hasEnrolled
+        return !hasEnrolled
     }
 
     /**

--- a/vscode/src/services/utils/enrollment-event.ts
+++ b/vscode/src/services/utils/enrollment-event.ts
@@ -12,17 +12,17 @@ import { localStorage } from '../LocalStorageProvider'
  * @param isEnabled Whether the user has the feature flag enabled or not.
  */
 export function logFirstEnrollmentEvent(key: FeatureFlag, isEnabled: boolean): boolean {
-    // Check if the user is already enrolled in the experiment or not
-    const isEnrolled = localStorage.getEnrollmentHistory(key)
+    // Check if the user is able to enroll or if she is already enrolled in the experiment
+    const hasJustEnrolled = localStorage.tryToEnroll(key)
     // We only want to log the enrollment event once in the user's lifetime.
-    if (!isEnrolled) {
+    if (hasJustEnrolled) {
         const eventName = getFeatureFlagEventName(key)
         const args = { variant: isEnabled ? 'treatment' : 'control' }
         telemetryRecorder.recordEvent(`cody.experiment.${eventName}`, 'enrolled', {
             privateMetadata: args,
         })
     }
-    return isEnrolled
+    return !hasJustEnrolled
 }
 
 /**

--- a/vscode/test/integration/helpers.ts
+++ b/vscode/test/integration/helpers.ts
@@ -27,7 +27,7 @@ export async function beforeIntegrationTest(): Promise<void> {
     }
     if (!isAuthenticated()) {
         // Try waiting a bit longer.
-        await new Promise(resolve => setTimeout(resolve, 1000))
+        await new Promise(resolve => setTimeout(resolve, 2500))
         if (!isAuthenticated()) {
             throw new Error(
                 `Failed to authenticate for integration test (auth status is ${JSON.stringify(


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/CODY-4546/fix-the-flaky-agentsrcunauthedteststs-and-reenabled-it-back

## Changes

Until now `TestClient` despite having `secrets: AgentStatelessSecretStorage` field was not configured to use it.
Because of that it was impossible to properly test scenarios which required having pre-configured secret-storage content during the startup. After that fix I was able to slightly adjust and reenable unauth tests.

## Test plan

CI should be green.

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
