### PR TITLE
Add Cody freeze reporting to Sentry

### DIFF
--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/error/CodyPerformanceListener.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/error/CodyPerformanceListener.kt
@@ -1,0 +1,17 @@
+package com.sourcegraph.cody.error
+
+import com.intellij.diagnostic.PerformanceListener
+import com.intellij.diagnostic.ThreadDump
+import java.nio.file.Path
+
+class CodyPerformanceListener : PerformanceListener {
+  override fun dumpedThreads(toFile: Path, dump: ThreadDump) {
+    val isCodyStacktrace =
+        dump.edtStackTrace?.any { it.className.startsWith("com.sourcegraph") } != null
+
+    if (isCodyStacktrace) {
+      val throwable = Throwable("IDE UI freeze detected").apply { stackTrace = dump.edtStackTrace }
+      SentryService.getInstance().report(throwable)
+    }
+  }
+}

--- a/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -67,6 +67,8 @@
         <postStartupActivity
                 implementation="com.sourcegraph.cody.initialization.PostStartupActivity"/>
 
+        <idePerformanceListener implementation="com.sourcegraph.cody.error.CodyPerformanceListener"/>
+
         <!-- Cody -->
         <toolWindow
                 id="Cody"


### PR DESCRIPTION
## Changes

This PR hooks into existing IntelliJ freeze monitoring and if hang is caused by Cody it reports it to our Sentry service.

## Test plan

N/A, but I created artifical hang and verified it is reported in Sentry:

![image](https://github.com/user-attachments/assets/2862e9aa-d57a-4a7b-bfe5-e3ba045b31f3)
