### PR TITLE
Do not hide stable releases by default

### DIFF
--- a/jetbrains/build.gradle.kts
+++ b/jetbrains/build.gradle.kts
@@ -630,13 +630,6 @@ tasks {
     // https://plugins.jetbrains.com/docs/intellij/deployment.html#specifying-a-release-channel
     val channel = properties("pluginVersion")!!.split('-').getOrElse(1) { "default" }
     channels.set(listOf(channel))
-
-    if (channel == "default") {
-      // The published version WILL NOT be available right after the JetBrains approval.
-      // Instead, we control if and when we want to make it available.
-      // (Note: there is ~48h waiting time for JetBrains approval).
-      hidden.set(true)
-    }
   }
 
   test { dependsOn(project.tasks.getByPath("buildCody")) }


### PR DESCRIPTION
Some time ago we decided to hide stable releases by default. That was caused by the fact we were focused on limiting the time from the moment releases to the moment of the JB approval (having QA in between). Presently, we are more careful about stable releases. We can be more confident about stables. We can make it public by default.

## Test plan
- n/a

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
