### PR TITLE
add storybook for error item

### DIFF
--- a/vscode/webviews/ChatErrorNotice.story.tsx
+++ b/vscode/webviews/ChatErrorNotice.story.tsx
@@ -60,3 +60,70 @@ export const ChatRateLimitPro: Story = {
         },
     },
 }
+
+export const ApiVersionError: Story = {
+    args: {
+        error: errorToChatError(new Error('Request failed: unable to determine Cody API version')),
+        userInfo: {
+            isDotComUser: true,
+            isCodyProUser: false,
+        },
+        humanMessage: {
+            rerunWithDifferentContext: () => {},
+            hasInitialContext: { repositories: false, files: false },
+            hasExplicitMentions: false,
+            appendAtMention: () => {},
+        },
+    },
+}
+
+export const RateLimitFreeUser: Story = {
+    args: {
+        error: new RateLimitError(
+            'chat messages and commands',
+            'Chat',
+            true,
+            20,
+            String(60 * 60 * 24 * 25)
+        ), // 25 days
+        postMessage: () => {},
+        userInfo: {
+            isDotComUser: true,
+            isCodyProUser: false,
+        },
+    },
+}
+
+export const RateLimitProUser: Story = {
+    args: {
+        error: new RateLimitError(
+            'chat messages and commands',
+            'Chat',
+            false,
+            500,
+            String(60 * 60 * 24 * 5)
+        ), // 5 days
+        postMessage: () => {},
+        userInfo: {
+            isDotComUser: true,
+            isCodyProUser: true,
+        },
+    },
+}
+
+export const RateLimitEnterpriseUser: Story = {
+    args: {
+        error: new RateLimitError(
+            'chat messages and commands',
+            'Chat',
+            false,
+            1000,
+            String(60 * 60 * 24 * 2)
+        ), // 2 days
+        postMessage: () => {},
+        userInfo: {
+            isDotComUser: false,
+            isCodyProUser: true,
+        },
+    },
+}


### PR DESCRIPTION
added new stories to the error item storybook

<img width="1028" alt="image" src="https://github.com/user-attachments/assets/2e354b76-b953-467a-bf7e-7285a390d043" />


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

run `pnpm -C vscode run storybook` to start storybook