### PR TITLE
fix(prompt-editor): fix flushSync warning in PromptEditor

### DIFF
--- a/lib/prompt-editor/src/PromptEditor.tsx
+++ b/lib/prompt-editor/src/PromptEditor.tsx
@@ -110,7 +110,11 @@ export const PromptEditor: FunctionComponent<Props> = ({
             setEditorState(state: SerializedPromptEditorState): void {
                 const editor = editorRef.current
                 if (editor) {
-                    editor.setEditorState(editor.parseEditorState(state.lexicalEditorState))
+                    // Use requestAnimationFrame to ensure the editor state is set outside of React's render cycle
+                    // This prevents the flushSync warning
+                    requestAnimationFrame(() => {
+                        editor.setEditorState(editor.parseEditorState(state.lexicalEditorState))
+                    })
                 }
             },
             getSerializedValue(): SerializedPromptEditorValue {
@@ -325,7 +329,11 @@ export const PromptEditor: FunctionComponent<Props> = ({
                 const currentEditorState = normalizeEditorStateJSON(editor.getEditorState().toJSON())
                 const newEditorState = initialEditorState.lexicalEditorState
                 if (!isEqual(currentEditorState, newEditorState)) {
-                    editor.setEditorState(editor.parseEditorState(newEditorState))
+                    // Use requestAnimationFrame to ensure the editor state is set outside of React's render cycle
+                    // NOTE: This addresses the flushSync warning.
+                    requestAnimationFrame(() => {
+                        editor.setEditorState(editor.parseEditorState(newEditorState))
+                    })
                 }
             }
         }

--- a/vscode/test/e2e/initial-context.test.ts
+++ b/vscode/test/e2e/initial-context.test.ts
@@ -19,7 +19,7 @@ testWithGitRemote.extend<DotcomUrlOverride>({ dotcomUrl: mockServer.SERVER_URL }
         await sidebarSignin(page, sidebar)
         const chatFrame = getChatSidebarPanel(page)
         const lastChatInput = getChatInputs(chatFrame).last()
-
+        await lastChatInput.click({ delay: 100 })
         // The current repository should be initially present in the chat input.
         await expect(chatInputMentions(lastChatInput)).toHaveText(['myrepo'])
     }

--- a/vscode/webviews/chat/Transcript.test.tsx
+++ b/vscode/webviews/chat/Transcript.test.tsx
@@ -1,7 +1,7 @@
 import { type ChatMessage, FIXTURE_MODELS, errorToChatError, ps } from '@sourcegraph/cody-shared'
 import { fireEvent, getQueriesForElement, render as render_, screen } from '@testing-library/react'
 import type { ComponentProps } from 'react'
-import { describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { URI } from 'vscode-uri'
 import { AppWrapperForTest } from '../AppWrapperForTest'
 import { MockNoGuardrails } from '../utils/guardrails'
@@ -19,6 +19,21 @@ const PROPS: Omit<ComponentProps<typeof Transcript>, 'transcript'> = {
     setActiveChatContext: () => {},
     guardrails: new MockNoGuardrails(),
 }
+
+// Mock requestAnimationFrame to execute callback immediately in test environment
+const originalRAF = global.requestAnimationFrame
+beforeEach(() => {
+    global.requestAnimationFrame = (cb: FrameRequestCallback): number => {
+        // Execute the callback immediately
+        cb(0)
+        return 0
+    }
+})
+
+afterEach(() => {
+    // Restore the original requestAnimationFrame
+    global.requestAnimationFrame = originalRAF
+})
 
 vi.mock('../utils/VSCodeApi', () => ({
     getVSCodeAPI: vi.fn().mockReturnValue({


### PR DESCRIPTION
This PR fixes a React warning that occurs during test runs related to improper usage of flushSync within a React lifecycle method. The warning appears in the HumanMessageEditor test:

The issue was in the PromptEditor component, where editor.setEditorState() was being called directly during React's render cycle. The Lexical editor framework internally uses flushSync to ensure synchronous updates, which conflicts with React's rendering process.

To resolve this, `requestAnimationFrame` is used to ensure that the editor state is set outside of React's render cycle. This change is applied in two places:

- When setting the editor state from serialized data.
- When initializing the editor state with the initial editor state.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Run `pnpm test vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.test.tsx` to confirm the warning is gone. All existing tests should still pass

### Before

![image](https://github.com/user-attachments/assets/e8740d35-490b-4eba-af69-708342dc2d49)

### After

![image](https://github.com/user-attachments/assets/aa7191e9-df06-4203-bce8-b6498a319cba)
