### PR TITLE
feat(chat): Update the displayed message for rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **AI coding agent with the best codebase understanding**
 
-Cody is an AI coding agent that uses the latest LLMs and codebase context to help you understand, write, and fix code faster.
+Cody is an AI coding agent that uses the latest LLMs and codebase context to help you understand, write, and fix code faster. 
 
 [Docs](https://sourcegraph.com/docs/cody) • [cody.dev](https://about.sourcegraph.com/cody?utm_source=github.com&utm_medium=referral)
 

--- a/lib/shared/src/models/sync.ts
+++ b/lib/shared/src/models/sync.ts
@@ -195,7 +195,8 @@ export function syncModels({
                                             FeatureFlag.EnhancedContextWindow
                                         ),
                                         featureFlagProvider.evaluateFeatureFlag(
-                                            FeatureFlag.FallbackToFlash
+                                            FeatureFlag.FallbackToFlash,
+                                            true
                                         )
                                     ).pipe(
                                         switchMap(
@@ -239,16 +240,6 @@ export function syncModels({
                                                             serverModelsConfig
                                                         )
                                                 }
-
-                                                // NOTE: Calling `registerModelsFromVSCodeConfiguration()` doesn't
-                                                // entirely make sense in a world where LLM models are managed
-                                                // server-side. However, this is how Cody can be extended to use locally
-                                                // running LLMs such as Ollama. (Though some more testing is needed.)
-                                                // See:
-                                                // https://sourcegraph.com/blog/local-code-completion-with-ollama-and-cody
-                                                data.primaryModels.push(
-                                                    ...getModelsFromVSCodeConfiguration(config)
-                                                )
 
                                                 // TODO(sqs): remove waitlist from localStorage when user has access
                                                 if (isDotComUser && hasEarlyAccess) {
@@ -471,6 +462,16 @@ export function syncModels({
                                                         }
                                                     }
                                                 }
+
+                                                // NOTE: Calling `registerModelsFromVSCodeConfiguration()` doesn't
+                                                // entirely make sense in a world where LLM models are managed
+                                                // server-side. However, this is how Cody can be extended to use locally
+                                                // running LLMs such as Ollama (BYOK). (Though some more testing is needed.)
+                                                // See:
+                                                // https://sourcegraph.com/blog/local-code-completion-with-ollama-and-cody
+                                                data.primaryModels.push(
+                                                    ...getModelsFromVSCodeConfiguration(config)
+                                                )
 
                                                 data.primaryModels = data.primaryModels.map(model => {
                                                     if (

--- a/vscode/webviews/ChatErrorNotice.story.tsx
+++ b/vscode/webviews/ChatErrorNotice.story.tsx
@@ -60,3 +60,70 @@ export const ChatRateLimitPro: Story = {
         },
     },
 }
+
+export const ApiVersionError: Story = {
+    args: {
+        error: errorToChatError(new Error('Request failed: unable to determine Cody API version')),
+        userInfo: {
+            isDotComUser: true,
+            isCodyProUser: false,
+        },
+        humanMessage: {
+            rerunWithDifferentContext: () => {},
+            hasInitialContext: { repositories: false, files: false },
+            hasExplicitMentions: false,
+            appendAtMention: () => {},
+        },
+    },
+}
+
+export const RateLimitFreeUser: Story = {
+    args: {
+        error: new RateLimitError(
+            'chat messages and commands',
+            'Chat',
+            true,
+            20,
+            String(60 * 60 * 24 * 25)
+        ), // 25 days
+        postMessage: () => {},
+        userInfo: {
+            isDotComUser: true,
+            isCodyProUser: false,
+        },
+    },
+}
+
+export const RateLimitProUser: Story = {
+    args: {
+        error: new RateLimitError(
+            'chat messages and commands',
+            'Chat',
+            false,
+            500,
+            String(60 * 60 * 24 * 5)
+        ), // 5 days
+        postMessage: () => {},
+        userInfo: {
+            isDotComUser: true,
+            isCodyProUser: true,
+        },
+    },
+}
+
+export const RateLimitEnterpriseUser: Story = {
+    args: {
+        error: new RateLimitError(
+            'chat messages and commands',
+            'Chat',
+            false,
+            1000,
+            String(60 * 60 * 24 * 2)
+        ), // 2 days
+        postMessage: () => {},
+        userInfo: {
+            isDotComUser: false,
+            isCodyProUser: true,
+        },
+    },
+}


### PR DESCRIPTION
Update the displayed message for rate limiting
Put this behind the feature flag FallbackToFlash 

## Test plan
- Open Cody
- Send messages to hit the rate limit
- Free user: `Upgrade to Cody Pro`
- Pro user: `Upgrade to Cody Enterprise`
- Enterprise: `Usage limit of premium models reached, switching the model to Gemini Flash` AND `You can continue using Gemini Flash, or other standard models.`

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
