### PR TITLE
fix(history-tab): improve layout for empty state

### DIFF
--- a/vscode/webviews/tabs/HistoryTab.story.tsx
+++ b/vscode/webviews/tabs/HistoryTab.story.tsx
@@ -1,4 +1,5 @@
-import { CodyIDE, type UserLocalHistory } from '@sourcegraph/cody-shared'
+import { CodyIDE } from '@sourcegraph/cody-shared'
+import type { LightweightChatTranscript } from '@sourcegraph/cody-shared/src/chat/transcript'
 import type { Meta, StoryObj } from '@storybook/react'
 import { VSCodeStandaloneComponent } from '../storybook/VSCodeStoryDecorator'
 import { HistoryTabWithData } from './HistoryTab'
@@ -62,35 +63,23 @@ export const MultiDay: Story = {
 
 export const Paginated: Story = {
     args: {
+        IDE: CodyIDE.VSCode,
+        setView: () => {},
         chats: getMockedChatData(50),
     },
 }
 
-function getMockedChatData(items: number): UserLocalHistory['chat'][string][] {
-    const mockedChatData: UserLocalHistory['chat'][string][] = []
+function getMockedChatData(items: number): LightweightChatTranscript[] {
+    const mockedChatData: LightweightChatTranscript[] = []
 
     for (let i = 3; i <= items; i++) {
-        const numInteractions = Math.floor(Math.random() * 3) + 1 // 1-3 interactions
-        const interactions = []
         const lastTimestamp = Date.now() - Math.floor(Math.random() * 7) * 86400000 // Randomly within the last 7 days
-
-        for (let j = 0; j < numInteractions; j++) {
-            const humanMessageText = `Question about topic ${i}-${j + 1}`
-            interactions.push({
-                humanMessage: {
-                    speaker: 'human' as const,
-                    text: humanMessageText,
-                },
-                assistantMessage: {
-                    speaker: 'assistant' as const,
-                    text: `Answer to question ${i}-${j + 1}`,
-                },
-            })
-        }
+        const firstHumanMessageText = `Question about topic ${i}-1`
 
         mockedChatData.push({
             id: String(i),
-            interactions: interactions,
+            chatTitle: `Chat about topic ${i}`,
+            firstHumanMessageText,
             lastInteractionTimestamp: new Date(lastTimestamp).toISOString(),
         })
     }

--- a/vscode/webviews/tabs/HistoryTab.tsx
+++ b/vscode/webviews/tabs/HistoryTab.tsx
@@ -38,7 +38,7 @@ export const HistoryTab: React.FC<HistoryTabProps> = ({
     const chats = useMemo(() => (userHistory ? Object.values(userHistory) : userHistory), [userHistory])
 
     return (
-        <div className="tw-flex tw-overflow-hidden tw-h-full tw-w-full">
+        <div className="tw-flex tw-flex-col tw-justify-center tw-overflow-hidden tw-h-full tw-w-full">
             {!chats ? (
                 <LoadingDots />
             ) : (


### PR DESCRIPTION
Fixes QA-620

This commit updates the HistoryTab component to improve the layout when there are no chat history items.
Also fixed the Pagination story, where previously we were getting the empty story result instead of a pagination
listing

![cody-start-chat](https://github.com/user-attachments/assets/17fd83de-4f69-48fe-86a1-97e06364219e)


## Test plan
- Run pnpm storybook and check the pagination storybook
- Start with a profile that has no history and notice that the empty history notice is centered