### PR TITLE
fix(auto-edit): use correct doc context version to show inline completions more often

### DIFF
--- a/vscode/src/autoedits/analytics-logger/analytics-logger.test.ts
+++ b/vscode/src/autoedits/analytics-logger/analytics-logger.test.ts
@@ -78,7 +78,7 @@ describe('AutoeditAnalyticsLogger', () => {
         return {
             startedAt: performance.now(),
             filePath: getCurrentFilePath(document).toString(),
-            docContext,
+            requestDocContext: docContext,
             document,
             position,
             codeToReplaceData: codeToReplace,
@@ -120,7 +120,7 @@ describe('AutoeditAnalyticsLogger', () => {
             cacheId: uuid.v4() as AutoeditCacheID,
             prompt: modelOptions.prompt,
             codeToReplaceData: codeToReplace,
-            docContext,
+            predictionDocContext: docContext,
             editPosition: position,
             modelResponse: {
                 type: 'success',

--- a/vscode/src/autoedits/analytics-logger/analytics-logger.ts
+++ b/vscode/src/autoedits/analytics-logger/analytics-logger.ts
@@ -100,14 +100,14 @@ export class AutoeditAnalyticsLogger {
         codeToReplaceData,
         document,
         position,
-        docContext,
+        requestDocContext,
     }: {
         startedAt: number
         filePath: string
         codeToReplaceData: CodeToReplaceData
         document: vscode.TextDocument
         position: vscode.Position
-        docContext: DocumentContext
+        requestDocContext: DocumentContext
         payload: Required<
             Pick<StartedState['payload'], 'languageId' | 'model' | 'triggerKind' | 'codeToRewrite'>
         >
@@ -124,7 +124,7 @@ export class AutoeditAnalyticsLogger {
             codeToReplaceData,
             document,
             position,
-            docContext,
+            requestDocContext,
             payload: {
                 otherCompletionProviderEnabled: otherCompletionProviders.length > 0,
                 otherCompletionProviders,
@@ -175,12 +175,12 @@ export class AutoeditAnalyticsLogger {
         payload,
         modelResponse,
         codeToReplaceData,
-        docContext,
+        predictionDocContext,
         editPosition,
     }: {
         modelResponse: SuccessModelResponse | PartialModelResponse
         codeToReplaceData: CodeToReplaceData
-        docContext: DocumentContext
+        predictionDocContext: DocumentContext
         requestId: AutoeditRequestID
         cacheId: AutoeditCacheID
         hotStreakId?: AutoeditHotStreakID
@@ -200,7 +200,7 @@ export class AutoeditAnalyticsLogger {
                 loadedAt,
                 modelResponse,
                 codeToReplaceData,
-                docContext,
+                predictionDocContext,
                 cacheId,
                 hotStreakId,
                 editPosition,
@@ -257,9 +257,8 @@ export class AutoeditAnalyticsLogger {
                 'inlineCompletionItems' in renderOutput
                     ? renderOutput.inlineCompletionItems[0]
                     : undefined
-            const insertText = completion
-                ? (completion.insertText as string).slice(request.docContext.currentLinePrefix.length)
-                : undefined
+
+            const insertText = completion?.withoutCurrentLinePrefix.insertText
 
             return {
                 ...request,

--- a/vscode/src/autoedits/analytics-logger/types.ts
+++ b/vscode/src/autoedits/analytics-logger/types.ts
@@ -191,7 +191,7 @@ export interface StartedState extends AutoeditBaseState {
     codeToReplaceData: CodeToReplaceData
     document: vscode.TextDocument
     position: vscode.Position
-    docContext: DocumentContext
+    requestDocContext: DocumentContext
 
     /** Partial payload for this phase. Will be augmented with more info as we progress. */
     payload: {
@@ -257,6 +257,7 @@ export interface LoadedState extends Omit<ContextLoadedState, 'phase' | 'payload
     hotStreakId?: AutoeditHotStreakID
     hotStreakChunks?: HotStreakChunk[]
     editPosition: vscode.Position
+    predictionDocContext: DocumentContext
     payload: ContextLoadedState['payload'] & {
         /**
          * An ID to uniquely identify a suggest autoedit. Note: It is possible for this ID to be part

--- a/vscode/src/autoedits/autoedit-completion-item.ts
+++ b/vscode/src/autoedits/autoedit-completion-item.ts
@@ -1,5 +1,6 @@
 import * as uuid from 'uuid'
 import * as vscode from 'vscode'
+
 import type { AutoeditRequestID } from './analytics-logger'
 
 interface AutoeditCompletionItemParams {
@@ -7,6 +8,12 @@ interface AutoeditCompletionItemParams {
     insertText: string | vscode.SnippetString
     range: vscode.Range
     command?: vscode.Command
+
+    /** For debugging purposes */
+    withoutCurrentLinePrefix: {
+        insertText: string
+        range: vscode.Range
+    }
 }
 
 export class AutoeditCompletionItem extends vscode.InlineCompletionItem {
@@ -17,10 +24,12 @@ export class AutoeditCompletionItem extends vscode.InlineCompletionItem {
      * API's that require the completion item to only have an ID.
      */
     public id: string
+    public withoutCurrentLinePrefix: AutoeditCompletionItemParams['withoutCurrentLinePrefix']
 
     constructor(params: AutoeditCompletionItemParams) {
-        const { insertText, range, command, id } = params
+        const { insertText, range, command, id, withoutCurrentLinePrefix } = params
         super(insertText, range, command)
         this.id = id || uuid.v4()
+        this.withoutCurrentLinePrefix = withoutCurrentLinePrefix
     }
 }

--- a/vscode/src/autoedits/autoedits-provider.test.ts
+++ b/vscode/src/autoedits/autoedits-provider.test.ts
@@ -495,6 +495,10 @@ describe('AutoeditsProvider', () => {
                 id,
                 insertText: completionItem.text,
                 range: completionItem.range,
+                withoutCurrentLinePrefix: {
+                    insertText: completionItem.text,
+                    range: completionItem.range,
+                },
             }),
         ])
     })

--- a/vscode/src/autoedits/autoedits-provider.ts
+++ b/vscode/src/autoedits/autoedits-provider.ts
@@ -12,6 +12,7 @@ import {
     currentResolvedConfig,
     tokensToChars,
 } from '@sourcegraph/cody-shared'
+
 import type { CompletionBookkeepingEvent } from '../completions/analytics-logger'
 import { ContextRankingStrategy } from '../completions/context/completions-context-ranker'
 import { ContextMixer } from '../completions/context/context-mixer'
@@ -23,6 +24,7 @@ import type { AutocompleteEditItem, AutoeditChanges } from '../jsonrpc/agent-pro
 import { isRunningInsideAgent } from '../jsonrpc/isRunningInsideAgent'
 import type { FixupController } from '../non-stop/FixupController'
 import type { CodyStatusBar } from '../services/StatusBar'
+
 import type {
     AbortedModelResponse,
     AutoeditsModelAdapter,
@@ -36,6 +38,7 @@ import {
     type AutoeditHotStreakID,
     type AutoeditRequestID,
     type AutoeditRequestStateForAgentTesting,
+    type AutoeditTriggerKindMetadata,
     autoeditAnalyticsLogger,
     autoeditDiscardReason,
     autoeditSource,
@@ -46,17 +49,16 @@ import { AutoeditCompletionItem } from './autoedit-completion-item'
 import { autoeditsOnboarding } from './autoedit-onboarding'
 import { autoeditsProviderConfig } from './autoedits-config'
 import { FilterPredictionBasedOnRecentEdits } from './filter-prediction-edits'
-import { type ProcessedHotStreakResponse, processHotStreakResponses } from './hot-streak'
+import { processHotStreakResponses } from './hot-streak'
 import { createMockResponseGenerator } from './mock-response-generator'
 import { autoeditsOutputChannelLogger } from './output-channel-logger'
 import type { AutoeditsUserPromptStrategy } from './prompt/base'
 import { createPromptProvider } from './prompt/create-prompt-provider'
 import { type CodeToReplaceData, getCodeToReplaceData } from './prompt/prompt-utils'
 import { getCurrentFilePath } from './prompt/prompt-utils'
-import type { DecorationInfo } from './renderer/decorators/base'
 import { DefaultDecorator } from './renderer/decorators/default-decorator'
 import { InlineDiffDecorator } from './renderer/decorators/inline-diff-decorator'
-import { getAddedLines, getDecorationInfo } from './renderer/diff-utils'
+import { getAddedLines, getDecorationInfoFromPrediction } from './renderer/diff-utils'
 import { initImageSuggestionService } from './renderer/image-gen'
 import { AutoEditsInlineRendererManager } from './renderer/inline-manager'
 import { AutoEditsDefaultRendererManager, type AutoEditsRendererManager } from './renderer/manager'
@@ -328,7 +330,12 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
 
         if (inlineCompletionContext.selectedCompletionInfo !== undefined) {
             const { range, text } = inlineCompletionContext.selectedCompletionInfo
-            const completion = new AutoeditCompletionItem({ id: null, insertText: text, range })
+            const completion = new AutoeditCompletionItem({
+                id: null,
+                insertText: text,
+                range,
+                withoutCurrentLinePrefix: { insertText: text, range },
+            })
             // User has a currently selected item in the autocomplete widget.
             // Instead of attempting to suggest an auto-edit, just show the selected item
             // as the completion. This is to avoid an undesirable edit conflicting with the acceptance
@@ -343,6 +350,11 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
         }
 
         try {
+            const triggerKind =
+                this.lastManualTriggerTimestamp > performance.now() - 50
+                    ? autoeditTriggerKind.manual
+                    : autoeditTriggerKind.automatic
+
             stopLoading = this.statusBar.addLoader({
                 title: 'Auto-edits are being generated',
                 timeout: 5_000,
@@ -351,7 +363,7 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
             const throttledRequest = this.smartThrottleService.throttle({
                 uri: document.uri.toString(),
                 position,
-                isManuallyTriggered: this.lastManualTriggerTimestamp > performance.now() - 50,
+                isManuallyTriggered: triggerKind === autoeditTriggerKind.manual,
             })
 
             const abortSignal = throttledRequest.abortController.signal
@@ -402,13 +414,13 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
                 filePath: getCurrentFilePath(document).toString(),
                 codeToReplaceData: requestCodeToReplaceData,
                 position,
-                docContext: requestDocContext,
+                requestDocContext,
                 document,
                 payload: {
                     languageId: document.languageId,
                     model: autoeditsProviderConfig.model,
                     codeToRewrite: requestCodeToReplaceData.codeToRewrite,
-                    triggerKind: autoeditTriggerKind.automatic,
+                    triggerKind,
                 },
             })
 
@@ -465,8 +477,9 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
                 position,
                 prompt,
                 codeToReplaceData: requestCodeToReplaceData,
-                docContext: requestDocContext,
+                requestDocContext,
                 abortSignal,
+                triggerKind,
             })
 
             if (abortSignal?.aborted || predictionResult.type === 'aborted') {
@@ -497,7 +510,7 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
                 hotStreakId: predictionResult.hotStreakId,
                 prompt,
                 modelResponse: predictionResult.response,
-                docContext: predictionDocContext,
+                predictionDocContext,
                 codeToReplaceData: predictionCodeToReplaceData,
                 editPosition: predictionResult.editPosition,
                 payload: {
@@ -595,7 +608,6 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
                     prediction,
                     document,
                     position,
-                    docContext: predictionDocContext,
                     decorationInfo,
                     codeToReplaceData: predictionCodeToReplaceData,
                 },
@@ -727,8 +739,12 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
 
             if (process.env.NODE_ENV === 'development') {
                 console.error(errorToReport)
+                if (errorToReport.stack) {
+                    console.error(errorToReport.stack)
+                }
             }
 
+            // TODO: surface errors in the autoedit debug panel
             autoeditAnalyticsLogger.logError(errorToReport)
             return null
         } finally {
@@ -829,71 +845,24 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
         return this.rendererManager.handleDidShowSuggestion(requestId)
     }
 
-    /**
-     * Process model responses and emit hot streak predictions
-     * This allows us to emit suggestions before the model is done generating
-     */
-    private async getAndProcessModelResponses({
-        document,
-        position,
-        codeToReplaceData,
-        docContext,
-        prompt,
-        abortSignal,
-    }: {
-        document: vscode.TextDocument
-        position: vscode.Position
-        codeToReplaceData: CodeToReplaceData
-        docContext: DocumentContext
-        prompt: AutoeditsPrompt
-        abortSignal: AbortSignal
-    }): Promise<AsyncGenerator<ProcessedHotStreakResponse>> {
-        const userId = (await currentResolvedConfig()).clientState.anonymousUserID
-        const responseGenerator = await this.modelAdapter.getModelResponse({
-            url: autoeditsProviderConfig.url,
-            model: autoeditsProviderConfig.model,
-            prompt,
-            codeToRewrite: codeToReplaceData.codeToRewrite,
-            userId,
-            isChatModel: autoeditsProviderConfig.isChatModel,
-            abortSignal,
-            timeoutMs: autoeditsProviderConfig.timeoutMs,
-        })
-
-        const responseWithTiming = this.generatorWithTiming(
-            this.modelAdapter.constructor.name,
-            autoeditsProviderConfig.model,
-            responseGenerator
-        )
-
-        return processHotStreakResponses({
-            responseGenerator: responseWithTiming,
-            document,
-            codeToReplaceData,
-            docContext,
-            position,
-            options: {
-                hotStreakEnabled: this.features.shouldHotStreak,
-            },
-        })
-    }
-
     private async getPrediction({
         requestId,
         document,
         position,
         codeToReplaceData,
-        docContext,
+        requestDocContext,
         prompt,
         abortSignal,
+        triggerKind,
     }: {
         requestId: AutoeditRequestID
         document: vscode.TextDocument
         position: vscode.Position
         codeToReplaceData: CodeToReplaceData
-        docContext: DocumentContext
+        requestDocContext: DocumentContext
         prompt: AutoeditsPrompt
         abortSignal: AbortSignal
+        triggerKind: AutoeditTriggerKindMetadata
     }): Promise<PredictionResult> {
         const requestParams: AutoeditRequestManagerParams = {
             requestId,
@@ -902,9 +871,10 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
             documentText: document.getText(),
             documentVersion: document.version,
             codeToReplaceData,
-            docContext,
+            requestDocContext,
             position,
             abortSignal,
+            triggerKind,
         }
 
         if (autoeditsProviderConfig.isMockResponseFromCurrentDocumentTemplateEnabled) {
@@ -926,7 +896,7 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
                             responseGenerator,
                             document,
                             codeToReplaceData,
-                            docContext,
+                            requestDocContext,
                             position,
                             options: {
                                 hotStreakEnabled: this.features.shouldHotStreak,
@@ -938,15 +908,34 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
         }
 
         return this.requestManager.request(requestParams, async signal => {
-            const response = await this.getAndProcessModelResponses({
-                document,
-                position,
-                codeToReplaceData,
+            const userId = (await currentResolvedConfig()).clientState.anonymousUserID
+            const responseGenerator = await this.modelAdapter.getModelResponse({
+                url: autoeditsProviderConfig.url,
+                model: autoeditsProviderConfig.model,
                 prompt,
-                abortSignal: signal,
-                docContext,
+                codeToRewrite: codeToReplaceData.codeToRewrite,
+                userId,
+                isChatModel: autoeditsProviderConfig.isChatModel,
+                abortSignal,
+                timeoutMs: autoeditsProviderConfig.timeoutMs,
             })
-            return response
+
+            const responseWithTiming = this.generatorWithTiming(
+                this.modelAdapter.constructor.name,
+                autoeditsProviderConfig.model,
+                responseGenerator
+            )
+
+            return processHotStreakResponses({
+                responseGenerator: responseWithTiming,
+                document,
+                codeToReplaceData,
+                requestDocContext,
+                position,
+                options: {
+                    hotStreakEnabled: this.features.shouldHotStreak,
+                },
+            })
         })
     }
 
@@ -985,7 +974,7 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
     }
 
     /**
-     * Threshold in which we will prefer to show a next cursor suggeston instead
+     * Threshold in which we will prefer to show a next cursor suggestion instead
      * of the current suggestion.
      */
     private NEXT_CURSOR_SUGGESTION_THRESHOLD = 10
@@ -1010,7 +999,7 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
     }
 
     /**
-     * noop method for Agent compability with `InlineCompletionItemProvider`.
+     * noop method for Agent compatibility with `InlineCompletionItemProvider`.
      * See: vscode/src/completions/inline-completion-item-provider.ts
      */
     public clearLastCandidate(): void {
@@ -1044,18 +1033,4 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
         }
     }
 }
-
-export function getDecorationInfoFromPrediction(
-    document: vscode.TextDocument,
-    prediction: string,
-    range: vscode.Range
-): DecorationInfo {
-    const currentFileText = document.getText()
-    const predictedFileText =
-        currentFileText.slice(0, document.offsetAt(range.start)) +
-        prediction +
-        currentFileText.slice(document.offsetAt(range.end))
-
-    const decorationInfo = getDecorationInfo(currentFileText, predictedFileText)
-    return decorationInfo
-}
+export { getDecorationInfoFromPrediction }

--- a/vscode/src/autoedits/hot-streak/index.test.ts
+++ b/vscode/src/autoedits/hot-streak/index.test.ts
@@ -126,7 +126,7 @@ function createHotStreakParams(
         responseGenerator,
         document,
         codeToReplaceData,
-        docContext: docContext,
+        requestDocContext: docContext,
         position,
         options: {
             hotStreakEnabled: true,

--- a/vscode/src/autoedits/hot-streak/index.ts
+++ b/vscode/src/autoedits/hot-streak/index.ts
@@ -2,8 +2,8 @@ import type { CodeToReplaceData, DocumentContext } from '@sourcegraph/cody-share
 import * as uui from 'uuid'
 
 import * as vscode from 'vscode'
-
 import { TextDocument } from 'vscode-languageserver-textdocument'
+
 import { getCurrentDocContext } from '../../completions/get-current-doc-context'
 import { getNewLineChar } from '../../completions/text-processing'
 import { wrapVSCodeTextDocument } from '../../editor/utils/virtual-text-document'
@@ -17,6 +17,7 @@ import type {
 } from '../autoedits-provider'
 import { getCodeToReplaceData } from '../prompt/prompt-utils'
 import { isDuplicatingTextFromRewriteArea } from '../utils'
+
 import { getHotStreakChunk } from './get-chunk'
 import { getStableSuggestion } from './stable-suggestion'
 
@@ -24,7 +25,7 @@ export interface ProcessHotStreakResponsesParams {
     responseGenerator: AsyncGenerator<ModelResponse>
     document: vscode.TextDocument
     codeToReplaceData: CodeToReplaceData
-    docContext: DocumentContext
+    requestDocContext: DocumentContext
     position: vscode.Position
     options: {
         // If hot-streak is actually enabled. If it is not, we will not attempt to emit
@@ -51,7 +52,7 @@ export async function* processHotStreakResponses({
     responseGenerator,
     document: originalDocument,
     codeToReplaceData,
-    docContext,
+    requestDocContext,
     position,
     options,
 }: ProcessHotStreakResponsesParams): AsyncGenerator<ProcessedHotStreakResponse> {
@@ -104,14 +105,14 @@ export async function* processHotStreakResponses({
             // If we matched this new position, it would mean it would be possible to chain inline completions.
             const hotStreakPosition = position
 
-            // The hot streak prediction excludes part of the prefix. This means that it fundamentally relies
-            // on the prefix existing in the document to be a valid suggestion. We need to update the docContext
-            // to reflect this.
+            // The hot streak prediction excludes part of the prediction. This means that it fundamentally relies
+            // on this prediction part existing in the document to be a valid suggestion. We need to update the
+            // docContext to reflect this.
             const updatedDocContext = getCurrentDocContext({
                 document,
                 position: hotStreakPosition,
-                maxPrefixLength: docContext.maxPrefixLength,
-                maxSuffixLength: docContext.maxSuffixLength,
+                maxPrefixLength: requestDocContext.maxPrefixLength,
+                maxSuffixLength: requestDocContext.maxSuffixLength,
             })
 
             const lengthOfChunk = predictionChunk.range.end.line - predictionChunk.range.start.line - 1
@@ -199,7 +200,7 @@ export async function* processHotStreakResponses({
                 type: 'suggested',
                 response,
                 uri: document.uri.toString(),
-                docContext,
+                docContext: requestDocContext,
                 codeToReplaceData,
                 // Note: We still emit a position when hot streak is disabled, but it is not an accurate
                 // `editPosition`. This is just so we can maintain a single type whilst the feature flag is used.
@@ -227,7 +228,7 @@ export async function* processHotStreakResponses({
             type: 'suggested',
             response,
             uri: document.uri.toString(),
-            docContext,
+            docContext: requestDocContext,
             codeToReplaceData,
             // Note that an `editPosition` is returned here regardless of whether the suggestion is a hot-streak.
             // This is so this can still be used as a "next cursor" prediction source for a scenario where we have

--- a/vscode/src/autoedits/renderer/diff-utils.ts
+++ b/vscode/src/autoedits/renderer/diff-utils.ts
@@ -12,6 +12,21 @@ import type {
     ModifiedLineInfo,
 } from './decorators/base'
 
+export function getDecorationInfoFromPrediction(
+    document: vscode.TextDocument,
+    prediction: string,
+    range: vscode.Range
+): DecorationInfo {
+    const currentFileText = document.getText()
+    const predictedFileText =
+        currentFileText.slice(0, document.offsetAt(range.start)) +
+        prediction +
+        currentFileText.slice(document.offsetAt(range.end))
+
+    const decorationInfo = getDecorationInfo(currentFileText, predictedFileText)
+    return decorationInfo
+}
+
 /**
  * Generates decoration information by computing the differences between two texts.
  */

--- a/vscode/src/autoedits/renderer/manager.ts
+++ b/vscode/src/autoedits/renderer/manager.ts
@@ -7,6 +7,9 @@ import {
     getLatestVisibilityContext,
     isCompletionVisible,
 } from '../../completions/is-completion-visible'
+import { isRunningInsideAgent } from '../../jsonrpc/isRunningInsideAgent'
+import type { FixupController } from '../../non-stop/FixupController'
+import { CodyTaskState } from '../../non-stop/state'
 import {
     type AutoeditAcceptReasonMetadata,
     type AutoeditRejectReasonMetadata,
@@ -18,21 +21,19 @@ import {
     autoeditDiscardReason,
     autoeditRejectReason,
 } from '../analytics-logger'
+import { AutoeditCompletionItem } from '../autoedit-completion-item'
 import { autoeditsProviderConfig } from '../autoedits-config'
+import type { AutoeditClientCapabilities } from '../autoedits-provider'
+import { autoeditsOutputChannelLogger } from '../output-channel-logger'
 import type { CodeToReplaceData } from '../prompt/prompt-utils'
+import type { RequestManager } from '../request-manager'
 import {
     adjustPredictionIfInlineCompletionPossible,
     areSameUriDocs,
     extractInlineCompletionFromRewrittenCode,
 } from '../utils'
 
-import { isRunningInsideAgent } from '../../jsonrpc/isRunningInsideAgent'
-import type { FixupController } from '../../non-stop/FixupController'
-import { CodyTaskState } from '../../non-stop/state'
-import { AutoeditCompletionItem } from '../autoedit-completion-item'
-import type { AutoeditClientCapabilities } from '../autoedits-provider'
-import { autoeditsOutputChannelLogger } from '../output-channel-logger'
-import type { RequestManager } from '../request-manager'
+import { getCurrentLinePrefixAndSuffix } from '../../completions/get-current-doc-context'
 import type { AutoEditDecorations, AutoEditsDecorator, DecorationInfo } from './decorators/base'
 import {
     type AutoEditRenderOutput,
@@ -256,7 +257,7 @@ export class AutoEditsDefaultRendererManager
                     const {
                         document: invokedDocument,
                         position: invokedPosition,
-                        docContext,
+                        predictionDocContext,
                         renderOutput,
                     } = this.activeRequest
 
@@ -285,7 +286,7 @@ export class AutoEditsDefaultRendererManager
                             invokedPosition,
                             invokedDocument,
                             activeTextEditor,
-                            docContext,
+                            docContext: predictionDocContext,
                             inlineCompletionContext: undefined,
                             maxPrefixLength: tokensToChars(
                                 autoeditsProviderConfig.tokenLimit.prefixTokens
@@ -425,14 +426,7 @@ export class AutoEditsDefaultRendererManager
     }
 
     public getRenderOutput(
-        {
-            requestId,
-            prediction,
-            codeToReplaceData,
-            document,
-            position,
-            docContext,
-        }: GetRenderOutputArgs,
+        { requestId, prediction, codeToReplaceData, document, position }: GetRenderOutputArgs,
         capabilities?: AutoeditClientCapabilities
     ): AutoEditRenderOutput {
         const updatedPrediction = adjustPredictionIfInlineCompletionPossible(
@@ -440,31 +434,36 @@ export class AutoEditsDefaultRendererManager
             codeToReplaceData.codeToRewritePrefix,
             codeToReplaceData.codeToRewriteSuffix
         )
+
+        const { currentLinePrefix, currentLineSuffix } = getCurrentLinePrefixAndSuffix({
+            document,
+            position,
+        })
         const codeToRewriteAfterCurrentLine = codeToReplaceData.codeToRewriteSuffix.slice(
-            docContext.currentLineSuffix.length + 1 // Additional char for newline
+            currentLineSuffix.length + 1 // Additional char for newline
         )
         const isPrefixMatch = updatedPrediction.startsWith(codeToReplaceData.codeToRewritePrefix)
         const isSuffixMatch =
             // The current line suffix should not require any char removals to render the completion.
-            completionMatchesSuffix(updatedPrediction, docContext.currentLineSuffix) &&
+            completionMatchesSuffix(updatedPrediction, currentLineSuffix) &&
             // The new lines suggested after the current line must be equal to the prediction.
             updatedPrediction.endsWith(codeToRewriteAfterCurrentLine)
 
         if (isPrefixMatch && isSuffixMatch) {
-            const autocompleteInlineResponse = extractInlineCompletionFromRewrittenCode(
+            const insertText = extractInlineCompletionFromRewrittenCode(
                 updatedPrediction,
                 codeToReplaceData.codeToRewritePrefix,
                 codeToReplaceData.codeToRewriteSuffix
             )
 
-            if (autocompleteInlineResponse.trimEnd().length === 0) {
+            if (insertText.trimEnd().length === 0) {
                 return { type: 'none' }
             }
 
-            const insertText = docContext.currentLinePrefix + autocompleteInlineResponse
+            const completionText = currentLinePrefix + insertText
             const inlineCompletionItem = new AutoeditCompletionItem({
                 id: requestId,
-                insertText,
+                insertText: completionText,
                 range: new vscode.Range(
                     document.lineAt(position).range.start,
                     document.lineAt(position).range.end
@@ -477,6 +476,10 @@ export class AutoEditsDefaultRendererManager
                             requestId,
                         },
                     ],
+                },
+                withoutCurrentLinePrefix: {
+                    insertText,
+                    range: new vscode.Range(position, position),
                 },
             })
             autoeditsOutputChannelLogger.logDebug('tryMakeInlineCompletions', 'insert text', {

--- a/vscode/src/autoedits/request-manager.test.ts
+++ b/vscode/src/autoedits/request-manager.test.ts
@@ -16,7 +16,7 @@ import type { DocumentContext } from '@sourcegraph/cody-shared'
 import { documentAndPosition } from '../completions/test-helpers'
 
 import { AutoeditStopReason } from './adapters/base'
-import { type AutoeditSourceMetadata, autoeditSource } from './analytics-logger'
+import { type AutoeditSourceMetadata, autoeditSource, autoeditTriggerKind } from './analytics-logger'
 import type {
     AbortedPredictionResult,
     PredictionResult,
@@ -57,7 +57,7 @@ describe('Autoedits RequestManager', () => {
             yield createSuccessResponse(
                 prediction,
                 params.documentUri,
-                params.docContext,
+                params.requestDocContext,
                 params.codeToReplaceData
             )
         })
@@ -352,7 +352,7 @@ async function startRequests({
             yield createSuccessResponse(
                 prediction,
                 requestParams.documentUri,
-                requestParams.docContext,
+                requestParams.requestDocContext,
                 requestParams.codeToReplaceData
             )
         })
@@ -434,7 +434,8 @@ function createRequestParams(
         requestUrl: 'https://test.com',
         abortSignal: new AbortController().signal,
         codeToReplaceData,
-        docContext: {} as DocumentContext,
+        requestDocContext: {} as DocumentContext,
+        triggerKind: autoeditTriggerKind.automatic,
     }
 }
 

--- a/vscode/src/completions/get-current-doc-context.ts
+++ b/vscode/src/completions/get-current-doc-context.ts
@@ -348,3 +348,19 @@ function getLinesContext(params: GetLinesContextParams): LinesContext {
         nextNonEmptyLine,
     }
 }
+
+export function getCurrentLinePrefixAndSuffix({
+    document,
+    position,
+}: {
+    document: vscode.TextDocument
+    position: vscode.Position
+}) {
+    const currentLineStartPosition = new vscode.Position(position.line, 0)
+    const currentLinePrefix = document.getText(new vscode.Range(currentLineStartPosition, position))
+
+    const currentLineEndPosition = document.lineAt(position.line).range.end
+    const currentLineSuffix = document.getText(new vscode.Range(position, currentLineEndPosition))
+
+    return { currentLinePrefix, currentLineSuffix }
+}


### PR DESCRIPTION
- Renamed `docContext` to `predictionDocContext` and `requestDocContext` to clearly differentiate between them in the code. 
- In `vscode/src/autoedits/renderer/manager.ts`, the `getRenderOutput` function used to rely on `requestDocContext` to prepend the current line prefix to the inline completion insert text. However, if a user added any text after the completion started, and the current line prefix changed, it led to the `insertText` not matching the text already in the document and being hidden by VS Code. This PR fixes the issue by removing the dependency on `docContext` entirely from this function. Instead, it now relies on the always up-to-date recomputed current line prefix and suffix.
- Inlines the `getAndProcessModelResponses` body into `getPrediction` to reduce the number of nested functions for easier debugging.

## Test plan

Manually tested on a toy example `canvas.rs`. Create a new file and start typing `struct` on a new line:

```
struct Canvas {
    pub pixels: Vec,
    pub stride: u8,
    pub size: Size,
    pub format: Format,
}
```

The expected result:

<img width="305" alt="Screenshot 2025-05-02 at 14 03 07" src="https://github.com/user-attachments/assets/343ecb5f-46d4-47a2-b402-c6ee764c3a1d" />

