### PR TITLE
Rename displayAgentAutocomplete to displayInlay & clean up

### DIFF
--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
@@ -1,6 +1,7 @@
 package com.sourcegraph.cody.autocomplete
 
 import com.intellij.codeInsight.hint.HintManager
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.command.CommandProcessor
@@ -11,15 +12,12 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.EditorKind
 import com.intellij.openapi.editor.Inlay
-import com.intellij.openapi.editor.InlayModel
 import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.openapi.keymap.KeymapUtil
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.popup.Balloon
 import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.util.TextRange
-import com.intellij.openapi.wm.ToolWindowId
-import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.ui.GotItTooltip
 import com.intellij.util.concurrency.annotations.RequiresEdt
 import com.sourcegraph.Icons
@@ -207,7 +205,6 @@ class CodyAutocompleteManager {
       return
     }
 
-    val inlayModel = editor.inlayModel
     if (result.inlineCompletionItems.isEmpty() && result.decoratedEditItems.isEmpty()) {
       // NOTE(olafur): it would be nice to give the user a visual hint when this happens.
       // We don't do anything now because it's unclear what would be the most idiomatic
@@ -233,39 +230,30 @@ class CodyAutocompleteManager {
         // https://github.com/sourcegraph/jetbrains/issues/350
         // CodyFormatter.formatStringBasedOnDocument needs to be on a write action.
         WriteCommandAction.runWriteCommandAction(editor.project) {
-          displayAutocomplete(editor, offset, result.inlineCompletionItems, inlayModel)
+          displayInlay(editor, offset, result.inlineCompletionItems)
         }
       }
     }
   }
 
-  /**
-   * Render inlay hints for unprocessed autocomplete results from the agent.
-   *
-   * The reason we have a custom code path to render hints for agent autocompletions is because we
-   * can use `insertText` directly and the `range` encloses the entire line.
-   */
   @RequiresEdt
   @VisibleForTesting
