### PR TITLE
feat(auto-edit): add hot streak items to the autoedit debug panel

### DIFF
--- a/vscode/src/autoedits/adapters/base.ts
+++ b/vscode/src/autoedits/adapters/base.ts
@@ -57,6 +57,16 @@ export interface PartialModelResponse extends ModelResponseShared {
     stopReason: AutoeditStopReason.StreamingChunk | AutoeditStopReason.HotStreak
     prediction: string
     /**
+     * Response headers received from the model API
+     */
+    responseHeaders: Record<string, string>
+    /**
+     * Optional full response body received from the model API
+     * This is propagated to the analytics logger for debugging purposes
+     * TODO: replace `any` with the proper type.
+     */
+    responseBody: Record<string, any>
+    /**
      * The source of the suggestion, e.g. 'network', 'cache', etc.
      */
     source?: AutoeditSourceMetadata

--- a/vscode/src/autoedits/adapters/fireworks-websocket.ts
+++ b/vscode/src/autoedits/adapters/fireworks-websocket.ts
@@ -232,6 +232,7 @@ export class FireworksWebSocketAdapter implements AutoeditsModelAdapter {
                     yield this.processFireworksResponse(message, state, extractPrediction, {
                         requestHeaders,
                         requestUrl: url,
+                        requestBody: body,
                     })
                 }
             }
@@ -247,6 +248,7 @@ export class FireworksWebSocketAdapter implements AutoeditsModelAdapter {
         requestParams: {
             requestHeaders: Record<string, string>
             requestUrl: string
+            requestBody: ModelResponseShared['requestBody']
         }
     ): ModelResponse {
         if (!message.body) {
@@ -263,8 +265,9 @@ export class FireworksWebSocketAdapter implements AutoeditsModelAdapter {
                 prediction: state.prediction,
                 responseHeaders: message.headers,
                 responseBody: state.responseBody,
-                requestHeaders: requestParams.requestHeaders,
                 requestUrl: requestParams.requestUrl,
+                requestHeaders: requestParams.requestHeaders,
+                requestBody: requestParams.requestBody,
             }
         }
 
@@ -275,8 +278,11 @@ export class FireworksWebSocketAdapter implements AutoeditsModelAdapter {
                 type: 'partial',
                 stopReason: AutoeditStopReason.StreamingChunk,
                 prediction: state.prediction,
-                requestHeaders: requestParams.requestHeaders,
+                responseHeaders: requestParams.requestHeaders,
+                responseBody: state.responseBody,
                 requestUrl: requestParams.requestUrl,
+                requestHeaders: requestParams.requestHeaders,
+                requestBody: requestParams.requestBody,
             }
         } catch (parseError) {
             autoeditsOutputChannelLogger.logError(

--- a/vscode/src/autoedits/adapters/model-response/fireworks.ts
+++ b/vscode/src/autoedits/adapters/model-response/fireworks.ts
@@ -102,6 +102,8 @@ export async function* getFireworksModelResponse({
                             type: 'partial',
                             stopReason: AutoeditStopReason.StreamingChunk,
                             prediction: state.prediction,
+                            responseHeaders,
+                            responseBody: state.responseBody,
                         }
                     }
                 } catch (parseError) {

--- a/vscode/src/autoedits/adapters/sourcegraph-chat.ts
+++ b/vscode/src/autoedits/adapters/sourcegraph-chat.ts
@@ -63,6 +63,8 @@ export class SourcegraphChatAdapter implements AutoeditsModelAdapter {
                     prediction: accumulated,
                     requestUrl: option.url,
                     requestHeaders: {},
+                    responseHeaders: {},
+                    responseBody: {},
                 }
             } else if (msg.type === 'complete' || msg.type === 'error') {
                 break

--- a/vscode/src/autoedits/adapters/sourcegraph-completions.ts
+++ b/vscode/src/autoedits/adapters/sourcegraph-completions.ts
@@ -111,6 +111,8 @@ export class SourcegraphCompletionsAdapter implements AutoeditsModelAdapter {
                 prediction,
                 requestUrl,
                 requestHeaders,
+                responseHeaders,
+                responseBody,
             }
         }
 

--- a/vscode/src/autoedits/analytics-logger/types.ts
+++ b/vscode/src/autoedits/analytics-logger/types.ts
@@ -239,6 +239,13 @@ export interface ContextLoadedState extends Omit<StartedState, 'phase' | 'payloa
     }
 }
 
