### PR TITLE
handle broken avatar URLs

### DIFF
--- a/vscode/webviews/components/UserAvatar.tsx
+++ b/vscode/webviews/components/UserAvatar.tsx
@@ -1,4 +1,5 @@
 import { clsx } from 'clsx'
+import { useState } from 'react'
 import type { FunctionComponent } from 'react'
 import type { UserAccountInfo } from '../Chat'
 import styles from './UserAvatar.module.css'
@@ -44,8 +45,9 @@ const InnerUserAvatar: FunctionComponent<Omit<Props, 'sourcegraphGradientBorder'
 }) => {
     const title = user.displayName || user.username
     const highDPISize = size * 2
+    const [imgError, setImgError] = useState(false)
 
-    if (user?.avatarURL) {
+    if (user?.avatarURL && !imgError) {
         let url = user.avatarURL
         try {
             const urlObject = new URL(user.avatarURL)
@@ -68,6 +70,7 @@ const InnerUserAvatar: FunctionComponent<Omit<Props, 'sourcegraphGradientBorder'
                 alt={`Avatar for ${user.username}`}
                 width={size}
                 height={size}
+                onError={() => setImgError(true)}
             />
         )
     }


### PR DESCRIPTION
This PR adds error handling for user avatar URLs.  If the avatar URL is invalid or inaccessible, the component will fall back to displaying the user's initials instead of a broken image.

## Test plan
Still displays avatars from public-facing URLs and now uses the fallback for private or unreachable URLs.

Image from self-hosted GitLab.
Before:
![Screenshot 2025-04-22 at 2 45 08 PM](https://github.com/user-attachments/assets/58260a59-e303-4011-8d71-05e42836cc2f)
![Screenshot 2025-04-22 at 2 48 37 PM](https://github.com/user-attachments/assets/89d5059f-ac97-44c0-aaf2-26d628d26f32)

After:
![Screenshot 2025-04-22 at 2 46 55 PM](https://github.com/user-attachments/assets/404cd51e-7119-4da8-aaed-1df71cbfa951)
![Screenshot 2025-04-22 at 3 27 21 PM](https://github.com/user-attachments/assets/5fa6314d-587f-4e69-9cb6-2574aaeacd02)

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
