### PR TITLE
fix(autoedit): Use correct decorator when hiding suggestion

### DIFF
--- a/vscode/src/autoedits/renderer/manager.ts
+++ b/vscode/src/autoedits/renderer/manager.ts
@@ -401,7 +401,7 @@ export class AutoEditsDefaultRendererManager
         this.testing_completionSuggestedPromise = undefined
 
         if (decorator) {
-            await this.handleDidHideSuggestion(this.decorator)
+            await this.handleDidHideSuggestion(decorator)
         }
 
         if (activeRequest) {


### PR DESCRIPTION
## Description

Long shot... but noticed this isn't quite correct when we attempt to hide the suggestion.

Related to: https://linear.app/sourcegraph/issue/CODY-5747/floating-window-in-auto-edit-is-unresponsive-and-stuck

For a proper fix we should rework our decoration logic. Right now we create the decorator for every new request (and dispose of the old decorations). Instead we should create the decorator once, and just clear decorations from different editors when needed

 Consolidating the decoration logic [here](https://github.com/sourcegraph/cody/pull/7815) and then it should be easy to do this. 

## Test plan

Wasn't able to test this because the issue with stuck decorations is really intermittent.

Did manual testing to check this caused no new regressions

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
