### PR TITLE
fix/edit: Do not widen selections past the end of the document.

### DIFF
--- a/agent/recordings/customCommandsClient_509552979/recording.har.yaml
+++ b/agent/recordings/customCommandsClient_509552979/recording.har.yaml
@@ -533,11 +533,11 @@ log:
         send: 0
         ssl: -1
         wait: 1312
-    - _id: bae66576e73c6c98050a7cc623c9e0fe
+    - _id: 08e850ec487de9001def931aa702be9b
       _order: 0
       cache: {}
       request:
-        bodySize: 2243
+        bodySize: 2241
         cookies: []
         headers:
           - name: accept-encoding
@@ -550,7 +550,7 @@ log:
           - name: content-type
             value: application/json
           - name: traceparent
-            value: 00-c75240714eb84ab9436af1959442d333-d5887c5acb160a76-01
+            value: 00-0b51d2807e3d2be1bfd03f953ba68bf4-1ef2bacb5630f124-01
           - name: user-agent
             value: customcommandsclient/v1 (Node.js v20.4.0)
           - name: x-requested-with
@@ -607,9 +607,7 @@ log:
 
                   <SELECTEDCODE7662>export function sum(a: number, b: number): number {
                       /* CURSOR */
-                  }
-
-                  </SELECTEDCODE7662>
+                  }</SELECTEDCODE7662>
 
 
                   The user wants you to replace parts of the selected code or correct a problem by following their instructions.
@@ -652,7 +650,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 07 Mar 2025 18:54:01 GMT
+            value: Fri, 18 Apr 2025 06:07:43 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -676,13 +674,13 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1320
+        headersSize: 1368
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-03-07T18:53:58.821Z
-      time: 2487
+      startedDateTime: 2025-04-18T06:07:41.614Z
+      time: 2262
       timings:
         blocked: -1
         connect: -1
@@ -690,12 +688,12 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 2487
-    - _id: 5bb5e266d9ce9dbf5aeb3c8911884447
+        wait: 2262
+    - _id: 7724db516539b6806d8d83867420dd52
       _order: 0
       cache: {}
       request:
-        bodySize: 2361
+        bodySize: 2359
         cookies: []
         headers:
           - name: accept-encoding
@@ -708,7 +706,7 @@ log:
           - name: content-type
             value: application/json
           - name: traceparent
-            value: 00-587f68e6b04c01774ec8334db7f48892-354e7273c2b0359a-01
+            value: 00-a4c560991e9ee924b7e9721b66ee479f-95dbcdca294f1d93-01
           - name: user-agent
             value: customcommandsclient/v1 (Node.js v20.4.0)
           - name: x-requested-with
@@ -775,9 +773,7 @@ log:
                       isMammal: boolean
                   }
 
-                  /* SELECTION_END */
-
-                  </SELECTEDCODE7662>
+                  /* SELECTION_END */</SELECTEDCODE7662>
 
 
                   The user wants you to replace parts of the selected code or correct a problem by following their instructions.
@@ -806,14 +802,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=8&client-name=customcommandsclient&client-version=v1
       response:
-        bodySize: 730
+        bodySize: 720
         content:
           mimeType: text/event-stream
-          size: 730
+          size: 720
           text: >+
             event: completion
 
-            data: {"deltaText":"/* SELECTION_START */\nexport interface Animal {\n    name: string\n    makeAnimalSound(): string\n    isMammal: boolean\n    logAnimalName(): void\n}\n/* SELECTION_END */\n","stopReason":"stop_sequence"}
+            data: {"deltaText":"export interface Animal {\n    name: string\n    makeAnimalSound(): string\n    isMammal: boolean\n    logName(): void\n}","stopReason":"stop_sequence"}
 
 
             event: done
@@ -823,7 +819,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 07 Mar 2025 18:54:03 GMT
+            value: Fri, 18 Apr 2025 06:07:45 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -847,13 +843,13 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1320
+        headersSize: 1368
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-03-07T18:54:01.328Z
-      time: 1804
+      startedDateTime: 2025-04-18T06:07:43.893Z
+      time: 1571
       timings:
         blocked: -1
         connect: -1
@@ -861,7 +857,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 1804
+        wait: 1571
     - _id: f1b1cde4cd57488b7f0137954f0302f5
       _order: 0
       cache: {}

