### PR TITLE
fix(auto-edit): Respect the prefix suffix token limit for ipynb notebooks

### DIFF
--- a/vscode/src/autoedits/analytics-logger/analytics-logger.test.ts
+++ b/vscode/src/autoedits/analytics-logger/analytics-logger.test.ts
@@ -55,6 +55,8 @@ describe('AutoeditAnalyticsLogger', () => {
             maxSuffixLinesInArea: 2,
             codeToRewritePrefixLines: 1,
             codeToRewriteSuffixLines: 1,
+            prefixTokens: 100,
+            suffixTokens: 100,
         },
     })
 

--- a/vscode/src/autoedits/hot-streak/get-chunk.test.ts
+++ b/vscode/src/autoedits/hot-streak/get-chunk.test.ts
@@ -78,6 +78,8 @@ function createTestParams({
         maxSuffixLinesInArea: 2,
         codeToRewritePrefixLines: 1,
         codeToRewriteSuffixLines: 30,
+        prefixTokens: 100,
+        suffixTokens: 100,
     })
 
     return {

--- a/vscode/src/autoedits/hot-streak/index.test.ts
+++ b/vscode/src/autoedits/hot-streak/index.test.ts
@@ -112,6 +112,8 @@ function createHotStreakParams(
         maxSuffixLinesInArea: 2,
         codeToRewritePrefixLines: 1,
         codeToRewriteSuffixLines: 30,
+        prefixTokens: 100,
+        suffixTokens: 100,
     })
     const docContext = getCurrentDocContext({
         document,

--- a/vscode/src/autoedits/prompt/prompt-utils.test.ts
+++ b/vscode/src/autoedits/prompt/prompt-utils.test.ts
@@ -87,6 +87,8 @@ describe('getCurrentFilePromptComponents', () => {
                 maxSuffixLinesInArea: 1,
                 codeToRewritePrefixLines: 1,
                 codeToRewriteSuffixLines: 1,
+                prefixTokens: 100,
+                suffixTokens: 100,
             },
         })
 
@@ -154,6 +156,8 @@ describe('getCurrentFilePromptComponents', () => {
                 maxSuffixLinesInArea: 1,
                 codeToRewritePrefixLines: 1,
                 codeToRewriteSuffixLines: 1,
+                prefixTokens: 100,
+                suffixTokens: 100,
             },
         })
 
@@ -230,6 +234,8 @@ describe('getCodeToReplaceData', () => {
                 maxSuffixLinesInArea: 1,
                 codeToRewritePrefixLines: 1,
                 codeToRewriteSuffixLines: 1,
+                prefixTokens: 100,
+                suffixTokens: 100,
             },
         }
 
@@ -290,6 +296,8 @@ describe('getCodeToReplaceData', () => {
                 maxSuffixLinesInArea: 1,
                 codeToRewritePrefixLines: 1,
                 codeToRewriteSuffixLines: 1,
+                prefixTokens: 100,
+                suffixTokens: 100,
             },
         }
 
@@ -324,6 +332,8 @@ describe('getCodeToReplaceData', () => {
                 maxSuffixLinesInArea: 1,
                 codeToRewritePrefixLines: 1,
                 codeToRewriteSuffixLines: 1,
+                prefixTokens: 100,
+                suffixTokens: 100,
             },
         }
 
@@ -360,6 +370,8 @@ describe('getCodeToReplaceData', () => {
                 maxSuffixLinesInArea: 1,
                 codeToRewritePrefixLines: 1,
                 codeToRewriteSuffixLines: 1,
+                prefixTokens: 100,
+                suffixTokens: 100,
             },
         }
 
@@ -392,6 +404,8 @@ describe('getCodeToReplaceData', () => {
                 maxSuffixLinesInArea: 1,
                 codeToRewritePrefixLines: 1,
                 codeToRewriteSuffixLines: 1,
+                prefixTokens: 100,
+                suffixTokens: 100,
             },
         }
 
@@ -425,6 +439,8 @@ describe('getCodeToReplaceData', () => {
                 maxSuffixLinesInArea: 1,
                 codeToRewritePrefixLines: 1,
                 codeToRewriteSuffixLines: 1,
+                prefixTokens: 100,
+                suffixTokens: 100,
             },
         }
 
@@ -458,6 +474,8 @@ describe('getCodeToReplaceData', () => {
                 maxSuffixLinesInArea: 1,
                 codeToRewritePrefixLines: 1,
                 codeToRewriteSuffixLines: 1,
+                prefixTokens: 100,
+                suffixTokens: 100,
             },
         }
 
@@ -493,6 +511,8 @@ describe('getCodeToReplaceData', () => {
                 maxSuffixLinesInArea: 1,
                 codeToRewritePrefixLines: 3, // Increased prefix lines
                 codeToRewriteSuffixLines: 1,
+                prefixTokens: 100,
+                suffixTokens: 100,
             },
         }
 
@@ -531,6 +551,8 @@ describe('getCodeToReplaceData', () => {
                 maxSuffixLinesInArea: 1,
                 codeToRewritePrefixLines: 1,
                 codeToRewriteSuffixLines: 1,
+                prefixTokens: 100,
+                suffixTokens: 100,
             },
         }
 
