### PR TITLE
fix(vscode): read commit template from git's config

### DIFF
--- a/vscode/src/commands/scm/source-control.ts
+++ b/vscode/src/commands/scm/source-control.ts
@@ -114,12 +114,26 @@ export class CodySourceControl implements vscode.Disposable {
 
         // Get Commit Template from config and set it when available.
         if (!this.commitTemplate) {
-            const [localTemplate, globalTemplate] = await Promise.all([
-                repository.getConfig('commit.template'),
-                repository.getGlobalConfig('commit.template'),
-            ])
-
-            this.commitTemplate = scm?.commitTemplate ?? localTemplate ?? globalTemplate
+            if (scm?.commitTemplate) {
+                this.commitTemplate = scm.commitTemplate
+            } else {
+                // In the case that VSCode's SCM integration didn't read the commit template,
+                // look for via `git config --get`
+                const [localTemplateFilePath, globalTemplateFilePath] = await Promise.all([
+                    repository.getConfig('commit.template'),
+                    repository.getGlobalConfig('commit.template'),
+                ])
+                const commitTemplateFilePath = localTemplateFilePath ?? globalTemplateFilePath
+                if (commitTemplateFilePath) {
+                    try {
+                        this.commitTemplate = await vscode.workspace.fs.readFile(vscode.Uri.file(commitTemplateFilePath)).then(buffer =>
+                            new TextDecoder().decode(buffer)
+                        )
+                    } catch (error) {
+                        console.error(`Failed to read commit template file: ${commitTemplateFilePath}`, error)
+                    }
+                }
+            }
         }
 
         // Open the vscode source control view to show the progress.
@@ -134,7 +148,7 @@ export class CodySourceControl implements vscode.Disposable {
                 cancellable: true,
             },
             async (progress, token) => {
-                this.stream(repository, sourceControlInputbox, progress, token, scm?.commitTemplate)
+                this.stream(repository, sourceControlInputbox, progress, token, this.commitTemplate)
             }
         )
     }
@@ -177,7 +191,8 @@ export class CodySourceControl implements vscode.Disposable {
             const { prompt, ignoredContext } = await this.buildPrompt(
                 contextWindow,
                 getSimplePreamble(model, 1, 'Default', COMMIT_COMMAND_PROMPTS.intro),
-                context
+                context,
+                commitTemplate
             ).catch(error => {
                 sourceControlInputbox.value = `${error}`
                 throw new Error()
@@ -223,13 +238,14 @@ export class CodySourceControl implements vscode.Disposable {
     private async buildPrompt(
         contextWindow: ModelContextWindow,
         preamble: Message[],
-        context: ContextItem[]
+        context: ContextItem[],
+        commitTemplate?: string
     ): Promise<{ prompt: Message[]; ignoredContext: ContextItem[] }> {
         if (!context.length) {
             throw new Error('Failed to get git output.')
         }
 
-        const templatePrompt = this.commitTemplate
+        const templatePrompt = commitTemplate
             ? COMMIT_COMMAND_PROMPTS.template
             : COMMIT_COMMAND_PROMPTS.noTemplate
         const text = COMMIT_COMMAND_PROMPTS.instruction.replace('{COMMIT_TEMPLATE}', templatePrompt)

--- a/vscode/src/commands/scm/source-control.ts
+++ b/vscode/src/commands/scm/source-control.ts
@@ -126,11 +126,14 @@ export class CodySourceControl implements vscode.Disposable {
                 const commitTemplateFilePath = localTemplateFilePath ?? globalTemplateFilePath
                 if (commitTemplateFilePath) {
                     try {
-                        this.commitTemplate = await vscode.workspace.fs.readFile(vscode.Uri.file(commitTemplateFilePath)).then(buffer =>
-                            new TextDecoder().decode(buffer)
-                        )
+                        this.commitTemplate = await vscode.workspace.fs
+                            .readFile(vscode.Uri.file(commitTemplateFilePath))
+                            .then(buffer => new TextDecoder().decode(buffer))
                     } catch (error) {
-                        console.error(`Failed to read commit template file: ${commitTemplateFilePath}`, error)
+                        console.error(
+                            `Failed to read commit template file: ${commitTemplateFilePath}`,
+                            error
+                        )
                     }
                 }
             }


### PR DESCRIPTION
Inspired by PR #7748, read the commit template from `git config` if VSCode's SCM integration does not have a commit template already.

Works only with `git`.

Affects the "Generate Commit Message" functionality introduced in PR #4130

## Test plan

CI tests pass.

Usually VSCode's SCM integration loads the commit template, but you might be able to fake it out by unsetting the commit template (`git config --unset commit.template;git config --global --unset commit.template; sudo git config --system --unset commit.template`), launching VSCode, and then setting the commit template(s) again.

If you're able to fake out VSCode's SCM integration, you should still see the commit template being loaded (you might need to set some breakpoints to be sure)