--- a/agent/recordings/document-code_965949506/recording.har.yaml
+++ b/agent/recordings/document-code_965949506/recording.har.yaml
@@ -94,158 +94,6 @@ log:
         send: 0
         ssl: -1
         wait: 787
-    - _id: 23d70a5471c1b18aa13dbf0f9652a8f7
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 2582
-        cookies: []
-        headers:
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_fc324d3667e841181b0779375f26dedc911d26b303d23b29b1a2d7ee63dc77eb
-          - name: connection
-            value: keep-alive
-          - name: content-type
-            value: application/json
-          - name: traceparent
-            value: 00-2add1cde333a4763fc5b2fcb1944cbac-adb3da59c7b33bb8-01
-          - name: user-agent
-            value: document-code/v1 (Node.js v20.4.0)
-          - name: x-requested-with
-            value: document-code v1
-          - name: host
-            value: sourcegraph.com
-        headersSize: 499
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 4000
-            messages:
-              - speaker: system
-                text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.
-
-
-                  - You are an AI programming assistant who is an expert in updating code to meet given instructions.
-
-                  - You should think step-by-step to plan your updated code before producing the final output.
-
-                  - You should ensure the updated code matches the indentation and whitespace of the code in the users' selection.
-
-                  - Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.
-
-                  - Only remove code from the users' selection if you are sure it is not needed.
-
-                  - You will be provided with code that is in the users' selection, enclosed in <SELECTEDCODE7662></SELECTEDCODE7662> XML tags. You must use this code to help you plan your updated code.
-
-                  - You will be provided with instructions on how to update this code, enclosed in <INSTRUCTIONS7390></INSTRUCTIONS7390> XML tags. You must follow these instructions carefully and to the letter.
-
-                  - Only enclose your response in <CODE5711></CODE5711> XML tags. Do use any other XML tags unless they are part of the generated code.
-
-                  - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
-              - speaker: human
-                text: >-
-                  This is part of the file: src/sum.ts
-
-
-                  The user has the following code in their selection:
-
-                  <SELECTEDCODE7662>export function sum(a: number, b: number): number {
-                      /* CURSOR */
-                  }
-
-                  </SELECTEDCODE7662>
-
-
-                  The user wants you to generate documentation for the selected code by following their instructions.
-
-                  Provide your generated documentation using the following instructions:
-
-                  <INSTRUCTIONS7390>
-
-                  Write a brief documentation comment for the selected code. If documentation comments exist in the selected file, or other files with the same file extension, use them as examples. Pay attention to the scope of the selected code (e.g. exported function/API vs implementation detail in a function), and use the idiomatic style for that type of code scope. Only generate the documentation for the selected code, do not generate the code. Do not enclose any other code or comments besides the documentation. Enclose only the documentation for the selected code and nothing else.
-
-                  </INSTRUCTIONS7390>
-              - speaker: assistant
-                text: <CODE5711>
-            model: anthropic::2024-10-22::claude-3-5-haiku-latest
-            stopSequences:
-              - </CODE5711>
-              - "export function sum(a: number, b: number): number {"
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString:
-          - name: api-version
-            value: "8"
-          - name: client-name
-            value: document-code
-          - name: client-version
-            value: v1
-        url: https://sourcegraph.com/.api/completions/stream?api-version=8&client-name=document-code&client-version=v1
-      response:
-        bodySize: 798
-        content:
-          mimeType: text/event-stream
-          size: 798
-          text: >+
-            event: completion
-
-            data: {"deltaText":"/**\n * Calculates the sum of two numbers.\n *\n * @param a The first number to add\n * @param b The second number to add\n * @returns The sum of a and b\n */","stopReason":"stop_sequence"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Fri, 07 Mar 2025 18:54:00 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1320
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2025-03-07T18:53:57.503Z
-      time: 2841
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 2841
     - _id: 7b7f92b0ba6cc7523b72e359aaeffb6a
       _order: 0
       cache: {}
@@ -802,11 +650,11 @@ log:
         send: 0
         ssl: -1
         wait: 2205
-    - _id: 5d56a4af3d7e4957137a3d4af3a8431c
+    - _id: 44ac4a98773b0d475519826bcc83e0bd
       _order: 0
       cache: {}
       request:
-        bodySize: 2585
+        bodySize: 2580
         cookies: []
         headers:
           - name: accept-encoding
@@ -819,7 +667,157 @@ log:
           - name: content-type
             value: application/json
           - name: traceparent
-            value: 00-8903eef2b842695912692a46278cd91b-acde6cc2c53dd694-01
+            value: 00-c63bb3278f139bea67092721c0b99a51-2b192f3a2da4ca62-01
+          - name: user-agent
+            value: document-code/v1 (Node.js v20.4.0)
+          - name: x-requested-with
+            value: document-code v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 499
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 4000
+            messages:
+              - speaker: system
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph.
+
+
+                  - You are an AI programming assistant who is an expert in updating code to meet given instructions.
+
+                  - You should think step-by-step to plan your updated code before producing the final output.
+
+                  - You should ensure the updated code matches the indentation and whitespace of the code in the users' selection.
+
+                  - Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.
+
+                  - Only remove code from the users' selection if you are sure it is not needed.
+
+                  - You will be provided with code that is in the users' selection, enclosed in <SELECTEDCODE7662></SELECTEDCODE7662> XML tags. You must use this code to help you plan your updated code.
+
+                  - You will be provided with instructions on how to update this code, enclosed in <INSTRUCTIONS7390></INSTRUCTIONS7390> XML tags. You must follow these instructions carefully and to the letter.
+
+                  - Only enclose your response in <CODE5711></CODE5711> XML tags. Do use any other XML tags unless they are part of the generated code.
+
+                  - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
+              - speaker: human
+                text: >-
+                  This is part of the file: src/sum.ts
+
+
+                  The user has the following code in their selection:
+
+                  <SELECTEDCODE7662>export function sum(a: number, b: number): number {
+                      /* CURSOR */
+                  }</SELECTEDCODE7662>
+
+
+                  The user wants you to generate documentation for the selected code by following their instructions.
+
+                  Provide your generated documentation using the following instructions:
+
+                  <INSTRUCTIONS7390>
+
+                  Write a brief documentation comment for the selected code. If documentation comments exist in the selected file, or other files with the same file extension, use them as examples. Pay attention to the scope of the selected code (e.g. exported function/API vs implementation detail in a function), and use the idiomatic style for that type of code scope. Only generate the documentation for the selected code, do not generate the code. Do not enclose any other code or comments besides the documentation. Enclose only the documentation for the selected code and nothing else.
+
+                  </INSTRUCTIONS7390>
+              - speaker: assistant
+                text: <CODE5711>
+            model: anthropic::2024-10-22::claude-3-5-haiku-latest
+            stopSequences:
+              - </CODE5711>
+              - "export function sum(a: number, b: number): number {"
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString:
+          - name: api-version
+            value: "8"
+          - name: client-name
+            value: document-code
+          - name: client-version
+            value: v1
+        url: https://sourcegraph.com/.api/completions/stream?api-version=8&client-name=document-code&client-version=v1
+      response:
+        bodySize: 1096
+        content:
+          mimeType: text/event-stream
+          size: 1096
+          text: >+
+            event: completion
+
+            data: {"deltaText":"/**\n * Calculates the sum of two numbers.\n * \n * @param a The first number to add.\n * @param b The second number to add.\n * @returns The sum of a and b.\n */","stopReason":"stop_sequence"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 18 Apr 2025 06:07:55 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1368
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2025-04-18T06:07:46.491Z
+      time: 10496
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 10496
+    - _id: 4fc51a3cdcffc8347517b06caf9db829
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 2583
+        cookies: []
+        headers:
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_fc324d3667e841181b0779375f26dedc911d26b303d23b29b1a2d7ee63dc77eb
+          - name: connection
+            value: keep-alive
+          - name: content-type
+            value: application/json
+          - name: traceparent
+            value: 00-dce781991186de17709b3b7bdae94f77-a8d61d0ade506baf-01
           - name: user-agent
             value: document-code/v1 (Node.js v20.4.0)
           - name: x-requested-with
@@ -868,9 +866,7 @@ log:
                       fun greeting(): String {
                           return "Hello, world!"
                       }
-                  }
-
-                  </SELECTEDCODE7662>
+                  }</SELECTEDCODE7662>
 
 
                   The user wants you to generate documentation for the selected code by following their instructions.
