### PR TITLE
chore(auto-edit): allow custom models for websocket requests

### DIFF
--- a/vscode/src/autoedits/adapters/fireworks-websocket.ts
+++ b/vscode/src/autoedits/adapters/fireworks-websocket.ts
@@ -106,8 +106,7 @@ export class FireworksWebSocketAdapter implements AutoeditsModelAdapter {
         const maxTokens = getMaxOutputTokensForAutoedits(options.codeToRewrite)
         const baseParams: FireworksCompatibleRequestParams = {
             stream: true,
-            // TODO(CODY-5528): allow user to specify models
-            // model: options.model,
+            model: options.model,
             temperature: 0.1,
             max_tokens: maxTokens,
             response_format: {

--- a/vscode/src/autoedits/adapters/utils.ts
+++ b/vscode/src/autoedits/adapters/utils.ts
@@ -3,9 +3,7 @@ import type { InceptionLabsRequestParams } from './inceptionlabs'
 
 export interface FireworksCompatibleRequestParams {
     stream: boolean
-    // TODO(CODY-5745): make this mandatory to be consistent with fireworks API. This is required unless
-    // hitting fireworks direct URL.
-    model?: string
+    model: string
     temperature: number
     max_tokens: number
     response_format: {


### PR DESCRIPTION
Until https://github.com/sourcegraph/sourcegraph/pull/5030, the websocket proxy does not support custom models for fireworks requests since the proxy uses a hard-coded URL to a specific model. This has been changed to client's custom model and URL setting takes precedence.

ref: CODY-5745

## Test plan

- manual testing in conjunction with https://github.com/sourcegraph/sourcegraph/pull/5030