### PR TITLE
fix(usermenu): Show ES for user type instead of Enterprise for ES users

### DIFF
--- a/vscode/webviews/components/UserMenu.tsx
+++ b/vscode/webviews/components/UserMenu.tsx
@@ -1,4 +1,9 @@
-import { type AuthenticatedAuthStatus, CodyIDE, isDotCom } from '@sourcegraph/cody-shared'
+import {
+    type AuthenticatedAuthStatus,
+    CodyIDE,
+    isDotCom,
+    isWorkspaceInstance,
+} from '@sourcegraph/cody-shared'
 import {
     ArrowLeftRightIcon,
     BookOpenText,
@@ -65,6 +70,10 @@ export const UserMenu: React.FunctionComponent<UserMenuProps> = ({
     const telemetryRecorder = useTelemetryRecorder()
     const { displayName, username, primaryEmail, endpoint } = authStatus
     const isDotComUser = isDotCom(endpoint)
+    const isWorkspaceUser = isWorkspaceInstance(endpoint)
+
+    const userType = isDotComUser ? (isProUser ? 'Pro' : 'Free') : isWorkspaceUser ? 'ES' : 'Enterprise'
+    const endpointTitle = `${endpoint} (${isWorkspaceUser ? 'Enterprise Starter' : userType} User)`
 
     const [userMenuView, setUserMenuView] = useState<MenuView>('main')
 
@@ -480,9 +489,9 @@ export const UserMenu: React.FunctionComponent<UserMenuProps> = ({
                                         <Badge
                                             variant={isProUser ? 'cody' : 'secondary'}
                                             className="tw-opacity-85 tw-text-xs tw-h-fit tw-self-center"
-                                            title={endpoint}
+                                            title={endpointTitle}
                                         >
-                                            {isDotComUser ? (isProUser ? 'Pro' : 'Free') : 'Enterprise'}
+                                            {userType}
                                         </Badge>
                                     </div>
                                 </CommandItem>


### PR DESCRIPTION
Show ES instead of enterprise for workspace users since they are not real enterprise users.
I think that with the full Enterprise starter the button becomes too big, we instead show
something like this (endpoint + (Enterprise Starter User) as a title when hovering

![Loom Screenshot 2025-05-03 at 01 09 39](https://github.com/user-attachments/assets/06f08810-f59a-46f1-8117-2b5acb7b9a53)
![Loom Screenshot 2025-05-03 at 01 11 18](https://github.com/user-attachments/assets/7abd090e-3cf1-43e6-88db-6583025d25e7)



## Test plan
- Switch to an ES account and notice that the user type is ES and no longer Enterprise