@@ -900,14 +896,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=8&client-name=document-code&client-version=v1
       response:
-        bodySize: 802
+        bodySize: 1035
         content:
           mimeType: text/event-stream
-          size: 802
+          size: 1035
           text: >+
             event: completion
 
-            data: {"deltaText":"/**\n * Represents a simple greeting class that provides a method to generate a greeting message.\n *\n * @constructor Creates an instance of the Hello class\n */","stopReason":"stop_sequence"}
+            data: {"deltaText":"/**\n * Represents a simple Hello class with a greeting method.\n *\n * @return A string containing the classic \"Hello, world!\" message.\n */","stopReason":"stop_sequence"}
 
 
             event: done
@@ -917,7 +913,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 07 Mar 2025 18:54:08 GMT
+            value: Fri, 18 Apr 2025 06:07:59 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -941,13 +937,13 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1320
+        headersSize: 1368
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-03-07T18:54:06.767Z
-      time: 1974
+      startedDateTime: 2025-04-18T06:07:51.499Z
+      time: 8178
       timings:
         blocked: -1
         connect: -1
@@ -955,7 +951,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 1974
+        wait: 8178
     - _id: f1b1cde4cd57488b7f0137954f0302f5
       _order: 0
       cache: {}

--- a/agent/recordings/edit_1541920145/recording.har.yaml
+++ b/agent/recordings/edit_1541920145/recording.har.yaml
@@ -92,157 +92,6 @@ log:
         send: 0
         ssl: -1
         wait: 330
