### PR TITLE
change(chat): re-add current selection within initial mention 

### DIFF
--- a/vscode/src/chat/initialContext.ts
+++ b/vscode/src/chat/initialContext.ts
@@ -161,7 +161,7 @@ function getCurrentFileOrSelection({
                     if (range) {
                         items.push({
                             ...contextFile,
-                            type: 'current-selection',
+                            type: 'file',
                             title: 'Current Selection',
                             description: `${displayPathBasename(contextFile.uri)}:${displayLineRange(
                                 range

--- a/vscode/test/e2e/chat-atFile.test.ts
+++ b/vscode/test/e2e/chat-atFile.test.ts
@@ -378,7 +378,7 @@ test.extend<ExpectedV2Events>({
     await selectLineRangeInEditorTab(page, 2, 5)
 
     const [, lastChatInput] = await createEmptyChatPanel(page)
-    await expect(chatInputMentions(lastChatInput)).toHaveText(['buzz.ts'], {
+    await expect(chatInputMentions(lastChatInput)).toHaveText(['buzz.ts:2-5'], {
         timeout: 3_000,
     })
 

--- a/vscode/test/e2e/chat-atFile.test.ts
+++ b/vscode/test/e2e/chat-atFile.test.ts
@@ -376,14 +376,13 @@ test.extend<ExpectedV2Events>({
 
     await openFileInEditorTab(page, 'buzz.ts')
     await selectLineRangeInEditorTab(page, 2, 5)
-
     const [, lastChatInput] = await createEmptyChatPanel(page)
-    await expect(chatInputMentions(lastChatInput)).toHaveText(['buzz.ts:2-5'], {
+    await expect(chatInputMentions(lastChatInput)).toHaveText(['buzz.ts', 'buzz.ts:2-5'], {
         timeout: 3_000,
     })
 
     await lastChatInput.press('x')
     await selectLineRangeInEditorTab(page, 7, 10)
     await executeCommandInPalette(page, 'Cody: Add Selection to Cody Chat')
-    await expect(chatInputMentions(lastChatInput)).toHaveText(['buzz.ts', 'buzz.ts:7-10'])
+    await expect(chatInputMentions(lastChatInput)).toHaveText(['buzz.ts', 'buzz.ts:2-5', 'buzz.ts:7-10'])
 })

--- a/vscode/test/e2e/initial-context.test.ts
+++ b/vscode/test/e2e/initial-context.test.ts
@@ -35,7 +35,7 @@ testWithGitRemote('initial context - enterprise repo', async ({ page, sidebar, s
     await expect(chatInputMentions(lastChatInput)).toHaveText(['host.example/user/myrepo'])
 })
 
-testWithGitRemote.only('initial context - file', async ({ page, sidebar, server }) => {
+testWithGitRemote('initial context - file', async ({ page, sidebar, server }) => {
     mockEnterpriseRepoMapping(server, 'host.example/user/myrepo')
 
     await sidebarSignin(page, sidebar)
@@ -50,15 +50,15 @@ testWithGitRemote.only('initial context - file', async ({ page, sidebar, server 
     await selectLineRangeInEditorTab(page, 2, 4)
     await expect(chatInputMentions(lastChatInput)).toHaveText([
         'main.c',
-        'current selection',
+        'main.c:2-4',
         'host.example/user/myrepo',
     ])
 
-    // selecting another range keeps 'current selection' mention
+    // selecting another range modifies the 'current selection' mention
     await selectLineRangeInEditorTab(page, 1, 3)
     await expect(chatInputMentions(lastChatInput)).toHaveText([
         'main.c',
-        'current selection',
+        'main.c:1-3',
         'host.example/user/myrepo',
     ])
 

--- a/vscode/test/e2e/initial-context.test.ts
+++ b/vscode/test/e2e/initial-context.test.ts
@@ -35,7 +35,7 @@ testWithGitRemote('initial context - enterprise repo', async ({ page, sidebar, s
     await expect(chatInputMentions(lastChatInput)).toHaveText(['host.example/user/myrepo'])
 })
 
-testWithGitRemote('initial context - file', async ({ page, sidebar, server }) => {
+testWithGitRemote.only('initial context - file', async ({ page, sidebar, server }) => {
     mockEnterpriseRepoMapping(server, 'host.example/user/myrepo')
 
     await sidebarSignin(page, sidebar)
@@ -45,12 +45,22 @@ testWithGitRemote('initial context - file', async ({ page, sidebar, server }) =>
     const [, lastChatInput] = await createEmptyChatPanel(page)
 
     await expect(chatInputMentions(lastChatInput)).toHaveText(['main.c', 'host.example/user/myrepo'])
+
     // Initial context should not include current selection. Current selection should be added explicitly.
     await selectLineRangeInEditorTab(page, 2, 4)
-    await expect(chatInputMentions(lastChatInput)).toHaveText(['main.c', 'host.example/user/myrepo'])
+    await expect(chatInputMentions(lastChatInput)).toHaveText([
+        'main.c',
+        'current selection',
+        'host.example/user/myrepo',
+    ])
 
+    // selecting another range keeps 'current selection' mention
     await selectLineRangeInEditorTab(page, 1, 3)
-    await expect(chatInputMentions(lastChatInput)).toHaveText(['main.c', 'host.example/user/myrepo'])
+    await expect(chatInputMentions(lastChatInput)).toHaveText([
+        'main.c',
+        'current selection',
+        'host.example/user/myrepo',
+    ])
 
     await openFileInEditorTab(page, 'README.md')
     await expect(chatInputMentions(lastChatInput)).toHaveText(['README.md', 'host.example/user/myrepo'])

--- a/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
@@ -361,7 +361,6 @@ export const HumanMessageEditor: FunctionComponent<{
         // Remove tree type if streaming is not supported.
         const excludedTypes = new Set([
             'open-link',
-            'current-selection',
             ...(currentChatModel?.tags?.includes(ModelTag.StreamDisabled) ? ['tree'] : []),
         ])
 


### PR DESCRIPTION
Fixes #CODY-5632 by restoring current selection, dynamically updated when selection changes.

## Test plan
- Check that if you have test selected it is reflected in the chat message input as file:range
- If you modify the selection, the input value is also dynamically changed
- @mention current-selection will expand to file:range
- Using a prompt with cody://current-selection will expand to file:range
- Opt + L will add the selected text as file:range
