### PR TITLE
fix(autoedit): Use correct `position` for hot streak chunks

### DIFF
--- a/vscode/src/autoedits/hot-streak/index.ts
+++ b/vscode/src/autoedits/hot-streak/index.ts
@@ -96,12 +96,19 @@ export async function* processHotStreakResponses({
                 continue
             }
 
+            // TODO: Right now we always use the provided `position` in which the auto-edit was triggered from.
+            // This works great for the first chunk, but we should try to match the position of the users' cursor
+            // on the assumption that they have accepted the previous chunk (if present). For example, if the previous
+            // chunk was an inline completion, the cursor is moved to the end of the completion range when accepted.
+            // If we matched this new position, it would mean it would be possible to chain inline completions.
+            const hotStreakPosition = position
+
             // The hot streak prediction excludes part of the prefix. This means that it fundamentally relies
             // on the prefix existing in the document to be a valid suggestion. We need to update the docContext
             // to reflect this.
             const updatedDocContext = getCurrentDocContext({
                 document,
-                position,
+                position: hotStreakPosition,
                 maxPrefixLength: docContext.maxPrefixLength,
                 maxSuffixLength: docContext.maxSuffixLength,
             })
@@ -110,7 +117,7 @@ export async function* processHotStreakResponses({
             const adjustedCodeToReplace = getCodeToReplaceData({
                 docContext: updatedDocContext,
                 document,
-                position,
+                position: hotStreakPosition,
                 tokenBudget: {
                     ...autoeditsProviderConfig.tokenLimit,
                     codeToRewriteSuffixLines: Math.max(

--- a/vscode/src/autoedits/hot-streak/index.ts
+++ b/vscode/src/autoedits/hot-streak/index.ts
@@ -101,20 +101,22 @@ export async function* processHotStreakResponses({
             // to reflect this.
             const updatedDocContext = getCurrentDocContext({
                 document,
-                position: predictionChunk.range.start,
+                position,
                 maxPrefixLength: docContext.maxPrefixLength,
                 maxSuffixLength: docContext.maxSuffixLength,
             })
 
+            const lengthOfChunk = predictionChunk.range.end.line - predictionChunk.range.start.line - 1
             const adjustedCodeToReplace = getCodeToReplaceData({
                 docContext: updatedDocContext,
                 document,
-                position: predictionChunk.range.start,
+                position,
                 tokenBudget: {
                     ...autoeditsProviderConfig.tokenLimit,
-                    codeToRewritePrefixLines: 0,
-                    codeToRewriteSuffixLines:
-                        predictionChunk.range.end.line - predictionChunk.range.start.line - 1,
+                    codeToRewriteSuffixLines: Math.max(
+                        lengthOfChunk - autoeditsProviderConfig.tokenLimit.codeToRewritePrefixLines,
+                        0
+                    ),
                 },
             })
 


### PR DESCRIPTION
## Description

Previously we would always force the `position` to be at the start of the hot-streak chunk, and then adjust the prefix to be empty to account for it. That has some issues:
1. We incorrectly make inline completions for the first chunk, as the `position` is different than the users actual cursor position. This means sometimes we _think_ we have shown a completion but it was actually hidden by VS Code. We should have shown an edit in this case instead.
2. We need to also adjust other values like `maxPrefixLength` and `maxSuffixLength` when we reduce the prefix. This can get complex and it's easier just to maintain the original values (although we may want this logic in the future.)

closes https://github.com/sourcegraph/cody/pull/7811

## Test plan

Manual testing on real examples and mocked examples in cody-chat-eval

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
