### PR TITLE
fix(commit message): No error message in input box when there are no changes to commit

### DIFF
--- a/vscode/src/commands/context/git-api.test.ts
+++ b/vscode/src/commands/context/git-api.test.ts
@@ -63,15 +63,6 @@ describe('getContextFilesFromGitDiff', () => {
             title: 'git diff',
             uri: URI.parse('file:///path/to/file2.ts'),
             source: ContextItemSource.Terminal,
-            content:
-                "Here is the 'git diff' output:\n" +
-                '<output file="path/to/file2.ts">\n' +
-                'file2.ts\n' +
-                '--- a/file2.ts\n' +
-                '+++ b/file2.ts\n' +
-                '@@ -1,1 +1,2 @@\n' +
-                '+console.log("Unstaged change");\n' +
-                '</output>',
         })
     })
 
@@ -154,19 +145,6 @@ describe('getContextFilesFromGitDiff', () => {
             title: 'git diff --cached',
             uri: URI.parse('file:///path/to/deleted.file.txt'),
             source: ContextItemSource.Terminal,
-            content:
-                "Here is the 'git diff --cached' output:\n" +
-                '<output file="path/to/deleted.file.txt">\n' +
-                'path/to/deleted.file.txt\n' +
-                'deleted file mode 100644\n' +
-                'index 5b85839..0000000\n' +
-                '--- a/new.txt\n' +
-                '+++ /dev/null\n' +
-                '@@ -1,3 +0,0 @@\n' +
-                '-first line\n' +
-                '-line 2\n' +
-                '-another line 2\n' +
-                '</output>',
         })
     })
 })

--- a/vscode/src/commands/context/git-api.test.ts
+++ b/vscode/src/commands/context/git-api.test.ts
@@ -63,14 +63,15 @@ describe('getContextFilesFromGitDiff', () => {
             title: 'git diff',
             uri: URI.parse('file:///path/to/file2.ts'),
             source: ContextItemSource.Terminal,
-            content: "Here is the 'git diff' output:\n" +
-                        "<output file=\"path/to/file2.ts\">\n" +
-                        "file2.ts\n" +
-                        "--- a/file2.ts\n" +
-                        "+++ b/file2.ts\n" +
-                        "@@ -1,1 +1,2 @@\n" +
-                        "+console.log(\"Unstaged change\");\n" +
-                        "</output>",
+            content:
+                "Here is the 'git diff' output:\n" +
+                '<output file="path/to/file2.ts">\n' +
+                'file2.ts\n' +
+                '--- a/file2.ts\n' +
+                '+++ b/file2.ts\n' +
+                '@@ -1,1 +1,2 @@\n' +
+                '+console.log("Unstaged change");\n' +
+                '</output>',
         })
     })
 
@@ -136,14 +137,14 @@ describe('getContextFilesFromGitDiff', () => {
         diffWithHEAD.mockResolvedValue([])
         diff.mockResolvedValue(
             'diff --git a/path/to/deleted.file.txt b/path/to/deleted.file.txt\n' +
-            'deleted file mode 100644\n' +
-            'index 5b85839..0000000\n' +
-            '--- a/new.txt\n' +
-            '+++ /dev/null\n' +
-            '@@ -1,3 +0,0 @@\n' +
-            '-first line\n' +
-            '-line 2\n' +
-            '-another line 2'
+                'deleted file mode 100644\n' +
+                'index 5b85839..0000000\n' +
+                '--- a/new.txt\n' +
+                '+++ /dev/null\n' +
+                '@@ -1,3 +0,0 @@\n' +
+                '-first line\n' +
+                '-line 2\n' +
+                '-another line 2'
         )
 
         const result = await getContextFilesFromGitDiff(mockGitRepo)
@@ -153,18 +154,19 @@ describe('getContextFilesFromGitDiff', () => {
             title: 'git diff --cached',
             uri: URI.parse('file:///path/to/deleted.file.txt'),
             source: ContextItemSource.Terminal,
-            content: "Here is the 'git diff --cached' output:\n" +
-                        "<output file=\"path/to/deleted.file.txt\">\n" +
-                        "path/to/deleted.file.txt\n" +
-                        "deleted file mode 100644\n" +
-                        "index 5b85839..0000000\n" +
-                        "--- a/new.txt\n" +
-                        "+++ /dev/null\n" +
-                        "@@ -1,3 +0,0 @@\n" +
-                        "-first line\n" +
-                        "-line 2\n" +
-                        "-another line 2\n" +
-                        "</output>",
+            content:
+                "Here is the 'git diff --cached' output:\n" +
+                '<output file="path/to/deleted.file.txt">\n' +
+                'path/to/deleted.file.txt\n' +
+                'deleted file mode 100644\n' +
+                'index 5b85839..0000000\n' +
+                '--- a/new.txt\n' +
+                '+++ /dev/null\n' +
+                '@@ -1,3 +0,0 @@\n' +
+                '-first line\n' +
+                '-line 2\n' +
+                '-another line 2\n' +
+                '</output>',
         })
     })
 })

