### PR TITLE
feat(agentic context): use DeepCodyHandler as default chat handler

### DIFF
--- a/vscode/src/chat/chat-view/handlers/registry.ts
+++ b/vscode/src/chat/chat-view/handlers/registry.ts
@@ -7,7 +7,6 @@ import {
 } from '@sourcegraph/cody-shared/src/models/client'
 import { getConfiguration } from '../../../configuration'
 import { AgenticHandler } from './AgenticHandler'
-import { ChatHandler } from './ChatHandler'
 import { DeepCodyHandler } from './DeepCodyHandler'
 import { EditHandler } from './EditHandler'
 import { SearchHandler } from './SearchHandler'
@@ -61,7 +60,7 @@ export function getAgent(model: string, intent: ChatMessage['intent'], tools: Ag
     const modelHandler = agentRegistry.get(model)
     if (modelHandler) return modelHandler(model, tools)
 
-    return new ChatHandler(contextRetriever, editor, chatClient)
+    return new DeepCodyHandler(contextRetriever, editor, chatClient)
 }
 
 /**
@@ -78,8 +77,6 @@ export function getAgentName(intent: ChatMessage['intent'], model?: ChatModel): 
     if (model === ToolCodyModelRef) {
         return ToolCodyModelRef
     }
-    if (model === DeepCodyModelRef) {
-        return DeepCodyAgentID
-    }
-    return undefined
+
+    return DeepCodyAgentID
 }


### PR DESCRIPTION
This commit changes the default chat handler to `DeepCodyHandler`. It also removes the `ChatHandler` import and updates the `getAgent` function to return a `DeepCodyHandler` instance when no specific model handler is found. The `getAgentName` function is also updated to consistently return `DeepCodyAgentID`.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Agentic context is automatically included for all models