### PR TITLE
fix(rules): avoid duplicate .sourcegraph paths in rule search

### DIFF
--- a/lib/shared/src/rules/editing-helpers.ts
+++ b/lib/shared/src/rules/editing-helpers.ts
@@ -13,7 +13,7 @@ The YAML front matter has the following fields:
 - title (required string)
 - description (optional string)
 - tags (optional string[])
-- langauge (optional string)
+- language (optional string)
 - language_filters, repo_filters, path_filters, text_content_filters (optional {include: string[], exclude: string[]})
 
 The Markdown body is an LLM prompt that is included in AI code chat and editing on files that the rule applies to:

--- a/lib/shared/src/rules/rules.test.ts
+++ b/lib/shared/src/rules/rules.test.ts
@@ -122,7 +122,7 @@ describe('ruleSearchPaths', () => {
         const searchPaths = ruleSearchPaths(uri, root)
         expect(searchPaths.map(u => u.toString())).toStrictEqual([])
     })
-    
+
     it('avoids duplicate .sourcegraph paths', () => {
         const uri = URI.parse('file:///a/b/c/src/.sourcegraph/example.ts')
         const root = URI.parse('file:///a/b/c')

--- a/lib/shared/src/rules/rules.test.ts
+++ b/lib/shared/src/rules/rules.test.ts
@@ -122,4 +122,15 @@ describe('ruleSearchPaths', () => {
         const searchPaths = ruleSearchPaths(uri, root)
         expect(searchPaths.map(u => u.toString())).toStrictEqual([])
     })
+    
+    it('avoids duplicate .sourcegraph paths', () => {
+        const uri = URI.parse('file:///a/b/c/src/.sourcegraph/example.ts')
+        const root = URI.parse('file:///a/b/c')
+        const searchPaths = ruleSearchPaths(uri, root)
+        expect(searchPaths.map(u => u.toString())).toStrictEqual([
+            'file:///a/b/c/src/.sourcegraph',
+            'file:///a/b/c/.sourcegraph',
+        ])
+        // Ensures we don't get 'file:///a/b/c/src/.sourcegraph/.sourcegraph'
+    })
 })

--- a/lib/shared/src/rules/rules.ts
+++ b/lib/shared/src/rules/rules.ts
@@ -139,6 +139,11 @@ export function ruleSearchPaths(uri: URI, root: URI): URI[] {
             break
         }
         current = current.with({ path: pathFuncs.dirname(current.path) })
+        // skip adding the current path if it already ends with .sourcegraph
+        // to avoid duplicate .sourcegraph paths
+        if (current.path.endsWith('.sourcegraph')) {
+            continue
+        }
         searchPaths.push(current.with({ path: pathFuncs.resolve(current.path, '.sourcegraph') }))
     }
     return searchPaths

--- a/vscode/src/completions/analytics-logger.ts
+++ b/vscode/src/completions/analytics-logger.ts
@@ -259,7 +259,7 @@ interface ErrorEventPayload {
 interface FormatEventPayload {
     // `formatCompletion` duration.
     duration: number
-    // Current document langauge ID
+    // Current document language ID
     languageId: string
     // Formatter name extracted from user settings JSON.
     formatter?: string

--- a/vscode/src/rules/fs-rule-provider.ts
+++ b/vscode/src/rules/fs-rule-provider.ts
@@ -57,7 +57,7 @@ export function createFileSystemRuleProvider(): RuleProvider {
                     for (const uri of files) {
                         // Do not search for rules outside of a workspace folder.
                         const root = vscode.workspace.getWorkspaceFolder(uri)
-                        if (!root) {
+                        if (!root || !vscode.workspace.isTrusted) {
                             continue
                         }
                         const searchPaths = ruleSearchPaths(uri, root.uri)
@@ -79,7 +79,7 @@ export function createFileSystemRuleProvider(): RuleProvider {
                                     const rootFolder = vscode.workspace.getWorkspaceFolder(searchPath)
                                     // There should always be a root since we checked it above, but
                                     // be defensive.
-                                    if (!rootFolder) {
+                                    if (!rootFolder || !vscode.workspace.isTrusted) {
                                         return []
                                     }
                                     const root = rootFolder.uri

--- a/vscode/src/rules/fs-rule-provider.ts
+++ b/vscode/src/rules/fs-rule-provider.ts
@@ -84,18 +84,9 @@ export function createFileSystemRuleProvider(): RuleProvider {
                                     }
                                     const root = rootFolder.uri
 
-                                    // Check if directory exists before trying to read it
-                                    try {
-                                        await vscode.workspace.fs.stat(searchPath)
-                                    } catch (error) {
-                                        if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
-                                            // .sourcegraph directory doesn't exist, return empty array without error
-                                            return []
-                                        }
-                                        throw error // Rethrow other errors
-                                    }
-
-                                    const entries = await vscode.workspace.fs.readDirectory(searchPath)
+                                    const entries =
+                                        (await vscode.workspace.fs.stat(searchPath)) &&
+                                        (await vscode.workspace.fs.readDirectory(searchPath))
                                     signal?.throwIfAborted()
 
                                     const ruleFiles = entries.filter(([name]) => isRuleFilename(name))

--- a/vscode/src/rules/fs-rule-provider.ts
+++ b/vscode/src/rules/fs-rule-provider.ts
@@ -87,9 +87,12 @@ export function createFileSystemRuleProvider(): RuleProvider {
                                     // Check if directory exists before trying to read it
                                     try {
                                         await vscode.workspace.fs.stat(searchPath)
-                                    } catch {
-                                        // .sourcegraph directory doesn't exist, return empty array without error
-                                        return []
+                                    } catch (error) {
+                                        if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+                                            // .sourcegraph directory doesn't exist, return empty array without error
+                                            return []
+                                        }
+                                        throw error // Rethrow other errors
                                     }
 
                                     const entries = await vscode.workspace.fs.readDirectory(searchPath)


### PR DESCRIPTION
This commit prevents the addition of duplicate `.sourcegraph` paths when generating rule search paths. This avoids scenarios where the same `.sourcegraph` directory is added multiple times to the search path which would result in a console error since you are not supposed to have .sourcegraph.sourcegraph paths.

The fix involves checking if the current path already ends with `.sourcegraph` before adding it to the search paths. A new test case is added to ensure that duplicate paths are not generated. 

Additionally, a check is added to ensure that the directory exists before attempting to read it. If the directory does not exist, an empty array is returned without error.

UPDATE:
- Also restricted rules from running in untrusted workspaces

## Test plan
- create a .sourcegraph/test.rule.md within a folder that is the the workspace root
- check that the rule is properly loaded and you don't get any console errors regarding `"Error: ENOENT: no such file or directory, scandir`
- Check that rules load on trusted workspaces after this commit https://github.com/sourcegraph/cody/pull/7805/commits/467c6f77cf4b88363d348670479cea1c7063b6f9
per this commit https://github.com/sourcegraph/cody/pull/7805#discussion_r2077684798