### PR TITLE
fix(autoedit): Ensure next cursor decoration is cleared when file changed

### DIFF
--- a/vscode/src/autoedits/renderer/next-cursor-manager.ts
+++ b/vscode/src/autoedits/renderer/next-cursor-manager.ts
@@ -148,14 +148,17 @@ export class NextCursorManager implements vscode.Disposable {
             return
         }
 
-        const editor = this.getEditorForUri(this.activeCursorSuggestion.uri)
+        const cursorSuggestionUri = this.activeCursorSuggestion.uri
+
+        // Reset cursor suggestion state so the Tab command will be used for accepting any auto-edit suggestions
+        this.activeCursorSuggestion = null
+        void vscode.commands.executeCommand('setContext', 'cody.nextCursorSuggested', false)
+    
+        // Attempt to clear the suggestion decoration if it hasn't already been cleared
+        const editor = this.getEditorForUri(cursorSuggestionUri)
         if (!editor) {
             return
         }
-
-        this.activeCursorSuggestion = null
-        // Reset VS Code state so the Tab command will be used for accepting any auto-edit suggestions
-        void vscode.commands.executeCommand('setContext', 'cody.nextCursorSuggested', false)
         editor.setDecorations(NEXT_CURSOR_DECORATION.decoration, [])
     }
 

--- a/vscode/src/autoedits/renderer/next-cursor-manager.ts
+++ b/vscode/src/autoedits/renderer/next-cursor-manager.ts
@@ -153,7 +153,7 @@ export class NextCursorManager implements vscode.Disposable {
         // Reset cursor suggestion state so the Tab command will be used for accepting any auto-edit suggestions
         this.activeCursorSuggestion = null
         void vscode.commands.executeCommand('setContext', 'cody.nextCursorSuggested', false)
-    
+
         // Attempt to clear the suggestion decoration if it hasn't already been cleared
         const editor = this.getEditorForUri(cursorSuggestionUri)
         if (!editor) {


### PR DESCRIPTION
## Description

Fixes an issue where:
1. Next cursor prediction is shown
2. User changes file
3. Cursor prediction state isn't cleared, so the Tab command doesn't work to accept the next suggestion

## Test plan

Manually in cody-chat-eval by triggering a cursor prediciton and changing file

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
