### PR TITLE
feat(prompts): Display draft prompts in prompt selector

### DIFF
--- a/vscode/src/prompts/manager.ts
+++ b/vscode/src/prompts/manager.ts
@@ -29,7 +29,7 @@ export class PromptsManager implements vscode.Disposable {
                 items: prompts.map(
                     prompt =>
                         ({
-                            label: prompt.name,
+                            label: prompt.name + `${prompt.draft ? ' (Draft)' : ''}`,
                             detail: prompt.description,
                             value: JSON.stringify({
                                 id: prompt.id,


### PR DESCRIPTION
Fixes QA-579

Added  "(Draft)" suffix to the label of draft prompts in the prompt selector.
![Loom Screenshot 2025-05-03 at 09 38 04](https://github.com/user-attachments/assets/2106fb9d-db55-40e7-b9a8-8b5503ec223a)



## Test plan
- Add a prompt that is draft
- Use opt + shit + p and notice the title has (Draft) appended