@@ -570,6 +592,8 @@ describe('getCodeToReplaceData', () => {
                 maxSuffixLinesInArea: 2,
                 codeToRewritePrefixLines: 2,
                 codeToRewriteSuffixLines: 2,
+                prefixTokens: 100,
+                suffixTokens: 100,
             },
         }
 
@@ -604,6 +628,8 @@ describe('getCodeToReplaceData', () => {
                 maxSuffixLinesInArea: 5, // Larger than file
                 codeToRewritePrefixLines: 3, // Larger than file
                 codeToRewriteSuffixLines: 3, // Larger than file
+                prefixTokens: 100,
+                suffixTokens: 100,
             },
         }
 

--- a/vscode/src/autoedits/prompt/prompt-utils.ts
+++ b/vscode/src/autoedits/prompt/prompt-utils.ts
@@ -17,6 +17,10 @@ import {
     getNotebookCells,
 } from '../../completions/context/retrievers/recent-user-actions/notebook-utils'
 import { RetrieverIdentifier } from '../../completions/context/utils'
+import {
+    getPrefixWithCharLimit,
+    getSuffixWithCharLimit,
+} from '../../completions/get-current-doc-context'
 import { autoeditsOutputChannelLogger } from '../output-channel-logger'
 import { clip, splitLinesKeepEnds } from '../utils'
 
@@ -34,6 +38,8 @@ export interface CurrentFilePromptOptions {
         | 'codeToRewriteSuffixLines'
         | 'maxPrefixLinesInArea'
         | 'maxSuffixLinesInArea'
+        | 'prefixTokens'
+        | 'suffixTokens'
     >
 }
 
@@ -167,6 +173,8 @@ export function getCodeToReplaceData(options: CurrentFilePromptOptions): CodeToR
             codeToRewriteSuffixLines,
             maxPrefixLinesInArea,
             maxSuffixLinesInArea,
+            prefixTokens,
+            suffixTokens,
         },
     } = options
 
@@ -217,10 +225,15 @@ export function getCodeToReplaceData(options: CurrentFilePromptOptions): CodeToR
         suffixAfterArea: new vscode.Range(positionAtLineEnd(areaEnd), positionAtLineEnd(maxLine)),
     }
 
