### PR TITLE
fix(chat): force refresh for EnhancedContextWindow

### DIFF
--- a/lib/shared/src/models/sync.ts
+++ b/lib/shared/src/models/sync.ts
@@ -192,7 +192,8 @@ export function syncModels({
                                         ),
                                         enableToolCody,
                                         featureFlagProvider.evaluateFeatureFlag(
-                                            FeatureFlag.EnhancedContextWindow
+                                            FeatureFlag.EnhancedContextWindow,
+                                            true
                                         ),
                                         featureFlagProvider.evaluateFeatureFlag(
                                             FeatureFlag.FallbackToFlash

--- a/lib/shared/src/models/sync.ts
+++ b/lib/shared/src/models/sync.ts
@@ -193,7 +193,7 @@ export function syncModels({
                                         enableToolCody,
                                         featureFlagProvider.evaluateFeatureFlag(
                                             FeatureFlag.EnhancedContextWindow,
-                                            true
+                                            true /** force refresh */
                                         ),
                                         featureFlagProvider.evaluateFeatureFlag(
                                             FeatureFlag.FallbackToFlash


### PR DESCRIPTION
force EnhancedContextWindow feature flag value to fresh each time instead of using the cache

## Test plan
CI
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
