### PR TITLE
fix(auto-edit): model call latency metric did not reflect actual timing

### DIFF
--- a/vscode/src/autoedits/autoedits-provider.ts
+++ b/vscode/src/autoedits/autoedits-provider.ts
@@ -840,8 +840,14 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
             timeoutMs: autoeditsProviderConfig.timeoutMs,
         })
 
+        const responseWithTiming = this.generatorWithTiming(
+            this.modelAdapter.constructor.name,
+            autoeditsProviderConfig.model,
+            responseGenerator
+        )
+
         return processHotStreakResponses({
-            responseGenerator,
+            responseGenerator: responseWithTiming,
             document,
             codeToReplaceData,
             docContext,
@@ -920,12 +926,7 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
                 abortSignal: signal,
                 docContext,
             })
-
-            return this.generatorWithTiming(
-                this.modelAdapter.constructor.name,
-                autoeditsProviderConfig.model,
-                response
-            )
+            return response
         })
     }
 

--- a/vscode/src/autoedits/autoedits-provider.ts
+++ b/vscode/src/autoedits/autoedits-provider.ts
@@ -192,6 +192,7 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
     private modelCallLatencyMetric: Histogram<{
         adapter: string
         model: string
+        seq: number
     }>
 
     constructor(
@@ -261,8 +262,9 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
         this.modelCallLatencyMetric = meter.createHistogram<{
             adapter: string
             model: string
-        }>('autoedit.model.call.latency', {
-            description: 'Autoedit model call latency',
+            seq: number
+        }>('autoedit.model.latency', {
+            description: 'Autoedit model call latency by adapter and model',
             unit: 'ms',
         })
 
@@ -910,7 +912,6 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
         }
 
         return this.requestManager.request(requestParams, async signal => {
-            const startedAt = getTimeNowInMillis()
             const response = await this.getAndProcessModelResponses({
                 document,
                 position,
@@ -920,13 +921,35 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
                 docContext,
             })
 
-            this.modelCallLatencyMetric.record(getTimeNowInMillis() - startedAt, {
-                adapter: this.modelAdapter.constructor.name,
-                model: autoeditsProviderConfig.model,
-            })
-
-            return response
+            return this.generatorWithTiming(
+                this.modelAdapter.constructor.name,
+                autoeditsProviderConfig.model,
+                response
+            )
         })
+    }
+
+    private async *generatorWithTiming<T>(
+        adapter: string,
+        model: string,
+        generator: AsyncGenerator<T>
+    ): AsyncGenerator<T> {
+        const startedAt = getTimeNowInMillis()
+        let seq = 0
+        while (true) {
+            const res = await generator.next()
+            this.modelCallLatencyMetric.record(getTimeNowInMillis() - startedAt, {
+                adapter,
+                model,
+                seq,
+            })
+            seq += 1
+
+            if (res.done) {
+                return
+            }
+            yield res.value
+        }
     }
 
     public async manuallyTriggerCompletion(): Promise<void> {


### PR DESCRIPTION
`getAndProcessModelResponses` returns an `AsyncGenerator`. As a result, the wait does not happen until calls to `next` function. This causes timing skewed to only function call latencies. The fix is to record latency at the time `next` function is called instead.

ref: CODY-5528

## Test plan

verified by manually trying autoedit in debug environment and verify the metrics in metric explorer.
![Screenshot 2025-04-22 at 16 10 27](https://github.com/user-attachments/assets/43936eb7-1701-4479-8deb-66d021610b47)

