### PR TITLE
feat(autoedit): Add render output / hot streak information to debug panel

### DIFF
--- a/vscode/src/autoedits/debug-panel/autoedit-data-sdk.ts
+++ b/vscode/src/autoedits/debug-panel/autoedit-data-sdk.ts
@@ -22,6 +22,7 @@ export const extractAutoeditData = (entry: AutoeditRequestDebugState) => {
     const modelResponse = getModelResponse(entry)
     const context = getContext(entry)
     const renderOutput = getRenderOutput(entry)
+    const hotStreakId = getHotStreakId(entry)
 
     return {
         phase,
@@ -41,6 +42,7 @@ export const extractAutoeditData = (entry: AutoeditRequestDebugState) => {
         modelResponse,
         context,
         renderOutput,
+        hotStreakId,
     }
 }
 
@@ -321,6 +323,16 @@ export const getHotStreakChunks = (
 }
 
 /**
+ * Get the hot streak ID if available
+ */
+export const getHotStreakId = (entry: AutoeditRequestDebugState): string | null => {
+    if ('hotStreakId' in entry.state && entry.state.hotStreakId) {
+        return entry.state.hotStreakId
+    }
+    return null
+}
+
+/**
  * Get the full response body from the model if available
  */
 export const getFullResponseBody = (entry: AutoeditRequestDebugState): any | null => {
@@ -376,4 +388,5 @@ export const AutoeditDataSDK = {
     getFullResponseBody,
     getModelResponse,
     getHotStreakChunks,
+    getHotStreakId,
 }

--- a/vscode/src/autoedits/debug-panel/autoedit-data-sdk.ts
+++ b/vscode/src/autoedits/debug-panel/autoedit-data-sdk.ts
@@ -1,5 +1,6 @@
 import type { InlineCompletionItemRetrievedContext } from '../../completions/analytics-logger'
 import type { ModelResponse, PartialModelResponse, SuccessModelResponse } from '../adapters/base'
+import type { AutoEditRenderOutput } from '../renderer/render-output'
 import { getDetailedTimingInfo } from './autoedit-latency-utils'
 import type { AutoeditRequestDebugState } from './debug-store'
 
@@ -346,7 +347,7 @@ export const getModelResponse = (entry: AutoeditRequestDebugState): ModelRespons
 /**
  * Get the render output if available
  */
-export const getRenderOutput = (entry: AutoeditRequestDebugState): any | null => {
+export const getRenderOutput = (entry: AutoeditRequestDebugState): AutoEditRenderOutput | null => {
     if ('renderOutput' in entry.state) {
         return entry.state.renderOutput
     }

--- a/vscode/src/autoedits/debug-panel/autoedit-data-sdk.ts
+++ b/vscode/src/autoedits/debug-panel/autoedit-data-sdk.ts
@@ -20,6 +20,7 @@ export const extractAutoeditData = (entry: AutoeditRequestDebugState) => {
     const position = getPosition(entry)
     const modelResponse = getModelResponse(entry)
     const context = getContext(entry)
+    const renderOutput = getRenderOutput(entry)
 
     return {
         phase,
@@ -38,6 +39,7 @@ export const extractAutoeditData = (entry: AutoeditRequestDebugState) => {
         position,
         modelResponse,
         context,
+        renderOutput,
     }
 }
 
@@ -337,6 +339,16 @@ export const getFullResponseBody = (entry: AutoeditRequestDebugState): any | nul
 export const getModelResponse = (entry: AutoeditRequestDebugState): ModelResponse | null => {
     if ('modelResponse' in entry.state) {
         return entry.state.modelResponse
+    }
+    return null
+}
+
+/**
+ * Get the render output if available
+ */
+export const getRenderOutput = (entry: AutoeditRequestDebugState): any | null => {
+    if ('renderOutput' in entry.state) {
+        return entry.state.renderOutput
     }
     return null
 }

--- a/vscode/webviews/autoedit-debug/components/AutoeditDetailView.tsx
+++ b/vscode/webviews/autoedit-debug/components/AutoeditDetailView.tsx
@@ -14,6 +14,7 @@ import { CodeToRewriteDataSection } from '../sections/CodeToRewriteDataSection'
 import { ContextInfoSection } from '../sections/ContextInfoSection'
 import { NetworkRequestSection, NetworkResponseSection } from '../sections/NetworkRequestSection'
 import { PromptSection } from '../sections/PromptSection'
+import { RenderOutputSection } from '../sections/RenderOutputSection'
 import { TimelineSection } from '../sections/TimelineSection'
 import { FeedbackSection } from './FeedbackSection'
 import { SideBySideDiff } from './side-by-side-diff/SideBySideDiff'
@@ -153,6 +154,9 @@ export const AutoeditDetailView: FC<{
                         <TabButton value="context" activeTab={activeTab}>
                             Context
                         </TabButton>
+                        <TabButton value="render-output" activeTab={activeTab}>
+                            Render Output
+                        </TabButton>
                         <TabButton value="network-request" activeTab={activeTab}>
                             Request
                         </TabButton>
@@ -179,6 +183,10 @@ export const AutoeditDetailView: FC<{
 
                     <TabsPrimitive.Content value="context" className="tw-space-y-8">
                         <ContextInfoSection entry={entry} />
+                    </TabsPrimitive.Content>
+
+                    <TabsPrimitive.Content value="render-output" className="tw-space-y-8">
+                        <RenderOutputSection entry={entry} />
                     </TabsPrimitive.Content>
 
                     <TabsPrimitive.Content value="network-request" className="tw-space-y-8">

--- a/vscode/webviews/autoedit-debug/components/AutoeditListItem.tsx
+++ b/vscode/webviews/autoedit-debug/components/AutoeditListItem.tsx
@@ -67,12 +67,18 @@ const FileInfo: FC<{
     positionInfo: string
     inferenceTime?: string | null
     envoyUpstreamServiceTime?: string | null
-}> = ({ fileName, positionInfo, inferenceTime, envoyUpstreamServiceTime }) => (
+    renderOutputType?: string | null
+}> = ({ fileName, positionInfo, inferenceTime, envoyUpstreamServiceTime, renderOutputType }) => (
     <div className="tw-flex tw-items-center tw-justify-between tw-w-full tw-text-sm tw-text-gray-700 tw-dark:tw-text-gray-300">
-        <div className="tw-flex tw-items-center">
+        <div className="tw-flex tw-items-center tw-gap-2">
             <span className="tw-font-medium">
                 {`${fileName} ${positionInfo ? `:${positionInfo}` : ''}`}
             </span>
+            {renderOutputType && (
+                <span className="tw-text-xs tw-px-2 tw-py-0.5 tw-bg-gray-100 tw-dark:tw-bg-gray-700 tw-rounded">
+                    {renderOutputType}
+                </span>
+            )}
         </div>
         {inferenceTime && (
             <div className="tw-flex tw-items-center tw-gap-2">
@@ -126,6 +132,7 @@ export const AutoeditListItem: FC<AutoeditEntryItemProps> = ({ entry, isSelected
         positionInfo,
         discardReason,
         timing,
+        renderOutput,
     } = AutoeditDataSDK.extractAutoeditData(entry)
 
     // State management
@@ -189,6 +196,7 @@ export const AutoeditListItem: FC<AutoeditEntryItemProps> = ({ entry, isSelected
                         positionInfo={positionInfo}
                         inferenceTime={timing.inferenceTime}
                         envoyUpstreamServiceTime={timing.envoyUpstreamServiceTime}
+                        renderOutputType={renderOutput?.type}
                     />
 
                     {/* Code preview */}

--- a/vscode/webviews/autoedit-debug/sections/RenderOutputSection.tsx
+++ b/vscode/webviews/autoedit-debug/sections/RenderOutputSection.tsx
@@ -1,0 +1,85 @@
+import type { FC } from 'react'
+import { useCallback, useState } from 'react'
+
+import { AutoeditDataSDK } from '../../../src/autoedits/debug-panel/autoedit-data-sdk'
+import type { AutoeditRequestDebugState } from '../../../src/autoedits/debug-panel/debug-store'
+
+export const RenderOutputSection: FC<{
+    entry: AutoeditRequestDebugState
+}> = ({ entry }) => {
+    const { renderOutput } = AutoeditDataSDK.extractAutoeditData(entry)
+    const [expanded, setExpanded] = useState(false)
+
+    const toggleExpand = useCallback(() => {
+        setExpanded(!expanded)
+    }, [expanded])
+
+    if (!renderOutput) {
+        return (
+            <div className="tw-p-4 tw-bg-gray-50 tw-dark:tw-bg-gray-800/50 tw-rounded-md">
+                <p className="tw-text-sm tw-text-gray-500 tw-dark:tw-text-gray-400">
+                    No render output information available
+                </p>
+            </div>
+        )
+    }
+
+    // Handle image render output type specially
+    const isImageType = renderOutput.type === 'image' && 'imageData' in renderOutput
+
+    return (
+        <div className="tw-p-4 tw-bg-gray-50 tw-dark:tw-bg-gray-800/50 tw-rounded-md">
+            <div className="tw-flex tw-justify-between tw-items-center tw-mb-4">
+                <h3 className="tw-text-md tw-font-medium">Render Output</h3>
+                <button
+                    type="button"
+                    className="tw-text-sm tw-text-blue-500 hover:tw-underline"
+                    onClick={toggleExpand}
+                >
+                    {expanded ? 'Collapse' : 'Expand Raw Data'}
+                </button>
+            </div>
+
+            <div className="tw-flex tw-gap-2 tw-mb-4">
+                <span className="tw-text-sm tw-font-medium tw-text-gray-600 tw-dark:tw-text-gray-300">
+                    Type:
+                </span>
+                <span className="tw-px-2 tw-py-0.5 tw-bg-blue-100 tw-dark:tw-bg-blue-900/30 tw-rounded tw-text-sm tw-text-blue-800 tw-dark:tw-text-blue-300">
+                    {renderOutput.type}
+                </span>
+            </div>
+
+            {/* Render the actual image for image type render outputs */}
+            {isImageType && (
+                <div className="tw-mt-4 tw-mb-4">
+                    <h4 className="tw-text-sm tw-font-medium tw-mb-2">Preview:</h4>
+                    <div className="tw-border tw-border-gray-200 tw-dark:tw-border-gray-700 tw-rounded tw-p-2 tw-bg-white tw-dark:tw-bg-gray-900">
+                        <img
+                            src={renderOutput.imageData.light}
+                            className="tw-block tw-dark:tw-hidden tw-max-w-full tw-h-auto tw-rounded tw-shadow-sm"
+                            alt="Light theme suggestion preview"
+                        />
+                        <img
+                            src={renderOutput.imageData.dark}
+                            className="tw-hidden tw-dark:tw-block tw-max-w-full tw-h-auto tw-rounded tw-shadow-sm"
+                            alt="Dark theme suggestion preview"
+                        />
+                    </div>
+                    <div className="tw-mt-2 tw-text-xs tw-text-gray-500 tw-dark:tw-text-gray-400">
+                        Position: Line {renderOutput.imageData.position.line + 1}, Column{' '}
+                        {renderOutput.imageData.position.column + 1}
+                    </div>
+                </div>
+            )}
+
+            {expanded && (
+                <div className="tw-mt-2">
+                    <h4 className="tw-text-sm tw-font-medium tw-mb-2">Raw Data:</h4>
+                    <pre className="tw-bg-gray-100 tw-dark:tw-bg-gray-800/80 tw-p-2 tw-rounded tw-text-xs tw-overflow-auto tw-max-h-[400px]">
+                        {JSON.stringify(renderOutput, null, 2)}
+                    </pre>
+                </div>
+            )}
+        </div>
+    )
+}


### PR DESCRIPTION
## Description

Adds render output info to the debug UI




**Render output tab**

<img width="563" alt="image" src="https://github.com/user-attachments/assets/daf7698f-9417-4a21-8d5b-ce7043ddcb11" />


**Hot streak info + render output type on main item list**

<img width="344" alt="image" src="https://github.com/user-attachments/assets/7d38ef20-cee5-4070-a29e-ecd3ac94f7dc" />


## Test plan

Manual checking on debug panel

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