-    - _id: de587bf164b2da87e70c58e6ca333837
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 1984
-        cookies: []
-        headers:
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_fc324d3667e841181b0779375f26dedc911d26b303d23b29b1a2d7ee63dc77eb
-          - name: connection
-            value: keep-alive
-          - name: content-type
-            value: application/json
-          - name: traceparent
-            value: 00-61d5da54597e5e683adb3c045ea59e7a-ff69a075c3ac1d71-01
-          - name: user-agent
-            value: edit/v1 (Node.js v20.4.0)
-          - name: x-requested-with
-            value: edit v1
-          - name: host
-            value: sourcegraph.com
-        headersSize: 472
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 4000
-            messages:
-              - speaker: system
-                text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.
-
-
-                  - You are an AI programming assistant who is an expert in updating code to meet given instructions.
-
-                  - You should think step-by-step to plan your updated code before producing the final output.
-
-                  - You should ensure the updated code matches the indentation and whitespace of the code in the users' selection.
-
-                  - Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.
-
-                  - Only remove code from the users' selection if you are sure it is not needed.
-
-                  - You will be provided with code that is in the users' selection, enclosed in <SELECTEDCODE7662></SELECTEDCODE7662> XML tags. You must use this code to help you plan your updated code.
-
-                  - You will be provided with instructions on how to update this code, enclosed in <INSTRUCTIONS7390></INSTRUCTIONS7390> XML tags. You must follow these instructions carefully and to the letter.
-
-                  - Only enclose your response in <CODE5711></CODE5711> XML tags. Do use any other XML tags unless they are part of the generated code.
-
-                  - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
-              - speaker: human
-                text: >-
-                  This is part of the file: src/sum.ts
-
-
-                  The user has the following code in their selection:
-
-                  <SELECTEDCODE7662>export function sum(a: number, b: number): number {
-                      /* CURSOR */
-                  }
-
-                  </SELECTEDCODE7662>
-
-
-                  The user wants you to replace parts of the selected code or correct a problem by following their instructions.
-
-                  Provide your generated code using the following instructions:
-
-                  <INSTRUCTIONS7390>
-
-                  Rename `a` parameter to `c`
-
-                  </INSTRUCTIONS7390>
-              - speaker: assistant
-                text: <CODE5711>
-            model: anthropic::2024-10-22::claude-3-5-sonnet-latest
-            stopSequences:
-              - </CODE5711>
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString:
-          - name: api-version
-            value: "8"
-          - name: client-name
-            value: edit
-          - name: client-version
-            value: v1
-        url: https://sourcegraph.com/.api/completions/stream?api-version=8&client-name=edit&client-version=v1
-      response:
-        bodySize: 505
-        content:
-          mimeType: text/event-stream
-          size: 505
-          text: >+
-            event: completion
-
-            data: {"deltaText":"export function sum(c: number, b: number): number {\n    /* CURSOR */\n}\n","stopReason":"stop_sequence"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Fri, 07 Mar 2025 18:53:56 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1320
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2025-03-07T18:53:54.286Z
-      time: 1794
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 1794
     - _id: 53cd3b836acbf7d04ccd11784dc90794
       _order: 0
       cache: {}
@@ -429,11 +278,11 @@ log:
         send: 0
         ssl: -1
         wait: 2224
-    - _id: b09491600efcaea936949a563b9d589e
+    - _id: f9d9ee775b840cb488bee26f797a3420
       _order: 0
       cache: {}
       request:
-        bodySize: 2133
+        bodySize: 1982
         cookies: []
         headers:
           - name: accept-encoding
@@ -446,7 +295,156 @@ log:
           - name: content-type
             value: application/json
           - name: traceparent
-            value: 00-fda075464797ff4a27e3af3b4b901057-d86dd9686765ea93-01
+            value: 00-ff8c83ea6c0556deafc75f56a86120d7-9c215e05892f7ca6-01
+          - name: user-agent
+            value: edit/v1 (Node.js v20.4.0)
+          - name: x-requested-with
+            value: edit v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 472
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 4000
+            messages:
+              - speaker: system
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph.
+
+
+                  - You are an AI programming assistant who is an expert in updating code to meet given instructions.
+
+                  - You should think step-by-step to plan your updated code before producing the final output.
+
+                  - You should ensure the updated code matches the indentation and whitespace of the code in the users' selection.
+
+                  - Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.
+
+                  - Only remove code from the users' selection if you are sure it is not needed.
+
+                  - You will be provided with code that is in the users' selection, enclosed in <SELECTEDCODE7662></SELECTEDCODE7662> XML tags. You must use this code to help you plan your updated code.
+
+                  - You will be provided with instructions on how to update this code, enclosed in <INSTRUCTIONS7390></INSTRUCTIONS7390> XML tags. You must follow these instructions carefully and to the letter.
+
+                  - Only enclose your response in <CODE5711></CODE5711> XML tags. Do use any other XML tags unless they are part of the generated code.
+
+                  - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
+              - speaker: human
+                text: >-
+                  This is part of the file: src/sum.ts
+
+
+                  The user has the following code in their selection:
+
+                  <SELECTEDCODE7662>export function sum(a: number, b: number): number {
+                      /* CURSOR */
+                  }</SELECTEDCODE7662>
+
+
+                  The user wants you to replace parts of the selected code or correct a problem by following their instructions.
+
+                  Provide your generated code using the following instructions:
+
+                  <INSTRUCTIONS7390>
+
+                  Rename `a` parameter to `c`
+
+                  </INSTRUCTIONS7390>
+              - speaker: assistant
+                text: <CODE5711>
+            model: anthropic::2024-10-22::claude-3-5-sonnet-latest
+            stopSequences:
+              - </CODE5711>
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString:
+          - name: api-version
+            value: "8"
+          - name: client-name
+            value: edit
+          - name: client-version
+            value: v1
+        url: https://sourcegraph.com/.api/completions/stream?api-version=8&client-name=edit&client-version=v1
+      response:
+        bodySize: 587
+        content:
+          mimeType: text/event-stream
+          size: 587
+          text: >+
+            event: completion
+
+            data: {"deltaText":"export function sum(c: number, b: number): number {\n    /* CURSOR */\n}","stopReason":"stop_sequence"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 18 Apr 2025 06:07:41 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1368
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2025-04-18T06:07:39.736Z
+      time: 1932
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 1932
+    - _id: b13d2273a437198c3d4da4936086d0d3
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 2131
+        cookies: []
+        headers:
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_fc324d3667e841181b0779375f26dedc911d26b303d23b29b1a2d7ee63dc77eb
+          - name: connection
+            value: keep-alive
+          - name: content-type
+            value: application/json
+          - name: traceparent
+            value: 00-4b360e110796d337b59c33f23708190a-6e22b9dc83d3b385-01
           - name: user-agent
             value: edit/v1 (Node.js v20.4.0)
           - name: x-requested-with
@@ -504,9 +502,7 @@ log:
                       return a - b
                   }
 
-                  /* SELECTION_END */
-
-                  </SELECTEDCODE7662>
+                  /* SELECTION_END */</SELECTEDCODE7662>
 
 
                   The user wants you to replace parts of the selected code or correct a problem by following their instructions.
@@ -535,14 +531,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=8&client-name=edit&client-version=v1
       response:
-        bodySize: 1036
+        bodySize: 1116
         content:
           mimeType: text/event-stream
-          size: 1036
+          size: 1116
           text: >+
             event: completion
 
-            data: {"deltaText":"\nexport function trickyLogic(a: number, b: number): number {\n    switch (true) {\n        case a === 0:\n            return 1\n        case b === 2:\n            return 1\n        default:\n            return a - b\n    }\n}\n","stopReason":"stop_sequence"}
+            data: {"deltaText":"export function trickyLogic(a: number, b: number): number {\n    switch (true) {\n        case a === 0:\n            return 1\n        case b === 2:\n            return 1\n        default:\n            return a - b\n    }\n}","stopReason":"stop_sequence"}
 
 
             event: done
@@ -552,7 +548,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 07 Mar 2025 18:54:01 GMT
+            value: Fri, 18 Apr 2025 06:07:50 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -576,13 +572,13 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1320
+        headersSize: 1368
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-03-07T18:53:58.421Z
-      time: 2640
+      startedDateTime: 2025-04-18T06:07:41.768Z
+      time: 10197
       timings:
         blocked: -1
         connect: -1
@@ -590,7 +586,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 2640
+        wait: 10197
     - _id: f1b1cde4cd57488b7f0137954f0302f5
       _order: 0
       cache: {}

--- a/agent/recordings/fix_3001320056/recording.har.yaml
+++ b/agent/recordings/fix_3001320056/recording.har.yaml
@@ -94,11 +94,11 @@ log:
         send: 0
         ssl: -1
         wait: 211
-    - _id: 19415cc71acacd46afcef34a2c2fd509
+    - _id: 063c131a30182e5d1ab9717fb1c587da
       _order: 0
       cache: {}
       request:
-        bodySize: 2277
+        bodySize: 2275
         cookies: []
         headers:
           - name: accept-encoding
@@ -111,7 +111,7 @@ log:
           - name: content-type
             value: application/json
           - name: traceparent
-            value: 00-605c5ac0981606ee63975f37285ee7a7-4f7f0d352bdf2128-01
+            value: 00-addbb0a81e2beaee7b64f828206bc88a-3f506f32e14ede58-01
           - name: user-agent
             value: fix/v1 (Node.js v20.4.0)
           - name: x-requested-with
@@ -160,9 +160,7 @@ log:
 
                   <SELECTEDCODE7662>export function fixCommandExample(): number {
                       return '42';
-                  }
-
-                  </SELECTEDCODE7662>
+                  }</SELECTEDCODE7662>
 
 
                   The user wants you to correct problems in their code by following their instructions.
