### PR TITLE
feat(auto-edit): Add a feedback tab in the autoedit debug panel

### DIFF
--- a/lib/shared/src/completions/types.ts
+++ b/lib/shared/src/completions/types.ts
@@ -3,7 +3,7 @@ import type { URI } from 'vscode-uri'
 
 export type AutocompleteContextSnippetMetadataFields = Record<string, number | string>
 
-interface AutocompleteContextSnippetMetadata {
+export interface AutocompleteContextSnippetMetadata {
     /**
      * This field is relevant for user action context sources such as `recent-edit`, `recent-copy` and `recent-viewport`.
      * It indicates the time in milliseconds since the action was performed (eg: time Since the last edit).

--- a/vscode/src/autoedits/analytics-logger/analytics-logger.test.ts
+++ b/vscode/src/autoedits/analytics-logger/analytics-logger.test.ts
@@ -14,7 +14,7 @@ import { getCurrentDocContext } from '../../completions/get-current-doc-context'
 import { documentAndPosition } from '../../completions/test-helpers'
 import * as sentryModule from '../../services/sentry/sentry'
 import { type AutoeditModelOptions, AutoeditStopReason } from '../adapters/base'
-import { getCodeToReplaceData } from '../prompt/prompt-utils'
+import { getCodeToReplaceData, getCurrentFilePath } from '../prompt/prompt-utils'
 import { getDecorationInfo } from '../renderer/diff-utils'
 
 import { AutoeditAnalyticsLogger } from './analytics-logger'
@@ -74,6 +74,7 @@ describe('AutoeditAnalyticsLogger', () => {
     function getRequestStartMetadata(): Parameters<AutoeditAnalyticsLogger['createRequest']>[0] {
         return {
             startedAt: performance.now(),
+            filePath: getCurrentFilePath(document).toString(),
             docContext,
             document,
             position,
@@ -95,6 +96,7 @@ describe('AutoeditAnalyticsLogger', () => {
 
         autoeditLogger.markAsContextLoaded({
             requestId,
+            context: [],
             payload: {
                 contextSummary: {
                     strategy: 'none',
@@ -320,7 +322,11 @@ describe('AutoeditAnalyticsLogger', () => {
 
     it.skip('logs `discarded` if the suggestion was not suggested for any reason', () => {
         const requestId = autoeditLogger.createRequest(getRequestStartMetadata())
-        autoeditLogger.markAsContextLoaded({ requestId, payload: { contextSummary: undefined } })
+        autoeditLogger.markAsContextLoaded({
+            requestId,
+            context: [],
+            payload: { contextSummary: undefined },
+        })
         autoeditLogger.markAsDiscarded({
             requestId,
             discardReason: autoeditDiscardReason.emptyPrediction,

--- a/vscode/src/autoedits/analytics-logger/analytics-logger.ts
+++ b/vscode/src/autoedits/analytics-logger/analytics-logger.ts
@@ -531,18 +531,17 @@ export class AutoeditAnalyticsLogger {
     }
 
     public logFeedback(feedbackData: AutoeditFeedbackData): void {
-        const { metadata, privateMetadata } = splitSafeMetadata(feedbackData)
-
         this.writeAutoeditEvent({
             action: 'feedback-submitted',
             logDebugArgs: [`Feedback submitted for file: ${feedbackData.file_path}`],
             telemetryParams: {
                 version: 0,
                 metadata: {
-                    ...metadata,
                     recordsPrivateMetadataTranscript: 1,
                 },
-                privateMetadata,
+                privateMetadata: {
+                    inlineCompletionItemContext: feedbackData,
+                },
                 billingMetadata: {
                     product: 'cody',
                     category: 'core',

--- a/vscode/src/autoedits/analytics-logger/analytics-logger.ts
+++ b/vscode/src/autoedits/analytics-logger/analytics-logger.ts
@@ -25,6 +25,7 @@ import type { CodeToReplaceData } from '../prompt/prompt-utils'
 import type { DecorationInfo } from '../renderer/decorators/base'
 import { getDecorationStats } from '../renderer/diff-utils'
 
+import type { AutocompleteContextSnippet } from '../../../../lib/shared/src/completions/types'
 import { autoeditDebugStore } from '../debug-panel/debug-store'
 import type { AutoEditRenderOutput } from '../renderer/render-output'
 import { autoeditIdRegistry } from './suggestion-id-registry'
@@ -90,6 +91,7 @@ export class AutoeditAnalyticsLogger {
      */
     public createRequest({
         startedAt,
+        filePath,
         payload,
         codeToReplaceData,
         document,
@@ -97,6 +99,7 @@ export class AutoeditAnalyticsLogger {
         docContext,
     }: {
         startedAt: number
+        filePath: string
         codeToReplaceData: CodeToReplaceData
         document: vscode.TextDocument
         position: vscode.Position
@@ -113,6 +116,7 @@ export class AutoeditAnalyticsLogger {
             requestId,
             phase: 'started',
             startedAt,
+            filePath,
             codeToReplaceData,
             document,
             position,
@@ -136,14 +140,17 @@ export class AutoeditAnalyticsLogger {
 
     public markAsContextLoaded({
         requestId,
+        context,
         payload,
     }: {
         requestId: AutoeditRequestID
+        context: AutocompleteContextSnippet[]
         payload: Pick<ContextLoadedState['payload'], 'contextSummary'>
     }): void {
         this.tryTransitionTo(requestId, 'contextLoaded', request => ({
             ...request,
             contextLoadedAt: getTimeNowInMillis(),
+            context,
             payload: {
                 ...request.payload,
                 contextSummary: payload.contextSummary,

--- a/vscode/src/autoedits/analytics-logger/types.ts
+++ b/vscode/src/autoedits/analytics-logger/types.ts
@@ -1,6 +1,6 @@
 import type * as vscode from 'vscode'
 
-import type { DocumentContext } from '@sourcegraph/cody-shared'
+import type { AutocompleteContextSnippet, DocumentContext } from '@sourcegraph/cody-shared'
 
 import type { ContextSummary } from '../../completions/context/context-mixer'
 import type { CodeGenEventMetadata } from '../../services/CharactersLogger'
@@ -170,6 +170,9 @@ export interface StartedState extends AutoeditBaseState {
     /** Time (ms) when we started computing or requesting the suggestion. */
     startedAt: number
 
+    /** The relative file path of the document being edited. */
+    filePath: string
+
     /** Metadata required to show a suggestion based on `requestId` only. */
     codeToReplaceData: CodeToReplaceData
     document: vscode.TextDocument
@@ -212,6 +215,8 @@ export interface ContextLoadedState extends Omit<StartedState, 'phase' | 'payloa
     phase: 'contextLoaded'
     /** Timestamp when the context for the autoedit was loaded. */
     contextLoadedAt: number
+    /** Context snippets used by the autoedit model to create a prompt */
+    context: AutocompleteContextSnippet[]
     payload: StartedState['payload'] & {
         /**
          * Information about the context retrieval process that lead to this autoedit request. Refer

--- a/vscode/src/autoedits/analytics-logger/types.ts
+++ b/vscode/src/autoedits/analytics-logger/types.ts
@@ -1,7 +1,7 @@
 import type * as vscode from 'vscode'
 
-import type { AutocompleteContextSnippet, DocumentContext } from '@sourcegraph/cody-shared'
-
+import type { DocumentContext } from '@sourcegraph/cody-shared'
+import type { InlineCompletionItemRetrievedContext } from '../../../src/completions/analytics-logger'
 import type { ContextSummary } from '../../completions/context/context-mixer'
 import type { CodeGenEventMetadata } from '../../services/CharactersLogger'
 import type { ModelResponse } from '../adapters/base'
@@ -216,7 +216,7 @@ export interface ContextLoadedState extends Omit<StartedState, 'phase' | 'payloa
     /** Timestamp when the context for the autoedit was loaded. */
     contextLoadedAt: number
     /** Context snippets used by the autoedit model to create a prompt */
-    context: AutocompleteContextSnippet[]
+    context: InlineCompletionItemRetrievedContext[]
     payload: StartedState['payload'] & {
         /**
          * Information about the context retrieval process that lead to this autoedit request. Refer
@@ -381,4 +381,18 @@ export type AutoeditRequestState = PhaseStates[keyof PhaseStates]
 export interface AutoeditRequestStateForAgentTesting {
     phase?: Phase
     read?: boolean
+}
+
+export interface AutoeditFeedbackData {
+    source: 'feedback'
+    file_path: string
+    prefix: string
+    suffix: string
+    code_to_rewrite_prefix: string
+    code_to_rewrite_suffix: string
+    context: InlineCompletionItemRetrievedContext[]
+    chosen: string
+    rejected: string
+    assertions: string
+    is_reviewed: boolean
 }

--- a/vscode/src/autoedits/autoedits-provider.ts
+++ b/vscode/src/autoedits/autoedits-provider.ts
@@ -45,6 +45,7 @@ import { FilterPredictionBasedOnRecentEdits } from './filter-prediction-edits'
 import { autoeditsOutputChannelLogger } from './output-channel-logger'
 import { PromptCacheOptimizedV1 } from './prompt/prompt-cache-optimized-v1'
 import { type CodeToReplaceData, getCodeToReplaceData } from './prompt/prompt-utils'
+import { getCurrentFilePath } from './prompt/prompt-utils'
 import type { DecorationInfo } from './renderer/decorators/base'
 import { DefaultDecorator } from './renderer/decorators/default-decorator'
 import { InlineDiffDecorator } from './renderer/decorators/inline-diff-decorator'
@@ -304,6 +305,7 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
             const { codeToRewrite } = codeToReplaceData
             const requestId = autoeditAnalyticsLogger.createRequest({
                 startedAt,
+                filePath: getCurrentFilePath(document).toString(),
                 codeToReplaceData,
                 position,
                 docContext,
@@ -343,6 +345,7 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
             }
             autoeditAnalyticsLogger.markAsContextLoaded({
                 requestId,
+                context,
                 payload: { contextSummary },
             })
 

--- a/vscode/src/autoedits/autoedits-provider.ts
+++ b/vscode/src/autoedits/autoedits-provider.ts
@@ -2,6 +2,8 @@ import { type DebouncedFunc, debounce } from 'lodash'
 import { Observable } from 'observable-fns'
 import * as vscode from 'vscode'
 
+import { type Attributes, metrics } from '@opentelemetry/api'
+import type { Histogram } from '@opentelemetry/api'
 import {
     type ChatClient,
     type ClientCapabilities,
@@ -9,9 +11,6 @@ import {
     currentResolvedConfig,
     tokensToChars,
 } from '@sourcegraph/cody-shared'
-
-import { type Attributes, metrics } from '@opentelemetry/api'
-import type { Histogram } from '@opentelemetry/api'
 import type { CompletionBookkeepingEvent } from '../completions/analytics-logger'
 import { ContextRankingStrategy } from '../completions/context/completions-context-ranker'
 import { ContextMixer } from '../completions/context/context-mixer'

--- a/vscode/src/autoedits/debug-panel/autoedit-data-sdk.ts
+++ b/vscode/src/autoedits/debug-panel/autoedit-data-sdk.ts
@@ -1,3 +1,4 @@
+import type { InlineCompletionItemRetrievedContext } from '../../completions/analytics-logger'
 import type { ModelResponse, SuccessModelResponse } from '../adapters/base'
 import { getDetailedTimingInfo } from './autoedit-latency-utils'
 import type { AutoeditRequestDebugState } from './debug-store'
@@ -117,16 +118,9 @@ export const getCodeToRewrite = (entry: AutoeditRequestDebugState): string | und
     return undefined
 }
 
-export const getContext = (entry: AutoeditRequestDebugState): Array<Record<string, any>> => {
+export const getContext = (entry: AutoeditRequestDebugState): InlineCompletionItemRetrievedContext[] => {
     if ('context' in entry.state) {
-        const context = entry.state.context
-        const transformedContext = context.map(item => ({
-            filePath: item.uri?.path || '',
-            identifier: item.identifier,
-            content: item.content,
-            metadata: item.metadata,
-        }))
-        return transformedContext
+        return entry.state.context
     }
     return []
 }

--- a/vscode/src/autoedits/debug-panel/autoedit-data-sdk.ts
+++ b/vscode/src/autoedits/debug-panel/autoedit-data-sdk.ts
@@ -259,7 +259,7 @@ export const formatTriggerKind = (triggerKind?: number): string => {
  */
 export const getPrediction = (entry: AutoeditRequestDebugState): string | null => {
     if ('prediction' in entry.state && typeof entry.state.prediction === 'string') {
-        return entry.state.prediction.trim()
+        return entry.state.prediction
     }
     return null
 }

--- a/vscode/src/autoedits/debug-panel/autoedit-data-sdk.ts
+++ b/vscode/src/autoedits/debug-panel/autoedit-data-sdk.ts
@@ -6,6 +6,7 @@ export const extractAutoeditData = (entry: AutoeditRequestDebugState) => {
     const phase = entry.state.phase
     const discardReason = getDiscardReason(entry)
     const filePath = getFilePath(entry)
+    const fileName = getFileName(entry)
     const codeToRewrite = getCodeToRewrite(entry)
     const prediction = getPrediction(entry)
     const triggerKind = getTriggerKind(entry)
@@ -17,11 +18,13 @@ export const extractAutoeditData = (entry: AutoeditRequestDebugState) => {
     const document = getDocument(entry)
     const position = getPosition(entry)
     const modelResponse = getModelResponse(entry)
+    const context = getContext(entry)
 
     return {
         phase,
         discardReason,
         filePath,
+        fileName,
         codeToRewrite,
         prediction,
         triggerKind,
@@ -33,6 +36,7 @@ export const extractAutoeditData = (entry: AutoeditRequestDebugState) => {
         document,
         position,
         modelResponse,
+        context,
     }
 }
 
@@ -78,9 +82,16 @@ export const getModel = (entry: AutoeditRequestDebugState): string | null => {
 }
 
 /**
- * Extracts the file path from an autoedit entry
+ * Extracts the relative file path from an autoedit entry relative to workspace root.
  */
 export const getFilePath = (entry: AutoeditRequestDebugState): string => {
+    return entry.state.filePath
+}
+
+/**
+ * Extracts the file name from an autoedit entry
+ */
+export const getFileName = (entry: AutoeditRequestDebugState): string => {
     if ('document' in entry.state && entry.state.document) {
         // Access the URI property of the document which should contain the path
         // Using optional chaining to safely access properties
@@ -104,6 +115,20 @@ export const getCodeToRewrite = (entry: AutoeditRequestDebugState): string | und
         return entry.state.codeToReplaceData.codeToRewrite
     }
     return undefined
+}
+
+export const getContext = (entry: AutoeditRequestDebugState): Array<Record<string, any>> => {
+    if ('context' in entry.state) {
+        const context = entry.state.context
+        const transformedContext = context.map(item => ({
+            filePath: item.uri?.path || '',
+            identifier: item.identifier,
+            content: item.content,
+            metadata: item.metadata,
+        }))
+        return transformedContext
+    }
+    return []
 }
 
 /**
@@ -305,6 +330,7 @@ export const AutoeditDataSDK = {
     extractAutoeditData,
     getStartTime,
     getFilePath,
+    getFileName,
     getCodeToRewrite,
     getTriggerKind,
     getPositionInfo,

--- a/vscode/src/autoedits/debug-panel/debug-panel.ts
+++ b/vscode/src/autoedits/debug-panel/debug-panel.ts
@@ -1,7 +1,13 @@
 import * as vscode from 'vscode'
 
 import { manipulateWebviewHTML } from '../../chat/chat-view/ChatController'
-import type { AutoeditDebugMessageFromExtension } from './debug-protocol'
+import { autoeditAnalyticsLogger } from '../analytics-logger/analytics-logger'
+import type { AutoeditFeedbackData } from '../analytics-logger/types'
+import type {
+    AutoeditDebugMessageFromExtension,
+    AutoeditDebugMessageFromWebview,
+} from './debug-protocol'
+import type { AutoeditRequestDebugState } from './debug-store'
 
 import { autoeditDebugStore } from './debug-store'
 
@@ -45,15 +51,33 @@ export class AutoeditDebugPanel {
 
         // Handle messages from the webview
         this.panel.webview.onDidReceiveMessage(
-            message => {
-                if (message.type === 'ready') {
-                    // Send the initial data when the webview is ready
-                    void this.updateContent()
+            (message: AutoeditDebugMessageFromWebview) => {
+                console.log('Received message for submitting: ', message)
+                switch (message.type) {
+                    case 'ready':
+                        // Send the initial data when the webview is ready
+                        void this.updateContent()
+                        break
+                    case 'submitFeedback':
+                        // Handle feedback submission
+                        this.handleFeedbackSubmission(message.entry, message.feedback)
+                        break
                 }
             },
             null,
             this.disposables
         )
+    }
+
+    private handleFeedbackSubmission(
+        entry: AutoeditRequestDebugState,
+        feedback: AutoeditFeedbackData
+    ): void {
+        // Log the feedback using the analytics logger
+        autoeditAnalyticsLogger.logFeedback(feedback)
+
+        // Show a notification to the user
+        void vscode.window.showInformationMessage('Feedback submitted successfully')
     }
 
     /**

--- a/vscode/src/autoedits/debug-panel/debug-protocol.ts
+++ b/vscode/src/autoedits/debug-panel/debug-protocol.ts
@@ -1,3 +1,4 @@
+import type { AutoeditFeedbackData } from '../analytics-logger/types'
 import type { AutoeditRequestDebugState } from './debug-store'
 import type { AutoeditSessionStats, StatisticsEntry } from './session-stats'
 
@@ -8,7 +9,13 @@ export type AutoeditDebugMessageFromExtension = {
     statsForLastNRequests: StatisticsEntry[]
 }
 
-export type AutoeditDebugMessageFromWebview = { type: 'ready' }
+export type AutoeditDebugMessageFromWebview =
+    | { type: 'ready' }
+    | {
+          type: 'submitFeedback'
+          entry: AutoeditRequestDebugState
+          feedback: AutoeditFeedbackData
+      }
 
 export interface VSCodeAutoeditDebugWrapper {
     postMessage: (message: AutoeditDebugMessageFromWebview) => void

--- a/vscode/src/autoedits/prompt/prompt-utils.ts
+++ b/vscode/src/autoedits/prompt/prompt-utils.ts
@@ -195,7 +195,7 @@ export function getCodeToReplaceData(options: CurrentFilePromptOptions): CodeToR
     }
 }
 
-function getCurrentFilePath(document: vscode.TextDocument): PromptString {
+export function getCurrentFilePath(document: vscode.TextDocument): PromptString {
     const uri =
         document.uri.scheme === 'vscode-notebook-cell'
             ? getActiveNotebookUri() ?? document.uri

--- a/vscode/webviews/autoedit-debug.tsx
+++ b/vscode/webviews/autoedit-debug.tsx
@@ -93,6 +93,7 @@ function App() {
                 entries={state?.entries ?? []}
                 sessionStats={state?.sessionStats}
                 statsForLastNRequests={state?.statsForLastNRequests ?? []}
+                vscode={vscode}
             />
         </div>
     )

--- a/vscode/webviews/autoedit-debug.tsx
+++ b/vscode/webviews/autoedit-debug.tsx
@@ -2,13 +2,10 @@ import './autoedit-debug/autoedit-debug.css'
 import { useEffect, useState } from 'react'
 import { createRoot } from 'react-dom/client'
 
-import type {
-    AutoeditDebugMessageFromExtension,
-    VSCodeAutoeditDebugWrapper,
-} from '../src/autoedits/debug-panel/debug-protocol'
+import type { AutoeditDebugMessageFromExtension } from '../src/autoedits/debug-panel/debug-protocol'
 
 import { AutoeditDebugPanel } from './autoedit-debug/AutoeditDebugPanel'
-import { getVSCodeAPI } from './utils/VSCodeApi'
+import { vscode } from './autoedit-debug/webview-api'
 
 /**
  * Transforms array-formatted VS Code Range objects back into proper Range objects with start and end properties.
@@ -54,8 +51,6 @@ function transformRanges(obj: any): any {
     return obj
 }
 
-const vscode = getVSCodeAPI() as unknown as VSCodeAutoeditDebugWrapper
-
 function App() {
     const [state, setState] = useState<Omit<AutoeditDebugMessageFromExtension, 'type'> | null>(null)
 
@@ -93,7 +88,6 @@ function App() {
                 entries={state?.entries ?? []}
                 sessionStats={state?.sessionStats}
                 statsForLastNRequests={state?.statsForLastNRequests ?? []}
-                vscode={vscode}
             />
         </div>
     )

--- a/vscode/webviews/autoedit-debug/AutoeditDebugPanel.tsx
+++ b/vscode/webviews/autoedit-debug/AutoeditDebugPanel.tsx
@@ -1,5 +1,6 @@
 import { type FC, useCallback, useEffect, useMemo, useState } from 'react'
 
+import type { VSCodeAutoeditDebugWrapper } from '../../src/autoedits/debug-panel/debug-protocol'
 import type { AutoeditRequestDebugState } from '../../src/autoedits/debug-panel/debug-store'
 import type {
     AutoeditSessionStats,
@@ -31,7 +32,8 @@ export const AutoeditDebugPanel: FC<{
     entries: AutoeditRequestDebugState[]
     sessionStats?: AutoeditSessionStats
     statsForLastNRequests: StatisticsEntry[]
-}> = ({ entries, sessionStats, statsForLastNRequests }) => {
+    vscode: VSCodeAutoeditDebugWrapper
+}> = ({ entries, sessionStats, statsForLastNRequests, vscode }) => {
     const [phaseFilter, setPhaseFilter] = useState<string>('All Phases')
     const [currentView, setCurrentView] = useState<'requests' | 'stats'>('requests')
 
@@ -246,6 +248,7 @@ export const AutoeditDebugPanel: FC<{
                     onClose={handleClose}
                     hasPrevious={hasPrevious}
                     hasNext={hasNext}
+                    vscode={vscode}
                 />
             </div>
         </div>

--- a/vscode/webviews/autoedit-debug/AutoeditDebugPanel.tsx
+++ b/vscode/webviews/autoedit-debug/AutoeditDebugPanel.tsx
@@ -1,6 +1,5 @@
 import { type FC, useCallback, useEffect, useMemo, useState } from 'react'
 
-import type { VSCodeAutoeditDebugWrapper } from '../../src/autoedits/debug-panel/debug-protocol'
 import type { AutoeditRequestDebugState } from '../../src/autoedits/debug-panel/debug-store'
 import type {
     AutoeditSessionStats,
@@ -32,8 +31,7 @@ export const AutoeditDebugPanel: FC<{
     entries: AutoeditRequestDebugState[]
     sessionStats?: AutoeditSessionStats
     statsForLastNRequests: StatisticsEntry[]
-    vscode: VSCodeAutoeditDebugWrapper
-}> = ({ entries, sessionStats, statsForLastNRequests, vscode }) => {
+}> = ({ entries, sessionStats, statsForLastNRequests }) => {
     const [phaseFilter, setPhaseFilter] = useState<string>('All Phases')
     const [currentView, setCurrentView] = useState<'requests' | 'stats'>('requests')
 
@@ -248,7 +246,6 @@ export const AutoeditDebugPanel: FC<{
                     onClose={handleClose}
                     hasPrevious={hasPrevious}
                     hasNext={hasNext}
-                    vscode={vscode}
                 />
             </div>
         </div>

--- a/vscode/webviews/autoedit-debug/components/AutoeditDetailView.tsx
+++ b/vscode/webviews/autoedit-debug/components/AutoeditDetailView.tsx
@@ -3,6 +3,7 @@ import { ChevronLeft, ChevronRight, X } from 'lucide-react'
 import type { FC } from 'react'
 import { useState } from 'react'
 
+import type { VSCodeAutoeditDebugWrapper } from '../../../src/autoedits/debug-panel/debug-protocol'
 import type { AutoeditRequestDebugState } from '../../../src/autoedits/debug-panel/debug-store'
 import { Badge } from '../../components/shadcn/ui/badge'
 import { Button } from '../../components/shadcn/ui/button'
@@ -26,7 +27,8 @@ export const AutoeditDetailView: FC<{
     onClose: () => void
     hasPrevious: boolean
     hasNext: boolean
-}> = ({ entries, entry, onPrevious, onNext, onClose, hasPrevious, hasNext }) => {
+    vscode: VSCodeAutoeditDebugWrapper
+}> = ({ entries, entry, onPrevious, onNext, onClose, hasPrevious, hasNext, vscode }) => {
     const [activeTab, setActiveTab] = useState('timeline')
 
     // Extract all relevant data in one place using the SDK
@@ -198,7 +200,7 @@ export const AutoeditDetailView: FC<{
                     </TabsPrimitive.Content>
 
                     <TabsPrimitive.Content value="feedback" className="tw-space-y-8">
-                        <FeedbackSection entry={entry} />
+                        <FeedbackSection entry={entry} vscode={vscode} />
                     </TabsPrimitive.Content>
                 </div>
             </TabsPrimitive.Root>

--- a/vscode/webviews/autoedit-debug/components/AutoeditDetailView.tsx
+++ b/vscode/webviews/autoedit-debug/components/AutoeditDetailView.tsx
@@ -3,7 +3,6 @@ import { ChevronLeft, ChevronRight, X } from 'lucide-react'
 import type { FC } from 'react'
 import { useState } from 'react'
 
-import type { VSCodeAutoeditDebugWrapper } from '../../../src/autoedits/debug-panel/debug-protocol'
 import type { AutoeditRequestDebugState } from '../../../src/autoedits/debug-panel/debug-store'
 import { Badge } from '../../components/shadcn/ui/badge'
 import { Button } from '../../components/shadcn/ui/button'
@@ -27,8 +26,7 @@ export const AutoeditDetailView: FC<{
     onClose: () => void
     hasPrevious: boolean
     hasNext: boolean
-    vscode: VSCodeAutoeditDebugWrapper
-}> = ({ entries, entry, onPrevious, onNext, onClose, hasPrevious, hasNext, vscode }) => {
+}> = ({ entries, entry, onPrevious, onNext, onClose, hasPrevious, hasNext }) => {
     const [activeTab, setActiveTab] = useState('timeline')
 
     // Extract all relevant data in one place using the SDK
@@ -200,7 +198,7 @@ export const AutoeditDetailView: FC<{
                     </TabsPrimitive.Content>
 
                     <TabsPrimitive.Content value="feedback" className="tw-space-y-8">
-                        <FeedbackSection entry={entry} vscode={vscode} />
+                        <FeedbackSection entry={entry} />
                     </TabsPrimitive.Content>
                 </div>
             </TabsPrimitive.Root>

--- a/vscode/webviews/autoedit-debug/components/AutoeditDetailView.tsx
+++ b/vscode/webviews/autoedit-debug/components/AutoeditDetailView.tsx
@@ -15,6 +15,7 @@ import { ContextInfoSection } from '../sections/ContextInfoSection'
 import { NetworkRequestSection, NetworkResponseSection } from '../sections/NetworkRequestSection'
 import { PromptSection } from '../sections/PromptSection'
 import { TimelineSection } from '../sections/TimelineSection'
+import { FeedbackSection } from './FeedbackSection'
 import { SideBySideDiff } from './side-by-side-diff/SideBySideDiff'
 
 export const AutoeditDetailView: FC<{
@@ -29,7 +30,7 @@ export const AutoeditDetailView: FC<{
     const [activeTab, setActiveTab] = useState('timeline')
 
     // Extract all relevant data in one place using the SDK
-    const { phase, filePath, discardReason, position, prediction, codeToRewrite, triggerKind } =
+    const { phase, fileName, discardReason, position, prediction, codeToRewrite, triggerKind } =
         AutoeditDataSDK.extractAutoeditData(entry)
 
     return (
@@ -83,7 +84,7 @@ export const AutoeditDetailView: FC<{
 
                 <div>
                     <h2 className="tw-text-lg tw-font-semibold tw-truncate">
-                        {filePath}
+                        {fileName}
                         {position ? `:${position?.line + 1}:${position?.character + 1}` : ''}
                     </h2>
 
@@ -159,6 +160,9 @@ export const AutoeditDetailView: FC<{
                         <TabButton value="config" activeTab={activeTab}>
                             Config
                         </TabButton>
+                        <TabButton value="feedback" activeTab={activeTab}>
+                            Feedback
+                        </TabButton>
                     </TabsPrimitive.List>
                 </div>
 
@@ -189,6 +193,10 @@ export const AutoeditDetailView: FC<{
 
                     <TabsPrimitive.Content value="code-to-rewrite-data" className="tw-space-y-8">
                         <CodeToRewriteDataSection entry={entry} />
+                    </TabsPrimitive.Content>
+
+                    <TabsPrimitive.Content value="feedback" className="tw-space-y-8">
+                        <FeedbackSection entry={entry} />
                     </TabsPrimitive.Content>
                 </div>
             </TabsPrimitive.Root>

--- a/vscode/webviews/autoedit-debug/components/AutoeditDetailView.tsx
+++ b/vscode/webviews/autoedit-debug/components/AutoeditDetailView.tsx
@@ -94,6 +94,8 @@ export const AutoeditDetailView: FC<{
                             <SideBySideDiff
                                 sideBySideDiffDecorationInfo={entry.sideBySideDiffDecorationInfo}
                                 languageId={entry.state.payload.languageId}
+                                codeToRewrite={codeToRewrite || ''}
+                                prediction={prediction || ''}
                             />
                         </div>
                     )}

--- a/vscode/webviews/autoedit-debug/components/AutoeditListItem.tsx
+++ b/vscode/webviews/autoedit-debug/components/AutoeditListItem.tsx
@@ -63,15 +63,15 @@ const DetailedTiming: FC<{
 
 // Sub-component for file info
 const FileInfo: FC<{
-    filePath: string
+    fileName: string
     positionInfo: string
     inferenceTime?: string | null
     envoyUpstreamServiceTime?: string | null
-}> = ({ filePath, positionInfo, inferenceTime, envoyUpstreamServiceTime }) => (
+}> = ({ fileName, positionInfo, inferenceTime, envoyUpstreamServiceTime }) => (
     <div className="tw-flex tw-items-center tw-justify-between tw-w-full tw-text-sm tw-text-gray-700 tw-dark:tw-text-gray-300">
         <div className="tw-flex tw-items-center">
             <span className="tw-font-medium">
-                {`${filePath} ${positionInfo ? `:${positionInfo}` : ''}`}
+                {`${fileName} ${positionInfo ? `:${positionInfo}` : ''}`}
             </span>
         </div>
         {inferenceTime && (
@@ -120,7 +120,7 @@ export const AutoeditListItem: FC<AutoeditEntryItemProps> = ({ entry, isSelected
     // Extract all data from entry using the SDK
     const {
         phase,
-        filePath,
+        fileName,
         codeToRewrite = '',
         triggerKind,
         positionInfo,
@@ -185,7 +185,7 @@ export const AutoeditListItem: FC<AutoeditEntryItemProps> = ({ entry, isSelected
 
                     {/* File and position info */}
                     <FileInfo
-                        filePath={filePath}
+                        fileName={fileName}
                         positionInfo={positionInfo}
                         inferenceTime={timing.inferenceTime}
                         envoyUpstreamServiceTime={timing.envoyUpstreamServiceTime}

--- a/vscode/webviews/autoedit-debug/components/FeedbackSection.tsx
+++ b/vscode/webviews/autoedit-debug/components/FeedbackSection.tsx
@@ -28,15 +28,17 @@ export const FeedbackSection: FC<FeedbackSectionProps> = ({ entry }) => {
     }
 
     const feedbackJson = {
+        source: 'feedback',
         file_path: filePath,
         prefix: codeToReplaceData.prefixBeforeArea + codeToReplaceData.prefixInArea,
         suffix: codeToReplaceData.suffixInArea + codeToReplaceData.suffixAfterArea,
         code_to_rewrite_prefix: codeToReplaceData.codeToRewritePrefix,
         code_to_rewrite_suffix: codeToReplaceData.codeToRewriteSuffix,
+        context: context,
         chosen: expectedCode,
         rejected: prediction,
         assertions: assertions,
-        context: context,
+        is_reviewed: false,
     }
 
     const handleCopyJson = () => {

--- a/vscode/webviews/autoedit-debug/components/FeedbackSection.tsx
+++ b/vscode/webviews/autoedit-debug/components/FeedbackSection.tsx
@@ -2,7 +2,10 @@ import * as Form from '@radix-ui/react-form'
 import { ChevronDown, ChevronRight } from 'lucide-react'
 import type { FC } from 'react'
 import { useState } from 'react'
-import type { AutoeditFeedbackData } from '../../../src/autoedits/analytics-logger/types'
+import {
+    type AutoeditFeedbackData,
+    autoeditDiscardReason,
+} from '../../../src/autoedits/analytics-logger/types'
 import { AutoeditDataSDK } from '../../../src/autoedits/debug-panel/autoedit-data-sdk'
 import type { VSCodeAutoeditDebugWrapper } from '../../../src/autoedits/debug-panel/debug-protocol'
 import type { AutoeditRequestDebugState } from '../../../src/autoedits/debug-panel/debug-store'
@@ -21,7 +24,19 @@ export const FeedbackSection: FC<FeedbackSectionProps> = ({ entry, vscode }) => 
     const [isSubmitting, setIsSubmitting] = useState(false)
 
     const codeToReplaceData = entry.state.codeToReplaceData
-    const { filePath, prediction, context } = AutoeditDataSDK.extractAutoeditData(entry)
+    const {
+        filePath,
+        context,
+        prediction: initialPrediction,
+    } = AutoeditDataSDK.extractAutoeditData(entry)
+    let prediction = initialPrediction
+
+    if (
+        entry.state.phase === 'discarded' &&
+        entry.state.payload.discardReason === autoeditDiscardReason.predictionEqualsCodeToRewrite
+    ) {
+        prediction = codeToReplaceData.codeToRewrite
+    }
 
     if (!prediction) {
         return (

--- a/vscode/webviews/autoedit-debug/components/FeedbackSection.tsx
+++ b/vscode/webviews/autoedit-debug/components/FeedbackSection.tsx
@@ -1,0 +1,117 @@
+import * as Form from '@radix-ui/react-form'
+import { ChevronDown, ChevronRight } from 'lucide-react'
+import type { FC } from 'react'
+import { useState } from 'react'
+import { AutoeditDataSDK } from '../../../src/autoedits/debug-panel/autoedit-data-sdk'
+import type { AutoeditRequestDebugState } from '../../../src/autoedits/debug-panel/debug-store'
+import { Label } from '../../components/shadcn/ui/label'
+
+interface FeedbackSectionProps {
+    entry: AutoeditRequestDebugState
+}
+
+export const FeedbackSection: FC<FeedbackSectionProps> = ({ entry }) => {
+    const [expectedCode, setExpectedCode] = useState('')
+    const [assertions, setAssertions] = useState('')
+    const [copySuccess, setCopySuccess] = useState(false)
+    const [isJsonExpanded, setIsJsonExpanded] = useState(false)
+
+    const codeToReplaceData = entry.state.codeToReplaceData
+    const { filePath, prediction, context } = AutoeditDataSDK.extractAutoeditData(entry)
+
+    if (!prediction) {
+        return (
+            <div className="tw-text-gray-500 tw-text-center tw-py-8">
+                Feedback is only available for loaded requests
+            </div>
+        )
+    }
+
+    const feedbackJson = {
+        file_path: filePath,
+        prefix: codeToReplaceData.prefixBeforeArea + codeToReplaceData.prefixInArea,
+        suffix: codeToReplaceData.suffixInArea + codeToReplaceData.suffixAfterArea,
+        code_to_rewrite_prefix: codeToReplaceData.codeToRewritePrefix,
+        code_to_rewrite_suffix: codeToReplaceData.codeToRewriteSuffix,
+        chosen: expectedCode,
+        rejected: prediction,
+        assertions: assertions,
+        context: context,
+    }
+
+    const handleCopyJson = () => {
+        navigator.clipboard
+            .writeText(JSON.stringify(feedbackJson, null, 4))
+            .then(() => {
+                setCopySuccess(true)
+                setTimeout(() => setCopySuccess(false), 2000)
+            })
+            .catch(err => console.error('Failed to copy text: ', err))
+    }
+
+    return (
+        <Form.Root className="tw-space-y-6">
+            <Form.Field name="expected-code" className="tw-space-y-2">
+                <Label htmlFor="expected-code">Expected Code</Label>
+                <Form.Control asChild>
+                    <textarea
+                        id="expected-code"
+                        placeholder="Enter the code that the LLM should have generated..."
+                        className="tw-min-h-[200px] tw-font-mono tw-text-sm tw-w-full tw-p-2 tw-border tw-border-gray-200 tw-dark:tw-border-gray-700 tw-rounded tw-bg-white tw-dark:tw-bg-gray-800 tw-text-gray-900 tw-dark:tw-text-gray-100"
+                        value={expectedCode}
+                        onChange={e => setExpectedCode(e.target.value)}
+                    />
+                </Form.Control>
+            </Form.Field>
+
+            <Form.Field name="assertions" className="tw-space-y-2">
+                <Label htmlFor="assertions">Assertions</Label>
+                <Form.Control asChild>
+                    <textarea
+                        id="assertions"
+                        placeholder="Enter assertions to verify the code correctness..."
+                        className="tw-min-h-[100px] tw-font-mono tw-text-sm tw-w-full tw-p-2 tw-border tw-border-gray-200 tw-dark:tw-border-gray-700 tw-rounded tw-bg-white tw-dark:tw-bg-gray-800 tw-text-gray-900 tw-dark:tw-text-gray-100"
+                        value={assertions}
+                        onChange={e => setAssertions(e.target.value)}
+                    />
+                </Form.Control>
+            </Form.Field>
+
+            <div className="tw-mt-8">
+                <div className="tw-flex tw-justify-between tw-items-center tw-mb-2">
+                    <button
+                        type="button"
+                        onClick={() => setIsJsonExpanded(!isJsonExpanded)}
+                        className="tw-flex tw-items-center tw-gap-1 tw-text-sm tw-text-gray-600 hover:tw-text-gray-800 dark:tw-text-gray-400 dark:hover:tw-text-gray-200"
+                    >
+                        {isJsonExpanded ? (
+                            <>
+                                <ChevronDown className="tw-w-4 tw-h-4" />
+                                Hide JSON
+                            </>
+                        ) : (
+                            <>
+                                <ChevronRight className="tw-w-4 tw-h-4" />
+                                Show JSON
+                            </>
+                        )}
+                    </button>
+                    <button
+                        type="button"
+                        onClick={handleCopyJson}
+                        className="tw-text-xs tw-text-gray-600 hover:tw-text-gray-800 dark:tw-text-gray-400 dark:hover:tw-text-gray-200 tw-rounded tw-px-2 tw-py-1 tw-bg-gray-100 hover:tw-bg-gray-200 dark:tw-bg-gray-700 dark:hover:tw-bg-gray-600 tw-transition-colors tw-duration-150"
+                        title="Copy JSON to clipboard"
+                        aria-label="Copy JSON to clipboard"
+                    >
+                        {copySuccess ? 'Copied!' : 'Copy'}
+                    </button>
+                </div>
+                {isJsonExpanded && (
+                    <pre className="tw-bg-gray-100 tw-dark:tw-bg-gray-800 tw-p-4 tw-rounded tw-text-sm tw-font-mono tw-overflow-auto">
+                        {JSON.stringify(feedbackJson, null, 4)}
+                    </pre>
+                )}
+            </div>
+        </Form.Root>
+    )
+}

--- a/vscode/webviews/autoedit-debug/components/FeedbackSection.tsx
+++ b/vscode/webviews/autoedit-debug/components/FeedbackSection.tsx
@@ -7,16 +7,15 @@ import {
     autoeditDiscardReason,
 } from '../../../src/autoedits/analytics-logger/types'
 import { AutoeditDataSDK } from '../../../src/autoedits/debug-panel/autoedit-data-sdk'
-import type { VSCodeAutoeditDebugWrapper } from '../../../src/autoedits/debug-panel/debug-protocol'
 import type { AutoeditRequestDebugState } from '../../../src/autoedits/debug-panel/debug-store'
 import { Label } from '../../components/shadcn/ui/label'
+import { vscode } from '../webview-api'
 
 interface FeedbackSectionProps {
     entry: AutoeditRequestDebugState
-    vscode: VSCodeAutoeditDebugWrapper
 }
 
-export const FeedbackSection: FC<FeedbackSectionProps> = ({ entry, vscode }) => {
+export const FeedbackSection: FC<FeedbackSectionProps> = ({ entry }) => {
     const [expectedCode, setExpectedCode] = useState('')
     const [assertions, setAssertions] = useState('')
     const [copySuccess, setCopySuccess] = useState(false)

--- a/vscode/webviews/autoedit-debug/components/FeedbackSection.tsx
+++ b/vscode/webviews/autoedit-debug/components/FeedbackSection.tsx
@@ -2,19 +2,23 @@ import * as Form from '@radix-ui/react-form'
 import { ChevronDown, ChevronRight } from 'lucide-react'
 import type { FC } from 'react'
 import { useState } from 'react'
+import type { AutoeditFeedbackData } from '../../../src/autoedits/analytics-logger/types'
 import { AutoeditDataSDK } from '../../../src/autoedits/debug-panel/autoedit-data-sdk'
+import type { VSCodeAutoeditDebugWrapper } from '../../../src/autoedits/debug-panel/debug-protocol'
 import type { AutoeditRequestDebugState } from '../../../src/autoedits/debug-panel/debug-store'
 import { Label } from '../../components/shadcn/ui/label'
 
 interface FeedbackSectionProps {
     entry: AutoeditRequestDebugState
+    vscode: VSCodeAutoeditDebugWrapper
 }
 
-export const FeedbackSection: FC<FeedbackSectionProps> = ({ entry }) => {
+export const FeedbackSection: FC<FeedbackSectionProps> = ({ entry, vscode }) => {
     const [expectedCode, setExpectedCode] = useState('')
     const [assertions, setAssertions] = useState('')
     const [copySuccess, setCopySuccess] = useState(false)
     const [isJsonExpanded, setIsJsonExpanded] = useState(false)
+    const [isSubmitting, setIsSubmitting] = useState(false)
 
     const codeToReplaceData = entry.state.codeToReplaceData
     const { filePath, prediction, context } = AutoeditDataSDK.extractAutoeditData(entry)
@@ -27,7 +31,7 @@ export const FeedbackSection: FC<FeedbackSectionProps> = ({ entry }) => {
         )
     }
 
-    const feedbackJson = {
+    const feedbackJson: AutoeditFeedbackData = {
         source: 'feedback',
         file_path: filePath,
         prefix: codeToReplaceData.prefixBeforeArea + codeToReplaceData.prefixInArea,
@@ -49,6 +53,16 @@ export const FeedbackSection: FC<FeedbackSectionProps> = ({ entry }) => {
                 setTimeout(() => setCopySuccess(false), 2000)
             })
             .catch(err => console.error('Failed to copy text: ', err))
+    }
+
+    const handleSubmit = () => {
+        setIsSubmitting(true)
+        vscode.postMessage({
+            type: 'submitFeedback',
+            entry,
+            feedback: feedbackJson,
+        })
+        setIsSubmitting(false)
     }
 
     return (
@@ -98,15 +112,27 @@ export const FeedbackSection: FC<FeedbackSectionProps> = ({ entry }) => {
                             </>
                         )}
                     </button>
-                    <button
-                        type="button"
-                        onClick={handleCopyJson}
-                        className="tw-text-xs tw-text-gray-600 hover:tw-text-gray-800 dark:tw-text-gray-400 dark:hover:tw-text-gray-200 tw-rounded tw-px-2 tw-py-1 tw-bg-gray-100 hover:tw-bg-gray-200 dark:tw-bg-gray-700 dark:hover:tw-bg-gray-600 tw-transition-colors tw-duration-150"
-                        title="Copy JSON to clipboard"
-                        aria-label="Copy JSON to clipboard"
-                    >
-                        {copySuccess ? 'Copied!' : 'Copy'}
-                    </button>
+                    <div className="tw-flex tw-gap-2">
+                        <button
+                            type="button"
+                            onClick={handleCopyJson}
+                            className="tw-text-xs tw-text-gray-600 hover:tw-text-gray-800 dark:tw-text-gray-400 dark:hover:tw-text-gray-200 tw-rounded tw-px-2 tw-py-1 tw-bg-gray-100 hover:tw-bg-gray-200 dark:tw-bg-gray-700 dark:hover:tw-bg-gray-600 tw-transition-colors tw-duration-150"
+                            title="Copy JSON to clipboard"
+                            aria-label="Copy JSON to clipboard"
+                        >
+                            {copySuccess ? 'Copied!' : 'Copy'}
+                        </button>
+                        <button
+                            type="button"
+                            onClick={handleSubmit}
+                            disabled={isSubmitting}
+                            className="tw-text-xs tw-text-white tw-bg-blue-600 hover:tw-bg-blue-700 dark:tw-bg-blue-500 dark:hover:tw-bg-blue-600 tw-rounded tw-px-4 tw-py-1 tw-transition-colors tw-duration-150 disabled:tw-opacity-50 disabled:tw-cursor-not-allowed"
+                            title="Submit feedback"
+                            aria-label="Submit feedback"
+                        >
+                            {isSubmitting ? 'Submitting...' : 'Submit'}
+                        </button>
+                    </div>
                 </div>
                 {isJsonExpanded && (
                     <pre className="tw-bg-gray-100 tw-dark:tw-bg-gray-800 tw-p-4 tw-rounded tw-text-sm tw-font-mono tw-overflow-auto">

--- a/vscode/webviews/autoedit-debug/components/side-by-side-diff/SideBySideDiff.tsx
+++ b/vscode/webviews/autoedit-debug/components/side-by-side-diff/SideBySideDiff.tsx
@@ -1,6 +1,7 @@
 import type { FC } from 'react'
 import 'highlight.js/styles/github.css'
 import hljs from 'highlight.js/lib/core'
+import { useState } from 'react'
 
 import type {
     DecorationInfo,
@@ -23,8 +24,24 @@ for (const [name, language] of Object.entries(SYNTAX_HIGHLIGHTING_LANGUAGES)) {
 export const SideBySideDiff: FC<{
     sideBySideDiffDecorationInfo: DecorationInfo
     languageId: string
-}> = ({ sideBySideDiffDecorationInfo, languageId }) => {
+    codeToRewrite: string
+    prediction: string
+}> = ({ sideBySideDiffDecorationInfo, languageId, codeToRewrite, prediction }) => {
     const sideBySideLines = buildSideBySideLines(sideBySideDiffDecorationInfo, languageId)
+    const [leftCopySuccess, setLeftCopySuccess] = useState(false)
+    const [rightCopySuccess, setRightCopySuccess] = useState(false)
+
+    const handleCopy = (text: string, setSuccess: (success: boolean) => void) => {
+        if (text) {
+            navigator.clipboard
+                .writeText(text)
+                .then(() => {
+                    setSuccess(true)
+                    setTimeout(() => setSuccess(false), 2000)
+                })
+                .catch(err => console.error('Failed to copy text: ', err))
+        }
+    }
 
     return (
         <div className="tw-overflow-x-auto">
@@ -32,9 +49,35 @@ export const SideBySideDiff: FC<{
                 <thead>
                     <tr className="tw-border-b tw-border-gray-300 tw-bg-gray-50">
                         <th className="tw-w-12 tw-text-right tw-pr-2 tw-sticky tw-left-0 tw-z-10 tw-bg-gray-50" />
-                        <th className="tw-w-[calc(50%-24px)] tw-text-left">Code To Rewrite</th>
+                        <th className="tw-w-[calc(50%-24px)] tw-text-left">
+                            <div className="tw-flex tw-items-center tw-gap-2">
+                                <span>Code To Rewrite</span>
+                                <button
+                                    type="button"
+                                    onClick={() => handleCopy(codeToRewrite, setLeftCopySuccess)}
+                                    className="tw-text-xs tw-text-gray-600 hover:tw-text-gray-800 dark:tw-text-gray-400 dark:hover:tw-text-gray-200 tw-rounded tw-px-2 tw-py-1 tw-bg-gray-100 hover:tw-bg-gray-200 dark:tw-bg-gray-700 dark:hover:tw-bg-gray-600 tw-transition-colors tw-duration-150"
+                                    title="Copy code to rewrite"
+                                    aria-label="Copy code to rewrite"
+                                >
+                                    {leftCopySuccess ? 'Copied!' : 'Copy'}
+                                </button>
+                            </div>
+                        </th>
                         <th className="tw-w-12 tw-text-right tw-pr-2" />
-                        <th className="tw-w-[calc(50%-24px)] tw-text-left">Prediction</th>
+                        <th className="tw-w-[calc(50%-24px)] tw-text-left">
+                            <div className="tw-flex tw-items-center tw-gap-2">
+                                <span>Prediction</span>
+                                <button
+                                    type="button"
+                                    onClick={() => handleCopy(prediction, setRightCopySuccess)}
+                                    className="tw-text-xs tw-text-gray-600 hover:tw-text-gray-800 dark:tw-text-gray-400 dark:hover:tw-text-gray-200 tw-rounded tw-px-2 tw-py-1 tw-bg-gray-100 hover:tw-bg-gray-200 dark:tw-bg-gray-700 dark:hover:tw-bg-gray-600 tw-transition-colors tw-duration-150"
+                                    title="Copy prediction"
+                                    aria-label="Copy prediction"
+                                >
+                                    {rightCopySuccess ? 'Copied!' : 'Copy'}
+                                </button>
+                            </div>
+                        </th>
                     </tr>
                 </thead>
                 <tbody>

--- a/vscode/webviews/autoedit-debug/webview-api.ts
+++ b/vscode/webviews/autoedit-debug/webview-api.ts
@@ -1,0 +1,5 @@
+import type { VSCodeAutoeditDebugWrapper } from '../../src/autoedits/debug-panel/debug-protocol'
+import { getVSCodeAPI } from '../utils/VSCodeApi'
+
+//  https://code.visualstudio.com/api/extension-guides/webview#passing-messages-from-a-webview-to-an-extension
+export const vscode = getVSCodeAPI() as unknown as VSCodeAutoeditDebugWrapper


### PR DESCRIPTION
[**Feedback Loop for the model**] Adds the feedback tab in the `auto-edit` debug panel. It adds 2 text fields `Expected Code`, which can be used as a ground truth example for SFT/DPO and `Assertions` which will be used for evaluation in LLM judge.
 
Adds a submit option which sends the event data to backend telemetry for model training/evaluation.

![CleanShot 2025-04-10 at 11  01 33@2x](https://github.com/user-attachments/assets/118d972d-4d69-45ad-b67a-9f8cc7a13746)

![CleanShot 2025-04-10 at 11  01 49@2x](https://github.com/user-attachments/assets/a4d6745b-ec0c-4c26-940c-c933f058e58d)

## Test plan
Observe the telemetry events
```
█ telemetry-v2 recordEvent: cody.autoedit/feedback-submitted: {
  "parameters": {
    "version": 0,
    "metadata": [
      {
        "key": "recordsPrivateMetadataTranscript",
        "value": 1
      }
    ],
    "privateMetadata": {
      "inlineCompletionItemContext": {
        "source": "feedback",
        "file_path": "src/autoedits/prompt/base.ts",
        "prefix": "import ...        ...userPromptArgs\n",
        "suffix": "        // files. This ...}\n}\n",
        "code_to_rewrite_prefix": "    }: UserPromptForModelArgs): AutoeditsPrompt {\n        const promot= ",
        "code_to_rewrite_suffix": "\n        // We want our Agent tests ... viewed\n",
        "context": [...],
        "chosen": "    }: ... viewed\n",
        "rejected": "}: ... viewed",
        "assertions": "It should return the const promt = await UserPropmtDAta() ",
        "is_reviewed": false
      }
    }
  },
  "timestamp": "2025-04-10T17:26:25.944Z"
}
```