+    const remainingPrefixChars = Math.max(0, tokensToChars(prefixTokens) - docContext.prefix.length)
+    const remainingSuffixChars = Math.max(0, tokensToChars(suffixTokens) - docContext.suffix.length)
+
     const { prefixBeforeArea, suffixAfterArea } = getUpdatedCurrentFilePrefixAndSuffixOutsideArea(
         document,
         ranges.prefixBeforeArea,
-        ranges.suffixAfterArea
+        ranges.suffixAfterArea,
+        remainingPrefixChars,
+        remainingSuffixChars
     )
 
     return {
@@ -246,13 +259,15 @@ export function getCurrentFilePath(document: vscode.TextDocument): PromptString 
 function getUpdatedCurrentFilePrefixAndSuffixOutsideArea(
     document: vscode.TextDocument,
     rangePrefixBeforeArea: vscode.Range,
-    rangeSuffixAfterArea: vscode.Range
+    rangeSuffixAfterArea: vscode.Range,
+    remainingPrefixChars: number,
+    remainingSuffixChars: number
 ): {
     prefixBeforeArea: PromptString
     suffixAfterArea: PromptString
 } {
     const { prefixBeforeAreaForNotebook, suffixAfterAreaForNotebook } =
-        getPrefixAndSuffixForAreaForNotebook(document)
+        getPrefixAndSuffixForAreaForNotebook(document, remainingPrefixChars, remainingSuffixChars)
 
     const prefixBeforeArea = ps`${prefixBeforeAreaForNotebook}${PromptString.fromDocumentText(
         document,
@@ -270,7 +285,11 @@ function getUpdatedCurrentFilePrefixAndSuffixOutsideArea(
     }
 }
 
-function getPrefixAndSuffixForAreaForNotebook(document: vscode.TextDocument): {
+function getPrefixAndSuffixForAreaForNotebook(
+    document: vscode.TextDocument,
+    remainingPrefixChars: number,
+    remainingSuffixChars: number
+): {
     prefixBeforeAreaForNotebook: PromptString
     suffixAfterAreaForNotebook: PromptString
 } {
@@ -287,9 +306,19 @@ function getPrefixAndSuffixForAreaForNotebook(document: vscode.TextDocument): {
     const cellsAfterCurrentCell = notebookCells.slice(currentCellIndex + 1)
     const beforeContent = getTextFromNotebookCells(activeNotebook, cellsBeforeCurrentCell)
     const afterContent = getTextFromNotebookCells(activeNotebook, cellsAfterCurrentCell)
+
+    const beforeContentList = beforeContent.split('\n')
+    const afterContentList = afterContent.split('\n')
+
     return {
-        prefixBeforeAreaForNotebook: ps`${beforeContent}\n`,
-        suffixAfterAreaForNotebook: ps`\n${afterContent}`,
+        prefixBeforeAreaForNotebook: ps`${getPrefixWithCharLimit(
+            beforeContentList,
+            remainingPrefixChars
+        )}\n`,
+        suffixAfterAreaForNotebook: ps`\n${getSuffixWithCharLimit(
+            afterContentList,
+            remainingSuffixChars
+        )}`,
     }
 }
 

--- a/vscode/src/autoedits/prompt/test-helper.ts
+++ b/vscode/src/autoedits/prompt/test-helper.ts
@@ -11,6 +11,8 @@ interface CodeToReplaceTestOptions {
     maxSuffixLinesInArea: number
     codeToRewritePrefixLines: number
     codeToRewriteSuffixLines: number
+    prefixTokens: number
+    suffixTokens: number
 }
 
 export function createCodeToReplaceDataForTest(
@@ -48,6 +50,8 @@ export function getCodeToReplaceForRenderer(
             maxSuffixLinesInArea: 2,
             codeToRewritePrefixLines: 1,
             codeToRewriteSuffixLines: 1,
+            prefixTokens: 100,
+            suffixTokens: 100,
         },
         ...values
     )

--- a/vscode/src/autoedits/request-manager.test.ts
+++ b/vscode/src/autoedits/request-manager.test.ts
@@ -421,6 +421,8 @@ function createRequestParams(
         maxSuffixLinesInArea: 2,
         codeToRewritePrefixLines: 1,
         codeToRewriteSuffixLines: 1,
+        prefixTokens: 100,
+        suffixTokens: 100,
     })
 
     return {

--- a/vscode/src/autoedits/shrink-prediction.test.ts
+++ b/vscode/src/autoedits/shrink-prediction.test.ts
@@ -241,6 +241,8 @@ function getCodeToReplaceForShrinkPrediction(
             maxSuffixLinesInArea: 5,
             codeToRewritePrefixLines: 1,
             codeToRewriteSuffixLines: 2,
+            prefixTokens: 100,
+            suffixTokens: 100,
         },
         ...values
     )

--- a/vscode/src/completions/get-current-doc-context.ts
+++ b/vscode/src/completions/get-current-doc-context.ts
@@ -6,7 +6,9 @@ import {
     type DocumentContext,
     type DocumentDependentContext,
     type LinesContext,
+    PromptString,
     getEditorInsertSpaces,
+    ps,
 } from '@sourcegraph/cody-shared'
 import { detectMultiline } from './detect-multiline'
 import {
@@ -115,9 +117,18 @@ function getPrefix(params: GetPrefixParams): string {
     return prefixLines.join('\n')
 }
 
-export function getPrefixWithCharLimit(prefixLines: string[], maxPrefixLength: number): string {
+// Type guard to check if the array is PromptString[]
+function isPromptStringArray(arr: (string | PromptString)[]): arr is PromptString[] {
+    return arr.length > 0 && arr[0] instanceof PromptString
+}
+
+export function getPrefixWithCharLimit<T extends string | PromptString>(
+    prefixLines: T[],
+    maxPrefixLength: number
+): T {
     let total = 0
     let startLine = prefixLines.length
+
     for (let i = prefixLines.length - 1; i >= 0; i--) {
         if (total + prefixLines[i].length > maxPrefixLength) {
             break
@@ -125,10 +136,17 @@ export function getPrefixWithCharLimit(prefixLines: string[], maxPrefixLength: n
         startLine = i
         total += prefixLines[i].length
     }
-    return prefixLines.slice(startLine).join('\n')
+    const relevantLines = prefixLines.slice(startLine)
+    if (isPromptStringArray(prefixLines)) {
+        return PromptString.join(relevantLines as PromptString[], ps`\n`) as T
+    }
+    return relevantLines.join('\n') as T
 }
 
-export function getSuffixWithCharLimit(suffixLines: string[], maxSuffixLength: number): string {
+export function getSuffixWithCharLimit<T extends string | PromptString>(
+    suffixLines: T[],
+    maxSuffixLength: number
+): T {
     let totalSuffix = 0
     let endLine = 0
     for (let i = 0; i < suffixLines.length; i++) {
@@ -138,7 +156,11 @@ export function getSuffixWithCharLimit(suffixLines: string[], maxSuffixLength: n
         endLine = i + 1
         totalSuffix += suffixLines[i].length
     }
-    return suffixLines.slice(0, endLine).join('\n')
+    const relevantLines = suffixLines.slice(0, endLine)
+    if (isPromptStringArray(suffixLines)) {
+        return PromptString.join(relevantLines as PromptString[], ps`\n`) as T
+    }
+    return relevantLines.join('\n') as T
 }
 
 interface GetDerivedDocContextParams {


### PR DESCRIPTION
- The current logic in `ipynb` notebooks was not respecting the token limits. All the prefix and suffix were used from the other cells.
- The PR fixes that by only taking the lines with remaining tokens for notebooks. 

## Test plan
Updated unit tests