@@ -198,14 +196,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=8&client-name=fix&client-version=v1
       response:
-        bodySize: 455
+        bodySize: 495
         content:
           mimeType: text/event-stream
-          size: 455
+          size: 495
           text: >+
             event: completion
 
-            data: {"deltaText":"export function fixCommandExample(): number {\n    return 42;\n}\n","stopReason":"stop_sequence"}
+            data: {"deltaText":"export function fixCommandExample(): number {\n    return 42;\n}","stopReason":"stop_sequence"}
 
 
             event: done
@@ -215,7 +213,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 07 Mar 2025 18:53:58 GMT
+            value: Fri, 18 Apr 2025 06:07:47 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -239,13 +237,13 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1320
+        headersSize: 1368
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-03-07T18:53:56.876Z
-      time: 1525
+      startedDateTime: 2025-04-18T06:07:46.485Z
+      time: 1478
       timings:
         blocked: -1
         connect: -1
@@ -253,7 +251,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 1525
+        wait: 1478
     - _id: f1b1cde4cd57488b7f0137954f0302f5
       _order: 0
       cache: {}

--- a/agent/src/__snapshots__/custom-commands.test.ts.snap
+++ b/agent/src/__snapshots__/custom-commands.test.ts.snap
@@ -9,15 +9,12 @@ exports[`Custom Commands > commands/custom, chat command, open tabs context 1`] 
 `;
 
 exports[`Custom Commands > commands/custom, edit command, edit mode 1`] = `
