### PR TITLE
feat(chat): add copy message button to copy message output

### DIFF
--- a/vscode/test/e2e/chat-messages.test.ts
+++ b/vscode/test/e2e/chat-messages.test.ts
@@ -30,10 +30,9 @@ test('chat assistant response code buttons', async ({ page, nap, sidebar }, test
     await expect(assistantRow).toContainText('Hello! Here is a code snippet:')
     await expect(assistantRow).toContainText('def fib(n):')
 
-    const copyButton = assistantRow.getByRole('button', { name: 'Copy' })
+    const copyButton = assistantRow.getByTitle('Copy Code')
     const smartApplyButton = assistantRow.getByRole('button', { name: 'Apply' })
     const actionsDropdown = assistantRow.getByRole('button', { name: 'More Actions' })
-
     expect(await copyButton.count()).toBe(1)
     await expect(copyButton).toBeVisible()
     await expect(smartApplyButton).toBeVisible()

--- a/vscode/webviews/chat/ChatMessageContent/EditButtons.tsx
+++ b/vscode/webviews/chat/ChatMessageContent/EditButtons.tsx
@@ -514,18 +514,7 @@ export function createCopyButton(
     onCopy: CodeBlockActionsProps['copyButtonOnSubmit'],
     options?: ChatButtonOptions & { icon?: JSX.Element }
 ): React.ReactElement {
-    return (
-        <CopyButton
-            text={preText}
-            onCopy={onCopy}
-            label={options?.label}
-            pressedLabel={options?.pressedLabel}
-            className={options?.className}
-            showLabel={options?.showLabel}
-            title={options?.title}
-            icon={options?.icon}
-        />
-    )
+    return <CopyButton text={preText} onCopy={onCopy} {...options} />
 }
 
 function createApplyButton(

--- a/vscode/webviews/chat/ChatMessageContent/EditButtons.tsx
+++ b/vscode/webviews/chat/ChatMessageContent/EditButtons.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx'
 import type React from 'react'
-import { memo, useCallback, useState } from 'react'
+import { useCallback, useState } from 'react'
 import { CodyTaskState } from '../../../src/non-stop/state'
 import {
     CheckCodeBlockIcon,
@@ -17,21 +17,52 @@ import {
 import type { CodeBlockActionsProps } from './ChatMessageContent'
 import styles from './ChatMessageContent.module.css'
 
-/**
- * Higher-order component to create button components with shared behavior
- * @param defaultProps Default props for the component
- * @param renderFn Function to render the component
- * @returns A memoized React component
- */
-export function createButtonComponent<P>(
-    defaultProps: Partial<P>,
-    renderFn: (props: P) => React.ReactElement
-) {
-    return memo((props: P) => renderFn({ ...defaultProps, ...props } as P))
+
+export const CopyButton = ({
+    text,
+    onCopy,
+    className = styles.button,
+    showLabel = true,
+    title = 'Copy Code',
+    label = 'Copy',
+    icon: customIcon,
+}: {
+    text: string
+    onCopy?: CodeBlockActionsProps['copyButtonOnSubmit']
+    className?: string
+    showLabel?: boolean
+    title?: string
+    label?: string
+    icon?: JSX.Element
+}): React.ReactElement => {
+    const [currentLabel, setCurrentLabel] = useState(label)
+    const [icon, setIcon] = useState<JSX.Element>(customIcon || CopyCodeBlockIcon)
+
+    const handleClick = useCallback(() => {
+        setIcon(CheckCodeBlockIcon)
+        setCurrentLabel('Copied')
+        navigator.clipboard.writeText(text).catch(error => console.error(error))
+        if (onCopy) {
+            onCopy(text, 'Button')
+        }
+        // Log for `chat assistant response code buttons` e2e test.
+        console.log('Code: Copy to Clipboard', text)
+
+        setTimeout(() => {
+            setIcon(customIcon || CopyCodeBlockIcon)
+            setCurrentLabel(label)
+        }, 5000)
+    }, [onCopy, text, label, customIcon])
+
+    return (
+        <button type="button" className={className} onClick={handleClick} title={title}>
+            <div className={styles.iconContainer}>{icon}</div>
+            {showLabel && <span className="tw-hidden xs:tw-block">{currentLabel}</span>}
+        </button>
+    )
 }
 
 export type CreateEditButtonsParams = {
-    // TODO: Remove this when there is a portable abstraction for popup menus, instead of special-casing VSCode.
     isVSCode: boolean
     preText: string
     copyButtonOnSubmit?: CodeBlockActionsProps['copyButtonOnSubmit']
@@ -56,7 +87,7 @@ export function createEditButtons(params: CreateEditButtonsParams): React.ReactE
           )
 }
 
-export function createEditButtonsBasic(
+function createEditButtonsBasic(
     preText: string,
     copyButtonOnSubmit?: CodeBlockActionsProps['copyButtonOnSubmit'],
     insertButtonOnSubmit?: CodeBlockActionsProps['insertButtonOnSubmit'],
@@ -66,36 +97,13 @@ export function createEditButtonsBasic(
         return <div />
     }
 
-    const codeBlockActions = {
-        copy: copyButtonOnSubmit,
-        insert: insertButtonOnSubmit,
-    }
-
     return (
         <>
-            {createCodeBlockActionButton(
-                'copy',
-                preText,
-                'Copy Code',
-                CopyCodeBlockIcon,
-                codeBlockActions
-            )}
+            <CopyButton text={preText} onCopy={copyButtonOnSubmit} />
             {insertButtonOnSubmit && (
                 <div className={styles.insertButtons}>
-                    {createCodeBlockActionButton(
-                        'insert',
-                        preText,
-                        'Insert Code at Cursor',
-                        InsertCodeBlockIcon,
-                        codeBlockActions
-                    )}
-                    {createCodeBlockActionButton(
-                        'new',
-                        preText,
-                        'Save Code to New File...',
-                        SaveCodeBlockIcon,
-                        codeBlockActions
-                    )}
+                    {createInsertButton(preText, insertButtonOnSubmit)}
+                    {createSaveButton(preText, insertButtonOnSubmit)}
                 </div>
             )}
             {onExecute && createExecuteButton(onExecute)}
@@ -135,7 +143,7 @@ export function createAdditionsDeletions({
     )
 }
 
-export function createEditButtonsSmartApply({
+function createEditButtonsSmartApply({
     preText,
     isVSCode,
     copyButtonOnSubmit,
@@ -146,11 +154,11 @@ export function createEditButtonsSmartApply({
     smartApplyId,
     smartApplyState,
 }: CreateEditButtonsParams): React.ReactElement {
-    const copyButton = createCopyButton(preText, copyButtonOnSubmit ?? (() => {}))
-
     return (
         <>
-            {smartApplyState !== CodyTaskState.Applied && copyButtonOnSubmit && copyButton}
+            {smartApplyState !== CodyTaskState.Applied && copyButtonOnSubmit && (
+                <CopyButton text={preText} onCopy={copyButtonOnSubmit} />
+            )}
             {smartApply && smartApplyId && smartApplyState === CodyTaskState.Applied && (
                 <>
                     {createAcceptButton(smartApplyId, smartApply)}
@@ -179,381 +187,119 @@ export function createEditButtonsSmartApply({
 
 function createInsertButton(
     preText: string,
-    insertButtonOnSubmit?: CodeBlockActionsProps['insertButtonOnSubmit'],
-    icon?: JSX.Element
+    insertButtonOnSubmit?: CodeBlockActionsProps['insertButtonOnSubmit']
 ): React.ReactElement {
-    return <InsertButton text={preText} onInsert={insertButtonOnSubmit} icon={icon} />
+    return (
+        <button
+            type="button"
+            title="Insert Code at Cursor"
+            className={styles.button}
+            onClick={() => insertButtonOnSubmit?.(preText, false)}
+        >
+            <div className={styles.iconContainer}>{InsertCodeBlockIcon}</div>
+            <span className="tw-hidden xs:tw-block">Insert</span>
+        </button>
+    )
 }
 
 function createSaveButton(
     preText: string,
-    insertButtonOnSubmit?: CodeBlockActionsProps['insertButtonOnSubmit'],
-    icon?: JSX.Element
+    insertButtonOnSubmit?: CodeBlockActionsProps['insertButtonOnSubmit']
 ): React.ReactElement {
-    return <SaveButton text={preText} onInsert={insertButtonOnSubmit} icon={icon} />
-}
-
-/**
- * Creates a button to perform an action on a code block.
- * @returns The button element.
- */
-function createCodeBlockActionButton(
-    type: 'copy' | 'insert' | 'new',
-    text: string,
-    title: string,
-    defaultIcon: JSX.Element,
-    codeBlockActions: {
-        copy: CodeBlockActionsProps['copyButtonOnSubmit']
-        insert?: CodeBlockActionsProps['insertButtonOnSubmit']
-    }
-): React.ReactElement {
-    // Use the appropriate component based on the type
-    switch (type) {
-        case 'copy':
-            return (
-                <CopyButton
-                    text={text}
-                    onCopy={codeBlockActions.copy}
-                    title={title}
-                    icon={defaultIcon}
-                />
-            )
-        case 'insert':
-            return (
-                <InsertButton
-                    text={text}
-                    onInsert={codeBlockActions.insert}
-                    title={title}
-                    icon={defaultIcon}
-                />
-            )
-        case 'new':
-            return (
-                <SaveButton
-                    text={text}
-                    onInsert={codeBlockActions.insert}
-                    title={title}
-                    icon={defaultIcon}
-                />
-            )
-        default:
-            return <></>
-    }
-}
-
-// Base interface for all button components
-export interface BaseButtonProps {
-    className?: string
-    showLabel?: boolean
-    title?: string
-    label?: string
-    icon?: JSX.Element
-    disabled?: boolean
-}
-
-// Generic action button props with specific action type
-export interface ActionButtonProps<T extends unknown[] = []> extends BaseButtonProps {
-    onClick: (...args: T) => void
-    icon: JSX.Element
-}
-
-// Add ChatButtonOptions interface to define the options for the button
-export interface ChatButtonOptions extends BaseButtonProps {
-    pressedLabel?: string
-}
-
-// Extended options for CopyButton using the generic pattern
-export interface CopyButtonProps extends Omit<ChatButtonOptions, 'icon'> {
-    text: string
-    onCopy?: CodeBlockActionsProps['copyButtonOnSubmit']
-    icon?: JSX.Element
-}
-
-export const ActionButton: React.FC<ActionButtonProps<[]>> = memo(
-    ({ onClick, title, icon, label, showLabel = true, className = styles.button, disabled = false }) => {
-        return (
-            <button
-                type="button"
-                className={className}
-                onClick={onClick}
-                title={title}
-                disabled={disabled}
-            >
-                <div className={styles.iconContainer}>{icon}</div>
-                {showLabel && label && <span className="tw-hidden xs:tw-block">{label}</span>}
-            </button>
-        )
-    }
-)
-
-// Create CopyButton using the HOC
-export const CopyButton = createButtonComponent<CopyButtonProps>(
-    {
-        label: 'Copy',
-        pressedLabel: 'Copied',
-        className: styles.button,
-        showLabel: true,
-        title: 'Copy Code',
-    },
-    ({ text, onCopy, label, pressedLabel, className, showLabel, title, icon: customIcon }) => {
-        const [currentLabel, setCurrentLabel] = useState(label)
-        const [icon, setIcon] = useState<JSX.Element>(customIcon || CopyCodeBlockIcon)
-
-        const handleClick = useCallback(() => {
-            setIcon(CheckCodeBlockIcon)
-            setCurrentLabel(pressedLabel)
-            navigator.clipboard.writeText(text).catch(error => console.error(error))
-            if (onCopy) {
-                onCopy(text, 'Button')
-            }
-            // Log for `chat assistant response code buttons` e2e test.
-            console.log('Code: Copy to Clipboard', text)
-
-            setTimeout(() => {
-                setIcon(customIcon || CopyCodeBlockIcon)
-                setCurrentLabel(label)
-            }, 5000)
-        }, [onCopy, text, label, pressedLabel, customIcon])
-
-        return (
-            <ActionButton
-                onClick={handleClick}
-                title={title}
-                icon={icon}
-                label={currentLabel}
-                showLabel={showLabel}
-                className={className}
-            />
-        )
-    }
-)
-
-// Insert button component
-export interface InsertButtonProps extends Omit<BaseButtonProps, 'icon'> {
-    text: string
-    onInsert?: CodeBlockActionsProps['insertButtonOnSubmit']
-    icon?: JSX.Element
-}
-
-// Create InsertButton using the HOC
-export const InsertButton = createButtonComponent<InsertButtonProps>(
-    {
-        title: 'Insert Code at Cursor',
-        label: 'Insert',
-    },
-    ({ text, onInsert, title, icon: customIcon }) => {
-        const handleClick = useCallback(() => {
-            if (onInsert) {
-                onInsert(text, false)
-            }
-        }, [onInsert, text])
-
-        return (
-            <ActionButton
-                onClick={handleClick}
-                title={title}
-                icon={customIcon || InsertCodeBlockIcon}
-                label="Insert"
-            />
-        )
-    }
-)
-
-// Save button component
-export interface SaveButtonProps extends Omit<BaseButtonProps, 'icon'> {
-    text: string
-    onInsert?: CodeBlockActionsProps['insertButtonOnSubmit']
-    icon?: JSX.Element
-}
-
-// Create SaveButton using the HOC
-export const SaveButton = createButtonComponent<SaveButtonProps>(
-    {
-        title: 'Save Code to New File...',
-        label: 'Save',
-    },
-    ({ text, onInsert, title, icon: customIcon }) => {
-        const handleClick = useCallback(() => {
-            if (onInsert) {
-                onInsert(text, true)
-            }
-        }, [onInsert, text])
-
-        return (
-            <ActionButton
-                onClick={handleClick}
-                title={title}
-                icon={customIcon || SaveCodeBlockIcon}
-                label="Save"
-            />
-        )
-    }
-)
-
-// Apply button component
-export interface ApplyButtonProps extends Omit<ActionButtonProps<[]>, 'onClick' | 'icon'> {
-    onApply: () => void
-    state?: CodyTaskState
-}
-
-// Create ApplyButton using the HOC
-export const ApplyButton = createButtonComponent<ApplyButtonProps>(
-    {
-        title: 'Apply in Editor',
-    },
-    ({ onApply, state }) => {
-        let disabled = false
-        let label = 'Apply'
-        let icon = SparkleIcon
-        let onClick: () => void = onApply
-
-        switch (state) {
-            case 'Working':
-                disabled = true
-                label = 'Applying'
-                icon = SyncSpinIcon
-                onClick = () => {} // Use empty function instead of undefined
-                break
-            case 'Applied':
-            case 'Finished':
-                label = 'Reapply'
-                icon = RefreshIcon
-                break
-        }
-
-        return (
-            <ActionButton
-                onClick={onClick || (() => {})}
-                title="Apply in Editor"
-                icon={icon}
-                label={label}
-                disabled={disabled}
-            />
-        )
-    }
-)
-
-// Execute button component
-export interface ExecuteButtonProps extends Omit<ActionButtonProps<[]>, 'onClick' | 'icon'> {
-    onExecute: () => void
-}
-
-// Create ExecuteButton using the HOC
-export const ExecuteButton = createButtonComponent<ExecuteButtonProps>(
-    {
-        title: 'Execute in Terminal',
-        label: 'Execute',
-    },
-    ({ onExecute }) => {
-        return (
-            <ActionButton
-                onClick={onExecute}
-                title="Execute in Terminal"
-                icon={
-                    <div
-                        className={clsx(
-                            styles.iconContainer,
-                            'tw-align-middle codicon codicon-terminal'
-                        )}
-                    />
-                }
-                label="Execute"
-            />
-        )
-    }
-)
-
-// Accept button component
-export interface AcceptButtonProps extends Omit<ActionButtonProps<[]>, 'onClick' | 'icon'> {
-    id: string
-    smartApply: CodeBlockActionsProps['smartApply']
-}
-
-// Create AcceptButton using the HOC
-export const AcceptButton = createButtonComponent<AcceptButtonProps>(
-    {
-        title: 'Accept Changes',
-        label: 'Accept',
-    },
-    ({ id, smartApply }) => {
-        const handleClick = useCallback(() => {
-            smartApply.onAccept(id)
-        }, [id, smartApply])
-
-        return (
-            <ActionButton onClick={handleClick} title="Accept Changes" icon={TickIcon} label="Accept" />
-        )
-    }
-)
-
-// Reject button component
-export interface RejectButtonProps extends Omit<ActionButtonProps<[]>, 'onClick' | 'icon'> {
-    id: string
-    smartApply: CodeBlockActionsProps['smartApply']
-}
-
-// Create RejectButton using the HOC
-export const RejectButton = createButtonComponent<RejectButtonProps>(
-    {
-        title: 'Reject Changes',
-        label: 'Reject',
-    },
-    ({ id, smartApply }) => {
-        const handleClick = useCallback(() => {
-            smartApply.onReject(id)
-        }, [id, smartApply])
-
-        return (
-            <ActionButton onClick={handleClick} title="Reject Changes" icon={CloseIcon} label="Reject" />
-        )
-    }
-)
-
-export function createCopyButton(
-    preText: string,
-    onCopy: CodeBlockActionsProps['copyButtonOnSubmit'],
-    options?: ChatButtonOptions & { icon?: JSX.Element }
-): React.ReactElement {
-    return <CopyButton text={preText} onCopy={onCopy} {...options} />
+    return (
+        <button
+            type="button"
+            title="Save Code to New File..."
+            className={styles.button}
+            onClick={() => insertButtonOnSubmit?.(preText, true)}
+        >
+            <div className={styles.iconContainer}>{SaveCodeBlockIcon}</div>
+            <span className="tw-hidden xs:tw-block">Save</span>
+        </button>
+    )
 }
 
 function createApplyButton(
     onSmartApply: () => void,
     smartApplyState?: CodyTaskState
 ): React.ReactElement {
-    return <ApplyButton onApply={onSmartApply} state={smartApplyState} />
+    let disabled = false
+    let label = 'Apply'
+    let icon = SparkleIcon
+    let onClick: () => void = onSmartApply
+
+    switch (smartApplyState) {
+        case 'Working':
+            disabled = true
+            label = 'Applying'
+            icon = SyncSpinIcon
+            onClick = () => {}
+            break
+        case 'Applied':
+        case 'Finished':
+            label = 'Reapply'
+            icon = RefreshIcon
+            break
+    }
+
+    return (
+        <button
+            type="button"
+            className={styles.button}
+            onClick={onClick}
+            title="Apply in Editor"
+            disabled={disabled}
+        >
+            <div className={styles.iconContainer}>{icon}</div>
+            <span className="tw-hidden xs:tw-block">{label}</span>
+        </button>
+    )
 }
 
-/**
- * Creates a button that sends the command to the editor terminal on click.
- *
- * @param onExecute - the callback to run when the button is clicked.
- */
-export function createExecuteButton(onExecute: () => void): React.ReactElement {
-    return <ExecuteButton onExecute={onExecute} />
+function createExecuteButton(onExecute: () => void): React.ReactElement {
+    return (
+        <button type="button" className={styles.button} onClick={onExecute} title="Execute in Terminal">
+            <div className={clsx(styles.iconContainer, 'tw-align-middle codicon codicon-terminal')} />
+            <span className="tw-hidden xs:tw-block">Execute</span>
+        </button>
+    )
 }
 
 function createAcceptButton(
     id: string,
     smartApply: CodeBlockActionsProps['smartApply']
 ): React.ReactElement {
-    return <AcceptButton id={id} smartApply={smartApply} />
+    return (
+        <button
+            type="button"
+            className={styles.button}
+            onClick={() => smartApply.onAccept(id)}
+            title="Accept"
+        >
+            <div className={styles.iconContainer}>{TickIcon}</div>
+            <span className="tw-hidden xs:tw-block">Accept</span>
+        </button>
+    )
 }
 
 function createRejectButton(
     id: string,
     smartApply: CodeBlockActionsProps['smartApply']
 ): React.ReactElement {
-    return <RejectButton id={id} smartApply={smartApply} />
+    return (
+        <button
+            type="button"
+            className={styles.button}
+            onClick={() => smartApply.onReject(id)}
+            title="Reject"
+        >
+            <div className={styles.iconContainer}>{CloseIcon}</div>
+            <span className="tw-hidden xs:tw-block">Reject</span>
+        </button>
+    )
 }
 
-// VS Code provides additional support for rendering an OS-native dropdown, that has some
-// additional benefits. Mainly that it can "break out" of the webview.
-// TODO: A dropdown would be useful for other clients too, we should consider building
-// a generic web-based dropdown component that can be used by any client.
 function createActionsDropdown(preText: string): React.ReactElement {
-    // Attach `data-vscode-context`, this is also provided when the commands are executed,
-    // so serves as a way for us to pass `vscodeContext.text` to each relevant command
     const vscodeContext = {
         webviewSection: 'codeblock-actions',
         preventDefaultContextMenuItems: true,

--- a/vscode/webviews/chat/ChatMessageContent/EditButtons.tsx
+++ b/vscode/webviews/chat/ChatMessageContent/EditButtons.tsx
@@ -17,7 +17,6 @@ import {
 import type { CodeBlockActionsProps } from './ChatMessageContent'
 import styles from './ChatMessageContent.module.css'
 
-
 export const CopyButton = ({
     text,
     onCopy,

--- a/vscode/webviews/chat/ChatMessageContent/EditButtons.tsx
+++ b/vscode/webviews/chat/ChatMessageContent/EditButtons.tsx
@@ -62,6 +62,7 @@ export const CopyButton = ({
 }
 
 export type CreateEditButtonsParams = {
+    // TODO: Remove this when there is a portable abstraction for popup menus, instead of special-casing VSCode.
     isVSCode: boolean
     preText: string
     copyButtonOnSubmit?: CodeBlockActionsProps['copyButtonOnSubmit']
@@ -298,7 +299,13 @@ function createRejectButton(
     )
 }
 
+// VS Code provides additional support for rendering an OS-native dropdown, that has some
+// additional benefits. Mainly that it can "break out" of the webview.
+// TODO: A dropdown would be useful for other clients too, we should consider building
+// a generic web-based dropdown component that can be used by any client.
 function createActionsDropdown(preText: string): React.ReactElement {
+    // Attach `data-vscode-context`, this is also provided when the commands are executed,
+    // so serves as a way for us to pass `vscodeContext.text` to each relevant command
     const vscodeContext = {
         webviewSection: 'codeblock-actions',
         preventDefaultContextMenuItems: true,

--- a/vscode/webviews/chat/cells/messageCell/assistant/AssistantMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/assistant/AssistantMessageCell.tsx
@@ -174,7 +174,7 @@ export const AssistantMessageCell: FunctionComponent<{
                                         onCopy={copyButtonOnSubmit}
                                         showLabel={false}
                                         className={'tw-transition tw-opacity-65 hover:tw-opacity-100'}
-                                        title="Copy message"
+                                        title="Copy Message"
                                     />
                                 </>
                             )}

--- a/vscode/webviews/chat/cells/messageCell/assistant/AssistantMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/assistant/AssistantMessageCell.tsx
@@ -23,6 +23,9 @@ import {
     ChatMessageContent,
     type CodeBlockActionsProps,
 } from '../../../ChatMessageContent/ChatMessageContent'
+
+import styles from '../../../ChatMessageContent/ChatMessageContent.module.css'
+import { CopyButton } from '../../../ChatMessageContent/EditButtons'
 import { ErrorItem, RequestErrorItem } from '../../../ErrorItem'
 import { type Interaction, editHumanMessage } from '../../../Transcript'
 import { BaseMessageCell } from '../BaseMessageCell'
@@ -79,7 +82,6 @@ export const AssistantMessageCell: FunctionComponent<{
             () => (message.text ? reformatBotMessageForChat(message.text).toString() : ''),
             [message.text]
         )
-
         const chatModel = useChatModelByID(message.model, models)
         const isAborted = isAbortErrorOrSocketHangUp(message.error)
 
@@ -154,13 +156,30 @@ export const AssistantMessageCell: FunctionComponent<{
                     </>
                 }
                 footer={
-                    isAborted ? (
-                        <div className="tw-py-3 tw-flex tw-flex-col tw-gap-2">
-                            <div className="tw-text-sm tw-text-muted-foreground tw-mt-4">
-                                Output stream stopped
+                    <div className="tw-py-3 tw-flex tw-flex-col tw-gap-2">
+                        {isAborted && (
+                            <div className="tw-py-3 tw-flex tw-flex-col tw-gap-2">
+                                <div className="tw-text-sm tw-text-muted-foreground tw-mt-4">
+                                    Output stream stopped
+                                </div>
                             </div>
+                        )}
+                        <div
+                            className={`tw-flex tw-items-center tw-justify-end tw-gap-4  ${styles.buttonsContainer}`}
+                        >
+                            {!isLoading && (!message.error || isAborted) && !isSearchIntent && (
+                                <>
+                                    <CopyButton
+                                        text={message.text?.toString() || ''}
+                                        onCopy={copyButtonOnSubmit}
+                                        showLabel={false}
+                                        className={'tw-transition tw-opacity-65 hover:tw-opacity-100'}
+                                        title="Copy message"
+                                    />
+                                </>
+                            )}
                         </div>
-                    ) : null
+                    </div>
                 }
             />
         )


### PR DESCRIPTION
Fixes CODY-4963 introduce Copy message button to allow copying of message output useful
especially on Cody web.

![image](https://github.com/user-attachments/assets/8cd4a1ed-b0ce-49cc-a20a-b3a48aaeb670)

The copy button at the bottom corner of the AssistantMessageCell and it works both in VSCode and in
Cody web.

Most copilots have such a copy button to get the output which is super useful especially if you want
to past the reply somewhere else for further processing.

## Test plan
- Verify that the copy button is displayed correctly in the assistant message cell.
- Verify that clicking the copy button copies the assistant's message to the clipboard.
- Verify that the copy button is not displayed when the message is loading, has errors (unless aborted), or is a search intent.