### PR TITLE
fix(chat): use DeepCodyModelRef instead of id

### DIFF
--- a/vscode/src/chat/chat-view/handlers/registry.ts
+++ b/vscode/src/chat/chat-view/handlers/registry.ts
@@ -1,6 +1,10 @@
 import Anthropic from '@anthropic-ai/sdk'
 import type { ChatMessage, ChatModel } from '@sourcegraph/cody-shared'
-import { DeepCodyAgentID, ToolCodyModelRef } from '@sourcegraph/cody-shared/src/models/client'
+import {
+    DeepCodyAgentID,
+    DeepCodyModelRef,
+    ToolCodyModelRef,
+} from '@sourcegraph/cody-shared/src/models/client'
 import { getConfiguration } from '../../../configuration'
 import { AgenticHandler } from './AgenticHandler'
 import { ChatHandler } from './ChatHandler'
@@ -32,7 +36,7 @@ const agentRegistry = new Map<string, (id: string, tools: AgentTools) => AgentHa
         },
     ],
     [
-        DeepCodyAgentID,
+        DeepCodyModelRef,
         (_id, { contextRetriever, editor, chatClient }) =>
             new DeepCodyHandler(contextRetriever, editor, chatClient),
     ],
@@ -74,7 +78,7 @@ export function getAgentName(intent: ChatMessage['intent'], model?: ChatModel): 
     if (model === ToolCodyModelRef) {
         return ToolCodyModelRef
     }
-    if (model === DeepCodyAgentID) {
+    if (model === DeepCodyModelRef) {
         return DeepCodyAgentID
     }
     return undefined


### PR DESCRIPTION
This commit renames `DeepCodyAgentID` to `DeepCodyModelRef` to align with the naming convention used for other model references. This change ensures consistency and clarity in the codebase.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Agentic chat works:

<img width="613" alt="image" src="https://github.com/user-attachments/assets/75d5fce8-45bc-469f-96ee-63d73d575b1c" />

Before - agentic context is empty

<img width="609" alt="image" src="https://github.com/user-attachments/assets/302e1577-554b-462a-abea-d8814a368fd1" />

