### PR TITLE
Fix freeze reporter logic

### DIFF
--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/error/CodyPerformanceListener.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/error/CodyPerformanceListener.kt
@@ -7,7 +7,7 @@ import java.nio.file.Path
 class CodyPerformanceListener : PerformanceListener {
   override fun dumpedThreads(toFile: Path, dump: ThreadDump) {
     val isCodyStacktrace =
-        dump.edtStackTrace?.any { it.className.startsWith("com.sourcegraph") } != null
+        dump.edtStackTrace?.any { it.className.startsWith("com.sourcegraph") } == true
 
     if (isCodyStacktrace) {
       val throwable = Throwable("IDE UI freeze detected").apply { stackTrace = dump.edtStackTrace }


### PR DESCRIPTION
## Changes

I just noticed this after a merge.
`?.any { ... } != null` will always evaluate to `true` if `edtStackTrace` is not null.
Bad suggestion by Cody, which replaced `find` with `any`, but keep the orginal condition :) 

## Test plan

Verified manually with debugger.