+export interface HotStreakChunk {
+    prediction: string
+    loadedAt: number
+    modelResponse: ModelResponse
+    fullPrediction?: string
+}
+
 export interface LoadedState extends Omit<ContextLoadedState, 'phase' | 'payload'> {
     phase: 'loaded'
     /** Timestamp when the suggestion completed generation/loading. */
@@ -247,6 +254,7 @@ export interface LoadedState extends Omit<ContextLoadedState, 'phase' | 'payload
     modelResponse: ModelResponse
     cacheId: AutoeditCacheID
     hotStreakId?: AutoeditHotStreakID
+    hotStreakChunks?: HotStreakChunk[]
     editPosition: vscode.Position
     payload: ContextLoadedState['payload'] & {
         /**

--- a/vscode/src/autoedits/debug-panel/autoedit-data-sdk.ts
+++ b/vscode/src/autoedits/debug-panel/autoedit-data-sdk.ts
@@ -1,5 +1,5 @@
 import type { InlineCompletionItemRetrievedContext } from '../../completions/analytics-logger'
-import type { ModelResponse, SuccessModelResponse } from '../adapters/base'
+import type { ModelResponse, PartialModelResponse, SuccessModelResponse } from '../adapters/base'
 import { getDetailedTimingInfo } from './autoedit-latency-utils'
 import type { AutoeditRequestDebugState } from './debug-store'
 
@@ -289,9 +289,30 @@ export const getNetworkLatencyInfo = (
 
 export const getSuccessModelResponse = (
     entry: AutoeditRequestDebugState
-): SuccessModelResponse | null => {
-    if ('modelResponse' in entry.state && entry.state.modelResponse.type === 'success') {
+): SuccessModelResponse | PartialModelResponse | null => {
+    if (
+        'modelResponse' in entry.state &&
+        (entry.state.modelResponse.type === 'success' || entry.state.modelResponse.type === 'partial')
+    ) {
         return entry.state.modelResponse
+    }
+    return null
+}
+
+/**
+ * Get hot streak chunks if available
+ */
+export const getHotStreakChunks = (
+    entry: AutoeditRequestDebugState
+):
+    | { prediction: string; loadedAt: number; modelResponse: ModelResponse; fullPrediction?: string }[]
+    | null => {
+    if (
+        'hotStreakChunks' in entry.state &&
+        Array.isArray(entry.state.hotStreakChunks) &&
+        entry.state.hotStreakChunks.length > 0
+    ) {
+        return entry.state.hotStreakChunks
     }
     return null
 }
@@ -341,4 +362,5 @@ export const AutoeditDataSDK = {
     getNetworkLatencyInfo,
     getFullResponseBody,
     getModelResponse,
+    getHotStreakChunks,
 }

--- a/vscode/src/autoedits/hot-streak/index.test.ts
+++ b/vscode/src/autoedits/hot-streak/index.test.ts
@@ -27,6 +27,8 @@ async function* createModelResponseGenerator(
             stopReason: AutoeditStopReason.StreamingChunk,
             requestHeaders: {},
             requestUrl: 'test-url',
+            responseHeaders: {},
+            responseBody: {},
         }
     }
 
@@ -342,6 +344,8 @@ describe('processHotStreakResponses', () => {
                     stopReason: AutoeditStopReason.StreamingChunk,
                     requestHeaders: {},
                     requestUrl: 'test-url',
+                    responseHeaders: {},
+                    responseBody: {},
                 }
             }
 

--- a/vscode/src/autoedits/mock-response-generator.ts
+++ b/vscode/src/autoedits/mock-response-generator.ts
@@ -41,6 +41,8 @@ export async function* createMockResponseGenerator(prediction: string): AsyncGen
             type: 'partial',
             stopReason: AutoeditStopReason.StreamingChunk,
             prediction: partialPrediction,
+            responseHeaders: {},
+            responseBody: {},
             ...commonProps,
         }
         emittedLines = newEmittedLines

