### PR TITLE
fix(autoedit): add request body to the autoedit debug panel

### DIFF
--- a/vscode/src/autoedits/adapters/model-response/fireworks.ts
+++ b/vscode/src/autoedits/adapters/model-response/fireworks.ts
@@ -2,7 +2,7 @@ import { createSSEIterator, fetch, isAbortError, isNodeResponse } from '@sourceg
 import {
     AutoeditStopReason,
     type ModelResponse,
-    ModelResponseShared,
+    type ModelResponseShared,
     type SuccessModelResponse,
 } from '../base'
 import type { AutoeditsRequestBody } from '../utils'

--- a/vscode/webviews/autoedit-debug/sections/PromptSection.tsx
+++ b/vscode/webviews/autoedit-debug/sections/PromptSection.tsx
@@ -64,7 +64,7 @@ export const PromptSection: FC<{ entry: AutoeditRequestDebugState }> = ({ entry 
     // Format the prompt based on its type
     function formatPrompt(): string {
         if (!requestBody) {
-            return 'No prompt data available'
+            return 'Prompt is only available for loaded requests'
         }
 
         try {
@@ -149,7 +149,17 @@ export const PromptSection: FC<{ entry: AutoeditRequestDebugState }> = ({ entry 
 
     // Don't render anything if there's no prompt data
     if (!modelResponse?.requestBody) {
-        return null
+        return (
+            <div className="tw-mb-4 tw-flex tw-flex-col tw-h-full">
+                <div className="tw-flex tw-justify-end tw-items-center tw-mb-2">
+                    <div className="tw-flex tw-space-x-2">
+                        <div className="tw-text-xs tw-text-gray-600">
+                            Prompt is only available for loaded requests
+                        </div>
+                    </div>
+                </div>
+            </div>
+        )
     }
 
     // CSS classes for prompt text - always using full height now


### PR DESCRIPTION
Add the missing `requestBody` to the model response to surface it in the auto-edit debug panel.

## Test plan

manually check the autoedit debug panel while connected to DotCom