--- a/vscode/src/commands/context/git-api.test.ts
+++ b/vscode/src/commands/context/git-api.test.ts
@@ -2,14 +2,10 @@ import { ContextItemSource } from '@sourcegraph/cody-shared'
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest'
 import { URI } from 'vscode-uri'
 import type { Repository } from '../../repository/builtinGitExtension'
-import { doesFileExist } from '../utils/workspace-files'
 import { getContextFilesFromGitDiff } from './git-api'
 
 vi.mock('../repository')
 vi.mock('../utils')
-vi.mock('../utils/workspace-files', () => ({
-    doesFileExist: vi.fn(),
-}))
 
 describe('getContextFilesFromGitDiff', () => {
     const mockGitRepo = {
@@ -21,7 +17,6 @@ describe('getContextFilesFromGitDiff', () => {
     const diffIndexWithHEAD = mockGitRepo.diffIndexWithHEAD as Mock
     const diffWithHEAD = mockGitRepo.diffWithHEAD as Mock
     const diff = mockGitRepo.diff as Mock
-    const mockDoesFileExist = doesFileExist as Mock
 
     beforeEach(() => {
         vi.clearAllMocks()
@@ -37,8 +32,6 @@ describe('getContextFilesFromGitDiff', () => {
                 '@@ -1,1 +1,2 @@\n' +
                 '+console.log("Hello World");\n'
         )
-
-        mockDoesFileExist.mockResolvedValue(true)
 
         const result = await getContextFilesFromGitDiff(mockGitRepo)
 
@@ -62,8 +55,6 @@ describe('getContextFilesFromGitDiff', () => {
                 '+console.log("Unstaged change");\n'
         )
 
-        mockDoesFileExist.mockResolvedValue(true)
-
         const result = await getContextFilesFromGitDiff(mockGitRepo)
 
         expect(result).toHaveLength(1)
@@ -72,6 +63,14 @@ describe('getContextFilesFromGitDiff', () => {
             title: 'git diff',
             uri: URI.parse('file:///path/to/file2.ts'),
             source: ContextItemSource.Terminal,
+            content: "Here is the 'git diff' output:\n" +
+                        "<output file=\"path/to/file2.ts\">\n" +
+                        "file2.ts\n" +
+                        "--- a/file2.ts\n" +
+                        "+++ b/file2.ts\n" +
+                        "@@ -1,1 +1,2 @@\n" +
+                        "+console.log(\"Unstaged change\");\n" +
+                        "</output>",
         })
     })
 
@@ -102,24 +101,8 @@ describe('getContextFilesFromGitDiff', () => {
                 '+console.log("File 2");\n'
         )
 
-        mockDoesFileExist.mockResolvedValue(true)
         const result = await getContextFilesFromGitDiff(mockGitRepo)
         expect(result).toHaveLength(2)
-    })
-
-    it('should skip files that do not exist', async () => {
-        diffIndexWithHEAD.mockResolvedValue([{ uri: URI.parse('file:///path/to/nonexistent.ts') }])
-        diffWithHEAD.mockResolvedValue([])
-        diff.mockResolvedValue(
-            'diff --git a/nonexistent.ts b/nonexistent.ts\n' +
-                '--- a/nonexistent.ts\n' +
-                '+++ b/nonexistent.ts\n' +
-                '@@ -0,0 +1 @@\n' +
-                '+This file does not exist\n'
-        )
-
-        mockDoesFileExist.mockResolvedValue(false)
-        await expect(getContextFilesFromGitDiff(mockGitRepo)).rejects.toThrow('Failed to get git diff.')
     })
 
     it('should handle Windows OS paths', async () => {
@@ -138,7 +121,6 @@ describe('getContextFilesFromGitDiff', () => {
             displayPath: vi.fn().mockReturnValue('path\\to\\file3.ts'),
         }))
 
-        mockDoesFileExist.mockResolvedValue(true)
         const result = await getContextFilesFromGitDiff(mockGitRepo)
         expect(result).toHaveLength(1)
         expect(result[0]).toMatchObject({
@@ -146,6 +128,43 @@ describe('getContextFilesFromGitDiff', () => {
             title: 'git diff --cached',
             uri: URI.parse('file:///c:/path/to/file3.ts'),
             source: ContextItemSource.Terminal,
+        })
+    })
+
+    it('should handle deleted files', async () => {
+        diffIndexWithHEAD.mockResolvedValue([{ uri: URI.parse('file:///path/to/deleted.file.txt') }])
+        diffWithHEAD.mockResolvedValue([])
+        diff.mockResolvedValue(
+            'diff --git a/path/to/deleted.file.txt b/path/to/deleted.file.txt\n' +
+            'deleted file mode 100644\n' +
+            'index 5b85839..0000000\n' +
+            '--- a/new.txt\n' +
+            '+++ /dev/null\n' +
+            '@@ -1,3 +0,0 @@\n' +
+            '-first line\n' +
+            '-line 2\n' +
+            '-another line 2'
+        )
+
+        const result = await getContextFilesFromGitDiff(mockGitRepo)
+        expect(result).toHaveLength(1)
+        expect(result[0]).toMatchObject({
+            type: 'file',
+            title: 'git diff --cached',
+            uri: URI.parse('file:///path/to/deleted.file.txt'),
+            source: ContextItemSource.Terminal,
+            content: "Here is the 'git diff --cached' output:\n" +
+                        "<output file=\"path/to/deleted.file.txt\">\n" +
+                        "path/to/deleted.file.txt\n" +
+                        "deleted file mode 100644\n" +
+                        "index 5b85839..0000000\n" +
+                        "--- a/new.txt\n" +
+                        "+++ /dev/null\n" +
+                        "@@ -1,3 +0,0 @@\n" +
+                        "-first line\n" +
+                        "-line 2\n" +
+                        "-another line 2\n" +
+                        "</output>",
         })
     })
 })

--- a/vscode/src/commands/context/git-api.test.ts
+++ b/vscode/src/commands/context/git-api.test.ts
@@ -80,7 +80,7 @@ describe('getContextFilesFromGitDiff', () => {
         diffWithHEAD.mockResolvedValue([])
         diff.mockResolvedValue('')
 
-        await expect(getContextFilesFromGitDiff(mockGitRepo)).rejects.toThrow('Failed to get git diff.')
+        await expect(getContextFilesFromGitDiff(mockGitRepo)).rejects.toThrow('Empty git diff output.')
     })
 
     it('should handle multiple files in diffs', async () => {

--- a/vscode/src/commands/context/git-api.ts
+++ b/vscode/src/commands/context/git-api.ts
@@ -123,7 +123,10 @@ export async function getContextFilesFromGitDiff(gitRepo: Repository): Promise<C
  * @returns A promise that resolves to an array of ContextItem objects.
  * @throws If the git log is empty or if there is an error retrieving the git log.
  */
-export async function getContextFilesFromGitLog(gitRepo: Repository, maxEntries = 5): Promise<ContextItem[]> {
+export async function getContextFilesFromGitLog(
+    gitRepo: Repository,
+    maxEntries = 5
+): Promise<ContextItem[]> {
     const logs = await gitRepo.log({ maxEntries })
     if (!logs.length) {
         throw new Error('Empty git log output.')

--- a/vscode/src/commands/context/git-api.ts
+++ b/vscode/src/commands/context/git-api.ts
@@ -123,7 +123,7 @@ export async function getContextFilesFromGitDiff(gitRepo: Repository): Promise<C
  * @returns A promise that resolves to an array of ContextItem objects.
  * @throws If the git log is empty or if there is an error retrieving the git log.
  */
-async function getContextFilesFromGitLog(gitRepo: Repository, maxEntries = 5): Promise<ContextItem[]> {
+export async function getContextFilesFromGitLog(gitRepo: Repository, maxEntries = 5): Promise<ContextItem[]> {
     const logs = await gitRepo.log({ maxEntries })
     if (!logs.length) {
         throw new Error('Empty git log output.')
@@ -153,7 +153,7 @@ async function getContextFilesFromGitLog(gitRepo: Repository, maxEntries = 5): P
  * @param template - The git commit template.
  * @returns The context item containing the git commit template information.
  */
-async function getGitCommitTemplateContextFile(template: string): Promise<ContextItem> {
+export async function getGitCommitTemplateContextFile(template: string): Promise<ContextItem> {
     const content = `Here is my git commit template:\n\n${template}`
     return {
         type: 'file',

--- a/vscode/src/commands/context/git-api.ts
+++ b/vscode/src/commands/context/git-api.ts
@@ -20,20 +20,12 @@ export async function getContextFilesFromGitApi(
     gitRepo: Repository,
     template?: string
 ): Promise<ContextItem[]> {
-    const contextItems = []
-    try {
-        const diffContext = await getContextFilesFromGitDiff(gitRepo)
-        contextItems.push(...diffContext)
-    } catch (error) {
-        throw new Error("Unable to get context files from git diff", {cause: error})
-    }
-    try {
-        const logContext = await getContextFilesFromGitLog(gitRepo)
-        contextItems.push(...logContext)
-    } catch (error) {
-        throw new Error("Unable to get context files from git log", {cause: error})
-    }
+    const [diffContext, logContext] = await Promise.all([
+        getContextFilesFromGitDiff(gitRepo),
+        getContextFilesFromGitLog(gitRepo),
+    ])
 
+    const contextItems = [...diffContext, ...logContext]
     if (template) {
         contextItems.push(await getGitCommitTemplateContextFile(template))
     }
@@ -48,87 +40,79 @@ export async function getContextFilesFromGitApi(
  * @throws If the git diff output is empty or if there is an error retrieving the git diff.
  */
 export async function getContextFilesFromGitDiff(gitRepo: Repository): Promise<ContextItem[]> {
-    try {
-        // Get the list of files that currently have staged and unstaged changes.
-        const [stagedFiles, unstagedFiles] = await Promise.all([
-            gitRepo.diffIndexWithHEAD(),
-            gitRepo.diffWithHEAD(),
-        ])
+    // Get the list of files that currently have staged and unstaged changes.
+    const [stagedFiles, unstagedFiles] = await Promise.all([
+        gitRepo.diffIndexWithHEAD(),
+        gitRepo.diffWithHEAD(),
+    ])
 
-        // Get the diff output for staged changes if there is any,
-        // otherwise, get the diff output for unstaged changes.
-        const hasStagedChanges = Boolean(stagedFiles?.length)
-        const command = `git diff${hasStagedChanges ? ' --cached' : ''}`
+    // Get the diff output for staged changes if there is any,
+    // otherwise, get the diff output for unstaged changes.
+    const hasStagedChanges = Boolean(stagedFiles?.length)
+    const command = `git diff${hasStagedChanges ? ' --cached' : ''}`
 
-        // A list of file uris to use for comparison with the diff output.
-        const diffFiles = hasStagedChanges ? stagedFiles : unstagedFiles
+    // A list of file uris to use for comparison with the diff output.
+    const diffFiles = hasStagedChanges ? stagedFiles : unstagedFiles
 
-        // Split diff output by files: diff --git a/$FILE b/$FILE\n$DIFF
-        const diffOutput = await gitRepo?.diff(hasStagedChanges)
-        const diffOutputByFiles = diffOutput.split(/diff --git a\/.+? b\//).filter(Boolean)
+    // Split diff output by files: diff --git a/$FILE b/$FILE\n$DIFF
+    const diffOutput = await gitRepo?.diff(hasStagedChanges)
+    const diffOutputByFiles = diffOutput.split(/diff --git a\/.+? b\//).filter(Boolean)
 
-        // Compare the diff files to the diff output to ensure they match,
-        // if the numbers are different, we can't trust the diff output were split correctly.
-        if (diffOutputByFiles.length !== diffFiles.length) {
-            throw new Error('Discrepancy in diff output and diff files')
-        }
-
-        const diffs: ContextItem[] = []
-
-        for (const diffOutput of diffOutputByFiles) {
-            if (!diffOutput) {
-                continue // Skip this iteration if no file path is found
-            }
-
-            const diffPath = diffOutput.split('\n')[0]
-            if (!diffPath) {
-                continue
-            }
-
-            const normalizePath = (path: string) => path.replace(/\\/g, '/')
-
-            // Verify the file exists before adding it as context.
-            // We do this by checking the reverse path because of how nested workspaces might add unknown prefixes.
-            const normalizedDiffPath = normalizePath(diffPath) // Example: "vscode/test.txt" - the path from the workspace root
-            const matchingFile = diffFiles.find(file => {
-                // Example filePath: "/Users/yk/Desktop/cody/vscode/test.txt"
-                const filePath = normalizePath(file.uri.path)
-                return filePath.endsWith(normalizedDiffPath)
-            })
-
-            if (!matchingFile) {
-                continue
-            }
-
-            const content = diffTemplate
-                .replace('{command}', command)
-                .replace('<output>', `<output file="${displayPath(matchingFile.uri)}">`)
-                .replace('{output}', diffOutput.trim())
-
-            diffs.push({
-                type: 'file',
-                content,
-                title: command,
-                // Using the uri by file enables Cody Ignore checks during prompt-building step.
-                uri: matchingFile.uri,
-                source: ContextItemSource.Terminal,
-                size: await TokenCounterUtils.countTokens(content),
-            })
-        }
-
-        if (diffs.length === 0) {
-            throw new Error('Empty git diff output.')
-        }
-
-        // we sort by shortest diffs first so that we include as many changed files as possible
-        return diffs.sort((a, b) => a.size! - b.size!)
-    } catch (error) {
-        let errorMessage = "failed"
-        if (error instanceof Error && error.message) {
-            errorMessage += `: ${error.message}`
-        }
-        throw new Error('Failed to get git diff.', { cause: error })
+    // Compare the diff files to the diff output to ensure they match,
+    // if the numbers are different, we can't trust the diff output were split correctly.
+    if (diffOutputByFiles.length !== diffFiles.length) {
+        throw new Error('Discrepancy in diff output and diff files')
     }
+
+    const diffs: ContextItem[] = []
+
+    for (const diffOutput of diffOutputByFiles) {
+        if (!diffOutput) {
+            continue // Skip this iteration if no file path is found
+        }
+
+        const diffPath = diffOutput.split('\n')[0]
+        if (!diffPath) {
+            continue
+        }
+
+        const normalizePath = (path: string) => path.replace(/\\/g, '/')
+
+        // Verify the file exists before adding it as context.
+        // We do this by checking the reverse path because of how nested workspaces might add unknown prefixes.
+        const normalizedDiffPath = normalizePath(diffPath) // Example: "vscode/test.txt" - the path from the workspace root
+        const matchingFile = diffFiles.find(file => {
+            // Example filePath: "/Users/yk/Desktop/cody/vscode/test.txt"
+            const filePath = normalizePath(file.uri.path)
+            return filePath.endsWith(normalizedDiffPath)
+        })
+
+        if (!matchingFile) {
+            continue
+        }
+
+        const content = diffTemplate
+            .replace('{command}', command)
+            .replace('<output>', `<output file="${displayPath(matchingFile.uri)}">`)
+            .replace('{output}', diffOutput.trim())
+
+        diffs.push({
+            type: 'file',
+            content,
+            title: command,
+            // Using the uri by file enables Cody Ignore checks during prompt-building step.
+            uri: matchingFile.uri,
+            source: ContextItemSource.Terminal,
+            size: await TokenCounterUtils.countTokens(content),
+        })
+    }
+
+    if (diffs.length === 0) {
+        throw new Error('Empty git diff output.')
+    }
+
+    // we sort by shortest diffs first so that we include as many changed files as possible
+    return diffs.sort((a, b) => a.size! - b.size!)
 }
 
 /**

--- a/vscode/src/commands/scm/source-control.ts
+++ b/vscode/src/commands/scm/source-control.ts
@@ -20,7 +20,11 @@ import * as vscode from 'vscode'
 import { outputChannelLogger } from '../../output-channel-logger'
 import { PromptBuilder } from '../../prompt-builder'
 import type { API, GitExtension, InputBox, Repository } from '../../repository/builtinGitExtension'
-import { getContextFilesFromGitDiff, getContextFilesFromGitLog, getGitCommitTemplateContextFile } from '../context/git-api'
+import {
+    getContextFilesFromGitDiff,
+    getContextFilesFromGitLog,
+    getGitCommitTemplateContextFile,
+} from '../context/git-api'
 import { COMMIT_COMMAND_PROMPTS } from './prompts'
 
 export class CodySourceControl implements vscode.Disposable {
@@ -194,7 +198,7 @@ export class CodySourceControl implements vscode.Disposable {
 
             const diffContext = await getContextFilesFromGitDiff(repository)
 
-            const logContext = await getContextFilesFromGitLog(repository).catch((error) => {
+            const logContext = await getContextFilesFromGitLog(repository).catch(error => {
                 // we can generate a commit message without log context
                 // but in case the user wants to see what happened, record the error
                 outputChannelLogger.logError('getContextFilesFromGitLog', 'failed', error)
@@ -203,7 +207,7 @@ export class CodySourceControl implements vscode.Disposable {
 
             const context = [...diffContext, ...logContext]
 
-            if(commitTemplate) {
+            if (commitTemplate) {
                 context.push(await getGitCommitTemplateContextFile(commitTemplate))
             }
 

--- a/vscode/src/commands/scm/source-control.ts
+++ b/vscode/src/commands/scm/source-control.ts
@@ -17,11 +17,11 @@ import {
     telemetryRecorder,
 } from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
+import { outputChannelLogger } from '../../output-channel-logger'
 import { PromptBuilder } from '../../prompt-builder'
 import type { API, GitExtension, InputBox, Repository } from '../../repository/builtinGitExtension'
 import { getContextFilesFromGitApi } from '../context/git-api'
 import { COMMIT_COMMAND_PROMPTS } from './prompts'
-import { outputChannelLogger } from '../../output-channel-logger'
 
 export class CodySourceControl implements vscode.Disposable {
     private disposables: vscode.Disposable[] = []

--- a/vscode/src/commands/scm/source-control.ts
+++ b/vscode/src/commands/scm/source-control.ts
@@ -214,20 +214,20 @@ export class CodySourceControl implements vscode.Disposable {
             await streaming(stream, abortController, updateInputBox, progress)
 
             if (ignoredContext.length > 0) {
-                vscode.window.showInformationMessage(
-                    `Cody was forced to skip ${ignoredContext.length} ${pluralize(
+                const message = `Cody was forced to skip ${ignoredContext.length} ${pluralize(
                         'file',
                         ignoredContext.length,
                         'files'
                     )} when generating the commit message.`
-                )
+                outputChannelLogger.logError('Generate Commit Message', message)
+                vscode.window.showInformationMessage(message)
             }
         } catch (error) {
             this.statusUpdate()
             progress.report({ message: 'Error' })
             sourceControlInputbox.value = initialInputBoxValue // Revert to initial value on error
+            outputChannelLogger.logError('Generate Commit Message', 'failed', error)
             var errorMessage = "Could not generate a commit message"
-            outputChannelLogger.logError('getContextFileFromGitDiff', errorMessage, error)
             if (error instanceof Error && error.message) {
                 errorMessage += `: ${error.message}`
             }

--- a/vscode/src/commands/scm/source-control.ts
+++ b/vscode/src/commands/scm/source-control.ts
@@ -204,9 +204,9 @@ export class CodySourceControl implements vscode.Disposable {
                 // or are on the Cody ignore list.
                 // No matter the reason, all of them are being skipped,
                 // and we can't generate a commit message without any context.
-                let message = "Cody was forced to skip all of the files being committed"
-                if(contextTooBig) {
-                    message += " because they exceeded the context window limit"
+                let message = 'Cody was forced to skip all of the files being committed'
+                if (contextTooBig) {
+                    message += ' because they exceeded the context window limit'
                 }
                 throw new Error(message)
             }
@@ -227,12 +227,12 @@ export class CodySourceControl implements vscode.Disposable {
 
             if (ignoredContext.length > 0) {
                 let message = `Cody was forced to skip ${ignoredContext.length} ${pluralize(
-                        'file',
-                        ignoredContext.length,
-                        'files'
-                    )} when generating the commit message`
-                if(contextTooBig) {
-                    message += " because they exceeded the context window limit"
+                    'file',
+                    ignoredContext.length,
+                    'files'
+                )} when generating the commit message`
+                if (contextTooBig) {
+                    message += ' because they exceeded the context window limit'
                 }
                 outputChannelLogger.logError('Generate Commit Message', message)
                 vscode.window.showInformationMessage(message)
@@ -242,7 +242,7 @@ export class CodySourceControl implements vscode.Disposable {
             progress.report({ message: 'Error' })
             sourceControlInputbox.value = initialInputBoxValue // Revert to initial value on error
             outputChannelLogger.logError('Generate Commit Message', 'failed', error)
-            var errorMessage = "Could not generate a commit message"
+            let errorMessage = 'Could not generate a commit message'
             if (error instanceof Error && error.message) {
                 errorMessage += `: ${error.message}`
             }
@@ -259,7 +259,7 @@ export class CodySourceControl implements vscode.Disposable {
         preamble: Message[],
         context: ContextItem[],
         commitTemplate?: string
-    ): Promise<{ prompt: Message[]; ignoredContext: ContextItem[], contextTooBig: boolean }> {
+    ): Promise<{ prompt: Message[]; ignoredContext: ContextItem[]; contextTooBig: boolean }> {
         if (!context.length) {
             throw new Error('Failed to get git output.')
         }
@@ -274,7 +274,8 @@ export class CodySourceControl implements vscode.Disposable {
         promptBuilder.tryAddToPrefix(preamble)
         promptBuilder.tryAddMessages(transcript.reverse())
 
-        const { ignored: ignoredContext, limitReached: contextTooBig } = await promptBuilder.tryAddContext('user', context)
+        const { ignored: ignoredContext, limitReached: contextTooBig } =
+            await promptBuilder.tryAddContext('user', context)
         return { prompt: promptBuilder.build(), ignoredContext, contextTooBig }
     }
 

--- a/vscode/src/commands/scm/source-control.ts
+++ b/vscode/src/commands/scm/source-control.ts
@@ -197,7 +197,7 @@ export class CodySourceControl implements vscode.Disposable {
                 context,
                 commitTemplate
             ).catch(error => {
-                sourceControlInputbox.value = `${error}`
+                sourceControlInputbox.value = initialInputBoxValue
                 throw new Error()
             })
 


### PR DESCRIPTION
Fixes CODY-5227

When generating a commit message, in the case when there are no changes (staged or otherwise) to commit, the result of clicking the Generate Commit Message button was the text, `Error: Failed to get git output.` being placed in the commit message input box.
<img width="391" alt="Error: Failed to get git output." src="https://github.com/user-attachments/assets/99893086-7916-4ff0-8982-520c0f410aba" />

This PR changes that behavior: when commit message generation fails - for whatever reason - the input box remains unchanged, a message about the error is displayed via `showInformationMessage`, and the error is sent to the "Cody by Sourcegraph" output channel.

<img width="1228" alt="Screenshot 2025-04-29 at 16 59 09" src="https://github.com/user-attachments/assets/257059e3-4013-4708-ad78-d90cef87798d" />

Clarified error messages about skipping file because they're too big for the context
<img width="1345" alt="Skipping all files" src="https://github.com/user-attachments/assets/7c68dc90-7386-4149-90e8-b9199b3ad80b" />

Enabled commit message generation about file deletions
<img width="1345" alt="deleting files" src="https://github.com/user-attachments/assets/d210df7d-3542-4d1f-b87e-a6184bfc6f0f" />

## Test plan

CI/CD