-  fun displayAutocomplete(
+  fun displayInlay(
       editor: Editor,
       cursorOffset: Int,
       items: List<AutocompleteItem>,
-      inlayModel: InlayModel,
   ) {
-    if (editor.isDisposed) {
+    val project = editor.project ?: return
+    if (editor.isDisposed || project.isDisposed) {
       return
     }
 
-    val project = editor.project
     val defaultItem = items.firstOrNull() ?: return
     val range = getTextRange(editor.document, defaultItem.range) ?: return
-
     val originalText = editor.document.getText(range)
 
     val formattedCompletionText =
-        if (project == null ||
-            System.getProperty("cody.autocomplete.enableFormatting") == "false") {
+        if (System.getProperty("cody.autocomplete.enableFormatting") == "false") {
           defaultItem.insertText
         } else {
           CodyFormatter.formatStringBasedOnDocument(
@@ -274,10 +262,8 @@ class CodyAutocompleteManager {
 
     if (formattedCompletionText.trim().isBlank()) return
 
-    project?.let {
-      CodyAgentService.withAgent(project) { agent ->
-        agent.server.autocomplete_completionSuggested(CompletionItemParams(defaultItem.id))
-      }
+    CodyAgentService.withAgent(project) { agent ->
+      agent.server.autocomplete_completionSuggested(CompletionItemParams(defaultItem.id))
     }
 
     val startsInline =
@@ -290,20 +276,16 @@ class CodyAutocompleteManager {
         } else {
           0 to ""
         }
-
     val offset = range.startOffset + commonTextLength
 
     var inlay: Inlay<*>? = null
-    if (startsInline) {
-
-      if (inlineCompletionText.isNotEmpty()) {
-        val renderer =
-            CodyAutocompleteSingleLineRenderer(
-                inlineCompletionText, items, editor, AutocompleteRendererType.INLINE)
-        inlay = inlayModel.addInlineElement(offset, /* relatesToPrecedingText= */ true, renderer)
-      }
+    if (startsInline && inlineCompletionText.isNotEmpty()) {
+      val renderer =
+          CodyAutocompleteSingleLineRenderer(
+              inlineCompletionText, items, editor, AutocompleteRendererType.INLINE)
+      inlay =
+          editor.inlayModel.addInlineElement(offset, /* relatesToPrecedingText= */ true, renderer)
     }
-
     val lines = formattedCompletionText.lines()
     if (lines.size > 1) {
       val text =
@@ -311,7 +293,7 @@ class CodyAutocompleteManager {
       if (text.isNotEmpty()) {
         val renderer = CodyAutocompleteBlockElementRenderer(text, items, editor)
         val inlay2 =
-            inlayModel.addBlockElement(
+            editor.inlayModel.addBlockElement(
                 /* offset = */ offset,
                 /* relatesToPrecedingText = */ true,
                 /* showAbove = */ false,
@@ -323,62 +305,34 @@ class CodyAutocompleteManager {
       }
     }
 
-    if (inlay?.bounds?.location != null) {
-      val gotit =
-          GotItTooltip(
-                  "cody.autocomplete.gotIt",
-                  CodyBundle.getString("gotit.autocomplete.message")
-                      .fmt(
-                          KeymapUtil.getShortcutText("cody.acceptAutocompleteAction"),
-                          KeymapUtil.getShortcutText("cody.cycleForwardAutocompleteAction"),
-                          KeymapUtil.getShortcutText("cody.cycleBackAutocompleteAction")),
-                  inlay /* dispose tooltip alongside inlay */)
-              .withHeader(CodyBundle.getString("gotit.autocomplete.header"))
-              .withPosition(Balloon.Position.above)
-              .withIcon(Icons.CodyLogo)
-              .andShowCloseShortcut()
-      try {
-        gotit.show(editor.contentComponent) { _, _ -> inlay.bounds!!.location }
-      } catch (e: Exception) {
-        logger.info("Failed to display gotit tooltip", e)
-      }
-    }
+    displayGotItTooltip(inlay, editor)
+  }
 
-    if (inlay?.bounds?.location != null && project != null) {
-      val isProjectViewVisible =
-          ToolWindowManager.getInstance(project).getToolWindow(ToolWindowId.PROJECT_VIEW)?.isVisible
-              ?: false
-      val position =
-          if (isProjectViewVisible) Balloon.Position.atLeft
-          else if (inlay.bounds!!.location.y < 150) Balloon.Position.below
-          else Balloon.Position.above
-      val gotit =
-          GotItTooltip(
-                  "cody.autocomplete.gotIt",
-                  CodyBundle.getString("gotit.autocomplete.message")
-                      .fmt(
-                          KeymapUtil.getShortcutText("cody.acceptAutocompleteAction"),
-                          KeymapUtil.getShortcutText("cody.cycleForwardAutocompleteAction"),
-                          KeymapUtil.getShortcutText("cody.cycleBackAutocompleteAction")),
-                  inlay /* dispose tooltip alongside inlay */)
-              .withHeader(CodyBundle.getString("gotit.autocomplete.header"))
-              .withPosition(position)
-              .withIcon(Icons.CodyLogo)
-              .andShowCloseShortcut()
-      try {
-        gotit.show(editor.contentComponent) { _, _ ->
-          val location = inlay.bounds!!.location
-          if (position == Balloon.Position.below) {
-            val lineHeight = getLineHeight()
-            location.setLocation(location.x, location.y + lineHeight)
-          }
-          location
-        }
-      } catch (e: Exception) {
-        logger.info("Failed to display gotit tooltip", e)
-      }
+  private fun displayGotItTooltip(inlay: Inlay<*>?, editor: Editor) {
+    val location = inlay?.bounds?.location ?: return
+    val gotit = tooltip(inlay)
+    if (location.y < 150) {
+      location.setLocation(location.x, location.y + getLineHeight())
+    }
+    try {
+      gotit.show(editor.contentComponent) { _, _ -> location }
+    } catch (e: Exception) {
+      logger.info("Failed to display gotit tooltip", e)
     }
   }
+
+  private fun tooltip(disposable: Disposable): GotItTooltip =
+      GotItTooltip(
+              "cody.autocomplete.gotIt",
+              CodyBundle.getString("gotit.autocomplete.message")
+                  .fmt(
+                      KeymapUtil.getShortcutText("cody.acceptAutocompleteAction"),
+                      KeymapUtil.getShortcutText("cody.cycleForwardAutocompleteAction"),
+                      KeymapUtil.getShortcutText("cody.cycleBackAutocompleteAction")),
+              disposable)
+          .withHeader(CodyBundle.getString("gotit.autocomplete.header"))
+          .withPosition(Balloon.Position.above)
+          .withIcon(Icons.SourcegraphLogo)
 
   private fun getLineHeight(): Int {
     val colorsManager = EditorColorsManager.getInstance()

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/autocomplete/action/CycleCodyAutocompleteActionHandler.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/autocomplete/action/CycleCodyAutocompleteActionHandler.kt
@@ -42,7 +42,7 @@ class CycleCodyAutocompleteActionHandler(private val cycleDirection: CycleDirect
       ApplicationManager.getApplication().invokeLater {
         CodyAutocompleteManager.instance.let {
           it.clearAutocompleteSuggestions(editor)
-          it.displayAutocomplete(editor, caret.offset, newItems, editor.inlayModel)
+          it.displayInlay(editor, caret.offset, newItems)
         }
         autocompleteItemsCache[cacheKey] = newItems
       }

--- a/jetbrains/src/test/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManagerTest.kt
+++ b/jetbrains/src/test/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManagerTest.kt
@@ -10,7 +10,7 @@ import com.sourcegraph.cody.autocomplete.render.InlayModelUtil
 
 class CodyAutocompleteManagerTest : BasePlatformTestCase() {
 
-  fun test_displayAgentAutocomplete_cursorBased() {
+  fun test_displayInlay_cursorBased() {
     myFixture.configureByText("CommonPrefix.kt", "// say hello\n    CommonPrefix.\n// done")
     val editor =
         FileEditorManager.getInstance(project)
@@ -21,15 +21,14 @@ class CodyAutocompleteManagerTest : BasePlatformTestCase() {
                 id = "0",
                 range = Range(Position(1, 4), Position(1, 17)),
                 insertText = "CommonPrefix.sayHello(\"world\")"))
-    CodyAutocompleteManager.instance.displayAutocomplete(
-        editor, cursorOffset = 17, items, editor.inlayModel)
+    CodyAutocompleteManager.instance.displayInlay(editor, cursorOffset = 17, items)
     val allInlaysForEditor = InlayModelUtil.getAllInlaysForEditor(editor)
     assertEquals(1, allInlaysForEditor.size)
     val inlay = allInlaysForEditor[0]
     assertEquals(30, inlay.offset)
   }
 
-  fun test_displayAgentAutocomplete_lineStartBased() {
+  fun test_displayInlay_lineStartBased() {
     myFixture.configureByText("CommonPrefix.kt", "// say hello\n    CommonPrefix.\n// done")
     val editor =
         FileEditorManager.getInstance(project)
@@ -40,8 +39,7 @@ class CodyAutocompleteManagerTest : BasePlatformTestCase() {
                 id = "0",
                 range = Range(Position(1, 0), Position(1, 17)),
                 insertText = "    CommonPrefix.sayHello(\"world\")"))
-    CodyAutocompleteManager.instance.displayAutocomplete(
-        editor, cursorOffset = 17, items, editor.inlayModel)
+    CodyAutocompleteManager.instance.displayInlay(editor, cursorOffset = 17, items)
     val allInlaysForEditor = InlayModelUtil.getAllInlaysForEditor(editor)
     assertEquals(1, allInlaysForEditor.size)
     val inlay = allInlaysForEditor[0]


### PR DESCRIPTION
This PR is a cleanup to AutocompleteManager.

## Test plan
- autocompletes tested manually
- got it popup verified manually

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
