### PR TITLE
feat(auto-edit): Update hot-streak config as per the latency analysis

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -69,7 +69,7 @@ export enum FeatureFlag {
     CodyAutoEditInlineRendering = 'cody-autoedit-inline-rendering',
 
     // Enables hot-streak for autoedit suggestions
-    CodyAutoEditHotStreak = 'cody-autoedit-hot-streak',
+    CodyAutoEditHotStreak = 'cody-autoedit-hot-streak-v1',
 
     // Enables gpt-4o-mini as a default Edit model
     CodyEditDefaultToGpt4oMini = 'cody-edit-default-to-gpt-4o-mini',

--- a/vscode/src/autoedits/adapters/fireworks.ts
+++ b/vscode/src/autoedits/adapters/fireworks.ts
@@ -82,8 +82,6 @@ export class FireworksAdapter implements AutoeditsModelAdapter {
                 type: 'content',
                 content: options.codeToRewrite,
             },
-            rewrite_speculation: true,
-            adaptive_speculation: true,
             user: options.userId || undefined,
         }
 

--- a/vscode/src/autoedits/autoedits-config.ts
+++ b/vscode/src/autoedits/autoedits-config.ts
@@ -28,7 +28,7 @@ export interface AutoeditsProviderConfig extends BaseAutoeditsProviderConfig {
     isMockResponseFromCurrentDocumentTemplateEnabled: boolean
 }
 
-const defaultTokenLimit = {
+export const defaultTokenLimit: AutoEditsTokenLimit = {
     prefixTokens: 500,
     suffixTokens: 500,
     maxPrefixLinesInArea: 11,
@@ -44,6 +44,19 @@ const defaultTokenLimit = {
     },
 } as const satisfies AutoEditsTokenLimit
 
+export const hotStreakTokenLimit: AutoEditsTokenLimit = {
+    ...defaultTokenLimit,
+    codeToRewritePrefixLines: 4,
+    codeToRewriteSuffixLines: 24,
+    contextSpecificTokenLimit: {
+        [RetrieverIdentifier.RecentEditsRetriever]: 1000,
+        [RetrieverIdentifier.JaccardSimilarityRetriever]: 0,
+        [RetrieverIdentifier.RecentCopyRetriever]: 0,
+        [RetrieverIdentifier.DiagnosticsRetriever]: 100,
+        [RetrieverIdentifier.RecentViewPortRetriever]: 500,
+    },
+} as const satisfies AutoEditsTokenLimit
+
 let hotStreakEnabled = false
 featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.CodyAutoEditHotStreak).subscribe(value => {
     hotStreakEnabled = value
@@ -51,44 +64,85 @@ featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.CodyAutoEditHotStreak).subs
 })
 
 /**
+ * Determines if hot streak mode should be enabled based on feature flag and settings.
+ */
+function isHotStreakEnabled(): boolean {
+    return hotStreakEnabled || isHotStreakEnabledInSettings()
+}
+
+/**
+ * Configuration models for different authentication states and modes.
+ */
+type ConfigModels = {
+    dotcom: string
+    sgInstance: string
+}
+
+/**
+ * Configuration options shared between different provider modes.
+ */
+interface ProviderModeConfig {
+    tokenLimit: AutoEditsTokenLimit
+    promptProvider: AutoEditsModelConfig['promptProvider']
+    models: ConfigModels
+}
+
+/**
+ * Configuration map for different provider modes.
+ */
+const providerModes: Record<'standard' | 'hotStreak', ProviderModeConfig> = {
+    standard: {
+        tokenLimit: defaultTokenLimit,
+        promptProvider: undefined,
+        models: {
+            dotcom: 'autoedits-deepseek-lite-default',
+            sgInstance: 'fireworks::v1::autoedits-deepseek-lite-default',
+        },
+    },
+    hotStreak: {
+        tokenLimit: hotStreakTokenLimit,
+        promptProvider: 'long-suggestion-prompt-provider',
+        models: {
+            dotcom: 'autoedits-long-suggestion-default',
+            sgInstance: 'fireworks::v1::autoedits-long-suggestion-default',
+        },
+    },
+}
+
+/**
+ * Provider configurations based on authentication state.
+ */
+const providerConfigs: Record<
+    'dotCom' | 'sgInstance',
+    Omit<BaseAutoeditsProviderConfig, 'model' | 'tokenLimit' | 'promptProvider'>
+> = {
+    dotCom: {
+        provider: 'cody-gateway',
+        url: 'https://cody-gateway.sourcegraph.com/v1/completions/fireworks',
+        isChatModel: false,
+        timeoutMs: 10_000,
+    },
+    sgInstance: {
+        provider: 'sourcegraph',
+        url: '',
+        isChatModel: false,
+        timeoutMs: 10_000,
+    },
+}
+
+/**
  * Retrieves the base configuration for the AutoEdits provider based on authentication status.
  */
 function getBaseProviderConfig(): BaseAutoeditsProviderConfig {
-    const shouldHotStreak = hotStreakEnabled || isHotStreakEnabledInSettings()
-    const tokenLimit = shouldHotStreak
-        ? // Hot-streak can handle much longer suffixes
-          { ...defaultTokenLimit, codeToRewriteSuffixLines: 30 }
-        : defaultTokenLimit
-    const promptProvider: AutoEditsModelConfig['promptProvider'] = shouldHotStreak
-        ? 'long-suggestion-prompt-provider'
-        : undefined
-
-    // Common configuration for both authentication states
-    const baseConfig = {
-        promptProvider,
-        tokenLimit,
-        isChatModel: false,
-        timeoutMs: 10_000,
-    } as const
-
-    if (isDotComAuthed()) {
-        return {
-            ...baseConfig,
-            provider: 'cody-gateway',
-            model: shouldHotStreak
-                ? 'autoedits-long-suggestion-default'
-                : 'autoedits-deepseek-lite-default',
-            url: 'https://cody-gateway.sourcegraph.com/v1/completions/fireworks',
-        }
-    }
+    const mode = isHotStreakEnabled() ? 'hotStreak' : 'standard'
+    const config = providerModes[mode]
+    const authConfig = isDotComAuthed() ? providerConfigs.dotCom : providerConfigs.sgInstance
 
     return {
-        ...baseConfig,
-        provider: 'sourcegraph',
-        model: shouldHotStreak
-            ? 'fireworks::v1::autoedits-long-suggestion-default'
-            : 'fireworks::v1::autoedits-deepseek-lite-default',
-        url: '',
+        ...authConfig,
+        promptProvider: config.promptProvider,
+        tokenLimit: config.tokenLimit,
+        model: isDotComAuthed() ? config.models.dotcom : config.models.sgInstance,
     }
 }
 


### PR DESCRIPTION
Update the `auto-edit` config for the hot-streak as per the latency evaluation.
Latency evaluation details can be found in the [slack thread](https://sourcegraph.slack.com/archives/C08GUBSHMKN/p1745943031411789).


## Test plan
CI