-"/* SELECTION_START */
-export interface Animal {
+"export interface Animal {
     name: string
     makeAnimalSound(): string
     isMammal: boolean
-    logAnimalName(): void
-}
-/* SELECTION_END */
-"
+    logName(): void
+}"
 `;
 
 exports[`Custom Commands > commands/custom, edit command, insert mode 1`] = `

--- a/agent/src/__snapshots__/document-code.test.ts.snap
+++ b/agent/src/__snapshots__/document-code.test.ts.snap
@@ -22,9 +22,9 @@ export const TestLogger = {
 
 exports[`Document Code > commands/document (Kotlin class name) 1`] = `
 "/**
- * Represents a simple greeting class that provides a method to generate a greeting message.
+ * Represents a simple Hello class with a greeting method.
  *
- * @constructor Creates an instance of the Hello class
+ * @return A string containing the classic "Hello, world!" message.
  */
 class He/* CURSOR */llo {
     fun greeting(): String {
@@ -102,10 +102,10 @@ describe('test block', () => {
 exports[`Document Code > editCommands/document (basic function) 1`] = `
 "/**
  * Calculates the sum of two numbers.
- *
- * @param a The first number to add
- * @param b The second number to add
- * @returns The sum of a and b
+ * 
+ * @param a The first number to add.
+ * @param b The second number to add.
+ * @returns The sum of a and b.
  */
 export function sum(a: number, b: number): number {
     /* CURSOR */

--- a/agent/src/edit.test.ts
+++ b/agent/src/edit.test.ts
@@ -134,8 +134,7 @@ describe('Edit', { timeout: 5000 }, () => {
                   default:
                       return a - b
               }
-          }
-          "
+          }"
         `,
             explainPollyError
         )

--- a/vscode/src/chat/chat-view/ChatController.test.ts
+++ b/vscode/src/chat/chat-view/ChatController.test.ts
@@ -140,7 +140,7 @@ describe('ChatController', () => {
         expect(addBotMessageSpy).not.toHaveBeenCalled()
     })
 
-    test('verifies interactionId is passed through chat requests', { timeout: 3000 }, async () => {
+    test('verifies interactionId is passed through chat requests', { timeout: 5000 }, async () => {
         const mockRequestID = '0'
         mockContextRetriever.retrieveContext.mockResolvedValue([])
 

--- a/vscode/src/non-stop/FixupTask.ts
+++ b/vscode/src/non-stop/FixupTask.ts
@@ -153,7 +153,13 @@ export class FixupTask {
         // For all other Edits, we always expand the range to encompass all characters from the selection lines
         // This is so we can calculate an optimal diff, and the LLM has the best chance at understanding
         // the indentation in the returned code.
-        return new vscode.Range(proposedRange.start.line, 0, proposedRange.end.line + 1, 0)
+        const isLastLine = proposedRange.end.line === this.document.lineCount - 1
+        return new vscode.Range(
+            proposedRange.start.line,
+            0,
+            proposedRange.end.line + (isLastLine ? 0 : 1),
+            isLastLine ? this.document.lineAt(this.document.lineCount - 1).range.end.character : 0
+        )
     }
 
     /**


### PR DESCRIPTION
VSCode's text edit API is apparently forgiving and allows a position at `(N,0)` in an N-lined document, even if the last line does not end in a newline. (Note that lines are zero indexed so `(N,0)` is the N+1th line.)

JetBrains' text model is less forgiving and treats that extent as out of bounds. This causes exceptions when rejecting edits.

We could follow Postel's law and make EditService.performTextEdits more liberal in what it accepts. But since we're integrating this into N editors, I have chosen to make the TypeScript side more rigorous and not extend selections past the end of the document.

Fixes QA-507.

## Test plan

```
pnpm i && pnpm -C lib/shared build && pnpm build
cd jetbrains
SKIP_CODE_SEARCH_BUILD=true ./gradlew :customRunIde -PforceAgentBuild=true
```

Then:

1. Open a project
2. Write hello world in C in a file; end with a `}` but without a newline.
3. Move the cursor into the function, opt-K/alt-K
4. Instruct Cody to "improve code", opt-K
5. The edit will add some comments or `return EXIT_SUCCESS;` and so on.
6. Opt-X to reject the edit.

The proposed change should disappear and there should be no IDE exception about text boundaries.