### PR TITLE
Added support for Ctrl+C not working in Rider/Windows

### DIFF
--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/ui/web/WebUIProxy.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/ui/web/WebUIProxy.kt
@@ -136,7 +136,9 @@ internal class WebUIProxy(private val host: WebUIHost, private val browser: JBCe
               event.isConsumed &&
               (event.keyCode == KeyEvent.VK_ENTER ||
                   event.keyCode == KeyEvent.VK_DELETE ||
-                  event.keyCode == KeyEvent.VK_BACK_SPACE)) {
+                  event.keyCode == KeyEvent.VK_BACK_SPACE ||
+                  (event.isControlDown && event.keyCode == KeyEvent.VK_C) // Ctrl+C
+              )) {
 
             // trying to un-consume the event via reflection
             val consumedField = AWTEvent::class.java.getDeclaredField("consumed")


### PR DESCRIPTION
 Added support for Ctrl+C not working in Rider/Windows, when trying to copy text from Cody tool window.

CLOSE https://linear.app/sourcegraph/issue/CODY-4258/fix-ctrl-c-text-copy-issue-in-cody-for-rider-on-windows

## Test plan

1. Open Rider (Windows)
2. Open Cody chat and ask to generate some code snippet
3. Select part of a code snipper, and `Ctrl+C` to copy it
4. `Ctrl+V` in the editor to check result
