### PR TITLE
[JetBrains] Expire 'window/showMessage' notifications after an action trigger

### DIFF
--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentClient.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentClient.kt
@@ -7,7 +7,6 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.diagnostic.Logger
-import com.intellij.openapi.diagnostic.debug
 import com.intellij.openapi.fileChooser.FileChooserFactory
 import com.intellij.openapi.fileChooser.FileSaverDescriptor
 import com.intellij.openapi.fileEditor.FileEditorManager
@@ -16,6 +15,7 @@ import com.intellij.openapi.project.guessProjectDir
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.jetbrains.rd.util.firstOrNull
+import com.sourcegraph.Icons
 import com.sourcegraph.cody.agent.protocol.WebviewCreateWebviewPanelParams
 import com.sourcegraph.cody.agent.protocol_extensions.ProtocolTextDocumentExt
 import com.sourcegraph.cody.agent.protocol_generated.*
@@ -226,7 +226,15 @@ class CodyAgentClient(private val project: Project, private val webview: NativeW
 
     val selectedItem: CompletableFuture<String?> = CompletableFuture()
     params.items?.map { item ->
-      notification.addAction(SimpleDumbAwareEDTAction(item) { selectedItem.complete(item) })
+      notification.addAction(
+          SimpleDumbAwareEDTAction(item) {
+            selectedItem.complete(item)
+            // The API does not allow us to handle multiple triggers of actions for the same
+            // notifications
+            // (either the same action, nor two different actions for a single notification).
+            // Hence, we need to expire the notification on any action.
+            notification.expire()
+          })
     }
     notification.addAction(
         SimpleDumbAwareEDTAction("Dismiss") {
@@ -235,6 +243,7 @@ class CodyAgentClient(private val project: Project, private val webview: NativeW
         })
 
     Notifications.Bus.notify(notification)
+    notification.setIcon(Icons.SourcegraphLogo)
     notification.notify(project)
 
     return selectedItem


### PR DESCRIPTION
<img width="448" alt="image" src="https://github.com/user-attachments/assets/a5dc4f02-19b2-497e-b708-28d6da83d85a" />

This PR changes two things:
1. Add the icon - previously, without it, our notifications looked anonymously and were easy to be omitted. 
2. Expires the notification after first trigger of any action. API does not allow us to handle multiple trigger rn. Let's do not confuse users with blue-available-text actions that do nothing.

## Test plan
- see the image above

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
