### PR TITLE
feat(telemtry): allow list telemtry events in dev env

### DIFF
--- a/lib/shared/src/telemetry-v2/TelemetryRecorderProvider.ts
+++ b/lib/shared/src/telemetry-v2/TelemetryRecorderProvider.ts
@@ -67,7 +67,13 @@ export class TelemetryRecorderProvider extends BaseTelemetryRecorderProvider<
             configuration: true
             auth: true
             clientState: 'anonymousUserID'
-        }>
+        }> & {
+            /**
+             * List of events to allow. If not provided, all events will be allowed.
+             * Used in development mode to only export whitelisted events.
+             */
+            allowedEvents?: { feature: string; action: string }[]
+        }
     ) {
         const cap = clientCapabilities()
         const clientName = cap.telemetryClientName || `${cap.agentIDE}.Cody`
@@ -79,7 +85,7 @@ export class TelemetryRecorderProvider extends BaseTelemetryRecorderProvider<
             },
             process.env.CODY_TELEMETRY_EXPORTER === 'testing'
                 ? TESTING_TELEMETRY_EXPORTER.withAnonymousUserID(config.clientState.anonymousUserID)
-                : new GraphQLTelemetryExporter(),
+                : new GraphQLTelemetryExporter(config.allowedEvents),
             [
                 new ConfigurationMetadataProcessor(),
                 // Generate timestamps when recording events, instead of serverside


### PR DESCRIPTION
Allows submitting autoedit feedback from the autoedit debug panel in the development environment through allow listing telemetry events that can be sent from the dev mode.

## Test plan

Open the auto-edit debug panel and try submitting the feedback. You should see in the output channel that the event has been submitted. In the development environment, other events should not be forwarded to our backend.