### PR TITLE
fix(edit): decoding replies that didn't return html entities

### DIFF
--- a/vscode/src/edit/output/test-fixtures.ts
+++ b/vscode/src/edit/output/test-fixtures.ts
@@ -25,6 +25,10 @@ Some more text
 ${CLEAN_RESPONSE}
 \`\`\``
 
+const C_RESPONSE = 'int* current_ptr = &currentValue;'
+const CSHARP_RESPONSE =
+    'public List&lt;object&gt; FindNext（Drone drone, HashSet&lt; int&gt; testHashSet)'
+
 const DEFAULT_TASK = { document: { languageId: 'typescript' } } as FixupTask
 
 export const RESPONSE_TEST_FIXTURES: Record<string, ResponseTestFixture> = {
@@ -67,6 +71,16 @@ export const RESPONSE_TEST_FIXTURES: Record<string, ResponseTestFixture> = {
         response: CLEAN_RESPONSE.replace(/</g, '&lt;').replace(/>/g, '&gt;'),
         expected: CLEAN_RESPONSE,
         task: DEFAULT_TASK,
+    },
+    withCsharpHtmlEntities: {
+        response: CSHARP_RESPONSE,
+        expected: CSHARP_RESPONSE.replace(/&lt;/g, '<').replace(/&gt;/g, '>'),
+        task: { ...DEFAULT_TASK, document: { languageId: 'csharp' } } as FixupTask,
+    },
+    withAmpersAndSemicolonInC: {
+        response: C_RESPONSE,
+        expected: C_RESPONSE,
+        task: { ...DEFAULT_TASK, document: { languageId: 'c' } } as FixupTask,
     },
     withLeadingSpaces: {
         response: '   \n\n' + CLEAN_RESPONSE,


### PR DESCRIPTION
Fixes CODY-5760

This change improves the way HTML entities are decoded in LLM responses within the fixup task.

Previously, all HTML entities were aggressively decoded using the `he` library. This could inadvertently alter code containing ampersands, such as `int* current_ptr = &current_value;`.

The updated approach introduces a regular expression, `POTENTIAL_HTML_ENTITY_REGEX`, to detect the *few* HTML entities we actually care about, specifically `&lt;`, `&gt;`, `&amp;`, `&quot;`, and `&apos;`. Decoding is now only performed if these potential entities are detected, preventing unintended modifications to code.

This change also adds new test fixtures to verify the correct decoding of responses with C# HTML entities and ampersands in C code.

## Test plan
- Ask Cody to generate code that contains &text; 
- Smart apply it and notice that the response isn't modified