--- a/vscode/src/autoedits/request-manager.test.ts
+++ b/vscode/src/autoedits/request-manager.test.ts
@@ -424,6 +424,7 @@ function createRequestParams(
     })
 
     return {
+        requestId: 'test-request-id' as any,
         documentUri: document.uri.toString(),
         documentText: document.getText(),
         documentVersion,

--- a/vscode/webviews/autoedit-debug/sections/NetworkRequestSection.tsx
+++ b/vscode/webviews/autoedit-debug/sections/NetworkRequestSection.tsx
@@ -1,9 +1,15 @@
-import type { FC } from 'react'
+import React, { type FC } from 'react'
 
 import {
+    getHotStreakChunks,
     getModelResponse,
+    getStartTime,
     getSuccessModelResponse,
 } from '../../../src/autoedits/debug-panel/autoedit-data-sdk'
+import {
+    PhaseNames,
+    getDetailedTimingInfo,
+} from '../../../src/autoedits/debug-panel/autoedit-latency-utils'
 import type { AutoeditRequestDebugState } from '../../../src/autoedits/debug-panel/debug-store'
 import { JsonViewer } from '../components/JsonViewer'
 
@@ -61,8 +67,11 @@ export const NetworkResponseSection: FC<{
         return null
     }
 
-    // Extract modelResponse if available
+    // Extract modelResponse and hot streak data if available
     const modelResponse = getSuccessModelResponse(entry)
+    const hotStreakChunks = getHotStreakChunks(entry)
+    const startTime = getStartTime(entry)
+    const detailedTimingInfo = getDetailedTimingInfo(entry)
 
     return (
         <div className="tw-grid tw-grid-cols-2 tw-gap-4">
@@ -80,6 +89,72 @@ export const NetworkResponseSection: FC<{
                     </div>
                 </div>
             )}
+
+            {/* Display hot streak chunks if available */}
+            {hotStreakChunks && startTime && (
+                <div className="tw-col-span-2 tw-mt-4">
+                    <h4 className="tw-text-sm tw-font-medium tw-mb-2">Hot Streak Chunks</h4>
+                    <div className="tw-grid tw-grid-cols-[auto_1fr] tw-gap-2 tw-bg-gray-100 tw-dark:tw-bg-gray-800 tw-p-3 tw-rounded tw-text-xs">
+                        <div className="tw-font-medium">Time</div>
+                        <div className="tw-font-medium">Prediction</div>
+                        {hotStreakChunks
+                            // Filter out empty predictions
+                            .filter(chunk => chunk.prediction.trim() !== '')
+                            .map((chunk, index, filteredChunks) => {
+                                const timeFromStart = Math.round(chunk.loadedAt - startTime)
+
+                                // Calculate time from previous chunk
+                                let timeFromPrev: number
+                                if (index === 0) {
+                                    // First chunk: time from loadedAt
+                                    timeFromPrev =
+                                        detailedTimingInfo.details.find(
+                                            p => p.label === PhaseNames.Network
+                                        )?.valueMs ?? 0
+                                } else {
+                                    // Subsequent chunks: time from previous chunk
+                                    timeFromPrev = Math.round(
+                                        chunk.loadedAt - filteredChunks[index - 1].loadedAt
+                                    )
+                                }
+
+                                // Generate a stable key using chunk properties
+                                const chunkKey = `chunk-${chunk.prediction.slice(
+                                    0,
+                                    10
+                                )}-${timeFromStart}`
+
+                                return (
+                                    <React.Fragment key={chunkKey}>
+                                        <div className="tw-font-mono tw-pr-4">
+                                            <span className="tw-text-gray-500">{timeFromStart}ms</span>
+                                            {index > 0 && (
+                                                <span className="tw-text-gray-400 tw-ml-2">
+                                                    (+{timeFromPrev}ms)
+                                                </span>
+                                            )}
+                                        </div>
+                                        <div className="tw-whitespace-pre-wrap tw-pb-2 tw-border-b tw-border-gray-300 tw-dark:tw-border-gray-600">
+                                            {chunk.prediction}
+                                        </div>
+                                    </React.Fragment>
+                                )
+                            })}
+                    </div>
+                </div>
+            )}
+
+            {/* Display full prediction immediately after chunks */}
+            {hotStreakChunks &&
+                hotStreakChunks.length > 0 &&
+                hotStreakChunks[hotStreakChunks.length - 1]?.fullPrediction && (
+                    <div className="tw-col-span-2 tw-mt-2">
+                        <h4 className="tw-text-sm tw-font-medium tw-mb-2">Complete Prediction</h4>
+                        <div className="tw-bg-gray-50 tw-dark:tw-bg-gray-700 tw-p-3 tw-rounded tw-text-xs tw-whitespace-pre-wrap tw-border tw-border-green-200 tw-dark:tw-border-green-800">
+                            {hotStreakChunks[hotStreakChunks.length - 1].fullPrediction}
+                        </div>
+                    </div>
+                )}
 
             {/* Display full response body if available */}
             {modelResponse?.responseBody && (


### PR DESCRIPTION
- Adds hot-streak items to the autoedit debug panel to make debugging/dogfooding the next cursor prediction easier
- Fixes the illegal line number in the `processHotStreakResponses` function by changing `lineAt` calls to `validateRange`.

## Test plan

Manually test the autoedit debug panel
