### PR TITLE
fix(usermenu): add external link icon to upgrade to pro link

### DIFF
--- a/vscode/webviews/components/UserMenu.tsx
+++ b/vscode/webviews/components/UserMenu.tsx
@@ -525,6 +525,7 @@ export const UserMenu: React.FunctionComponent<UserMenuProps> = ({
                                             />
                                         </svg>
                                         <span className="tw-flex-grow">Upgrade to Pro</span>
+                                        <ExternalLinkIcon size={16} strokeWidth={1.25} />
                                     </CommandLink>
                                 )}
                                 {isDotComUser && (


### PR DESCRIPTION
Fixes QA-307

This commit adds an `ExternalLinkIcon` to the "Upgrade to Pro" link in the UserMenu. This provides a visual cue to the user that clicking the link will open an external website.
![Loom Screenshot 2025-05-03 at 10 22 10](https://github.com/user-attachments/assets/f8c80fa4-23a7-417e-82a1-1c34abe2bc99)


## Test plan
- Login with a free account
- Notice that the call to action to upgrade to pro contains also the external link icon