### PR TITLE
fix(autoedit): Adjust the config for long suggestion model

### DIFF
--- a/lib/shared/src/sourcegraph-api/completions/types.ts
+++ b/lib/shared/src/sourcegraph-api/completions/types.ts
@@ -110,7 +110,17 @@ export interface CompletionResponse {
     tools?: ToolCallContentPart[]
 }
 
-export interface CompletionParameters {
+export interface CompletionsRewriteSpeculationParams {
+    // Rewrite and adaptive speculation is used by fireworks which improves performance for sparse rewrite tasks.
+    // https://docs.fireworks.ai/guides/predicted-outputs#using-predicted-outputs
+    rewriteSpeculation?: boolean
+    adaptiveSpeculation?: boolean
+    speculationLengthOnStrongMatch?: number
+    speculationMinLengthOnStrongMatch?: number
+    speculationStrongMatchThreshold?: number
+}
+
+export interface CompletionParameters extends CompletionsRewriteSpeculationParams {
     fast?: boolean
     messages: Message[]
     maxTokensToSample: number
@@ -128,10 +138,6 @@ export interface CompletionParameters {
         type: 'content'
         content: string
     }
-    // Rewrite and adaptive speculation is used by fireworks which improves performance for sparse rewrite tasks.
-    // https://docs.fireworks.ai/guides/predicted-outputs#using-predicted-outputs
-    rewriteSpeculation?: boolean
-    adaptiveSpeculation?: boolean
 }
 
 export interface SerializedCompletionParameters extends Omit<CompletionParameters, 'messages'> {

--- a/vscode/src/autoedits/adapters/cody-gateway.test.ts
+++ b/vscode/src/autoedits/adapters/cody-gateway.test.ts
@@ -8,6 +8,7 @@ import {
     ps,
 } from '@sourcegraph/cody-shared'
 import * as shared from '@sourcegraph/cody-shared'
+import * as autoeditsConfig from '../autoedits-config'
 
 import type { AutoeditModelOptions } from './base'
 import { CodyGatewayAdapter } from './cody-gateway'
@@ -46,6 +47,52 @@ describe('CodyGatewayAdapter', () => {
 
     afterAll(() => {
         vi.restoreAllMocks()
+    })
+    
+    it('includes speculation parameters when hot streak is enabled', async () => {
+        // Mock hot streak enabled
+        vi.spyOn(autoeditsConfig, 'isHotStreakEnabled').mockReturnValue(true)
+        
+        mockFetchSpy.mockResolvedValueOnce({
+            status: 200,
+            headers: new Headers(),
+            json: () => Promise.resolve({ choices: [{ message: { content: 'response' } }] }),
+        })
+        
+        const generator = await adapter.getModelResponse(options)
+        await generator.next() // Trigger the API call
+        
+        const requestBody = JSON.parse(mockFetchSpy.mock.calls[0][1].body)
+        expect(requestBody).toEqual(
+            expect.objectContaining({
+                rewrite_speculation: true,
+                adaptive_speculation: true,
+                speculation_length_on_strong_match: 500,
+                speculation_min_length_on_strong_match: 500,
+                speculation_strong_match_threshold: 20
+            })
+        )
+    })
+    
+    it('does not include speculation parameters when hot streak is disabled', async () => {
+        // Mock hot streak disabled
+        vi.spyOn(autoeditsConfig, 'isHotStreakEnabled').mockReturnValue(false)
+        
+        mockFetchSpy.mockResolvedValueOnce({
+            status: 200,
+            headers: new Headers(),
+            json: () => Promise.resolve({ choices: [{ message: { content: 'response' } }] }),
+        })
+        
+        const generator = await adapter.getModelResponse(options)
+        await generator.next() // Trigger the API call
+        
+        const requestBody = JSON.parse(mockFetchSpy.mock.calls[0][1].body)
+        expect(requestBody.rewrite_speculation).toBeUndefined()
+        expect(requestBody.adaptive_speculation).toBeUndefined()
+        expect(requestBody.speculation_length_on_strong_match).toBeUndefined()
+        expect(requestBody.speculation_min_length_on_strong_match).toBeUndefined()
+        expect(requestBody.speculation_strong_match_threshold).toBeUndefined()
     })
 
     it('sends correct request parameters for chat model', async () => {

--- a/vscode/src/autoedits/adapters/cody-gateway.test.ts
+++ b/vscode/src/autoedits/adapters/cody-gateway.test.ts
@@ -48,20 +48,20 @@ describe('CodyGatewayAdapter', () => {
     afterAll(() => {
         vi.restoreAllMocks()
     })
-    
+
     it('includes speculation parameters when hot streak is enabled', async () => {
         // Mock hot streak enabled
         vi.spyOn(autoeditsConfig, 'isHotStreakEnabled').mockReturnValue(true)
-        
+
         mockFetchSpy.mockResolvedValueOnce({
             status: 200,
             headers: new Headers(),
             json: () => Promise.resolve({ choices: [{ message: { content: 'response' } }] }),
         })
-        
+
         const generator = await adapter.getModelResponse(options)
         await generator.next() // Trigger the API call
-        
+
         const requestBody = JSON.parse(mockFetchSpy.mock.calls[0][1].body)
         expect(requestBody).toEqual(
             expect.objectContaining({
@@ -69,24 +69,24 @@ describe('CodyGatewayAdapter', () => {
                 adaptive_speculation: true,
                 speculation_length_on_strong_match: 500,
                 speculation_min_length_on_strong_match: 500,
-                speculation_strong_match_threshold: 20
+                speculation_strong_match_threshold: 20,
             })
         )
     })
-    
+
     it('does not include speculation parameters when hot streak is disabled', async () => {
         // Mock hot streak disabled
         vi.spyOn(autoeditsConfig, 'isHotStreakEnabled').mockReturnValue(false)
-        
+
         mockFetchSpy.mockResolvedValueOnce({
             status: 200,
             headers: new Headers(),
             json: () => Promise.resolve({ choices: [{ message: { content: 'response' } }] }),
         })
-        
+
         const generator = await adapter.getModelResponse(options)
         await generator.next() // Trigger the API call
-        
+
         const requestBody = JSON.parse(mockFetchSpy.mock.calls[0][1].body)
         expect(requestBody.rewrite_speculation).toBeUndefined()
         expect(requestBody.adaptive_speculation).toBeUndefined()

--- a/vscode/src/autoedits/adapters/cody-gateway.ts
+++ b/vscode/src/autoedits/adapters/cody-gateway.ts
@@ -8,6 +8,7 @@ import { getFireworksModelResponse } from './model-response/fireworks'
 import {
     type AutoeditsRequestBody,
     type FireworksCompatibleRequestParams,
+    getFireworksCompatibleRewriteSpeculationParams,
     getMaxOutputTokensForAutoedits,
     getOpenaiCompatibleChatPrompt,
 } from './utils'
@@ -92,8 +93,8 @@ export class CodyGatewayAdapter implements AutoeditsModelAdapter {
                 content: options.codeToRewrite,
             },
             user: options.userId || undefined,
+            ...getFireworksCompatibleRewriteSpeculationParams(),
         }
-
         if (options.isChatModel) {
             return {
                 ...baseBody,

--- a/vscode/src/autoedits/adapters/fireworks-websocket.test.ts
+++ b/vscode/src/autoedits/adapters/fireworks-websocket.test.ts
@@ -65,7 +65,7 @@ describe('FireworksWebsocketAdapter', () => {
     it('includes speculation parameters when hot streak is enabled', async () => {
         // Mock hot streak enabled
         vi.spyOn(autoeditsConfig, 'isHotStreakEnabled').mockReturnValue(true)
-        
+
         messageFn.mockReturnValueOnce(
             JSON.stringify({
                 'x-message-id': 'm_0',
@@ -79,27 +79,27 @@ describe('FireworksWebsocketAdapter', () => {
                 'x-message-status-text': 'OK',
             })
         )
-        
+
         const generator = await adapter.getModelResponse(options)
         await generator.next()
-        
+
         // Get the request object directly from the mock call
         const request = messageFn.mock.calls[0][0]
-        expect(request["x-message-body"]).toEqual(
+        expect(request['x-message-body']).toEqual(
             expect.objectContaining({
                 rewrite_speculation: true,
                 adaptive_speculation: true,
                 speculation_length_on_strong_match: 500,
                 speculation_min_length_on_strong_match: 500,
-                speculation_strong_match_threshold: 20
+                speculation_strong_match_threshold: 20,
             })
         )
     })
-    
+
     it('does not include speculation parameters when hot streak is disabled', async () => {
         // Mock hot streak disabled
         vi.spyOn(autoeditsConfig, 'isHotStreakEnabled').mockReturnValue(false)
-        
+
         messageFn.mockReturnValueOnce(
             JSON.stringify({
                 'x-message-id': 'm_0',
@@ -113,13 +113,13 @@ describe('FireworksWebsocketAdapter', () => {
                 'x-message-status-text': 'OK',
             })
         )
-        
+
         const generator = await adapter.getModelResponse(options)
         await generator.next()
-        
+
         // Get the request object directly from the mock call
         const request = messageFn.mock.calls[0][0]
-        const body = request["x-message-body"]
+        const body = request['x-message-body']
         expect(body.rewrite_speculation).toBeUndefined()
         expect(body.adaptive_speculation).toBeUndefined()
         expect(body.speculation_length_on_strong_match).toBeUndefined()

--- a/vscode/src/autoedits/adapters/fireworks-websocket.test.ts
+++ b/vscode/src/autoedits/adapters/fireworks-websocket.test.ts
@@ -44,6 +44,7 @@ describe('FireworksWebsocketAdapter', () => {
         server.addListener('connection', client => {
             client.addEventListener('message', event => {
                 const request = JSON.parse(event.data as string)
+                // Pass the parsed request to messageFn
                 const response = messageFn(request)
                 client.send(response)
             })
@@ -59,6 +60,71 @@ describe('FireworksWebsocketAdapter', () => {
         adapter.dispose()
         vi.clearAllTimers()
         vi.restoreAllMocks()
+    })
+
+    it('includes speculation parameters when hot streak is enabled', async () => {
+        // Mock hot streak enabled
+        vi.spyOn(autoeditsConfig, 'isHotStreakEnabled').mockReturnValue(true)
+        
+        messageFn.mockReturnValueOnce(
+            JSON.stringify({
+                'x-message-id': 'm_0',
+                'x-message-headers': {},
+                'x-message-body': {
+                    data: {
+                        choices: [{ message: { content: 'response' } }],
+                    },
+                },
+                'x-message-status': 200,
+                'x-message-status-text': 'OK',
+            })
+        )
+        
+        const generator = await adapter.getModelResponse(options)
+        await generator.next()
+        
+        // Get the request object directly from the mock call
+        const request = messageFn.mock.calls[0][0]
+        expect(request["x-message-body"]).toEqual(
+            expect.objectContaining({
+                rewrite_speculation: true,
+                adaptive_speculation: true,
+                speculation_length_on_strong_match: 500,
+                speculation_min_length_on_strong_match: 500,
+                speculation_strong_match_threshold: 20
+            })
+        )
+    })
+    
+    it('does not include speculation parameters when hot streak is disabled', async () => {
+        // Mock hot streak disabled
+        vi.spyOn(autoeditsConfig, 'isHotStreakEnabled').mockReturnValue(false)
+        
+        messageFn.mockReturnValueOnce(
+            JSON.stringify({
+                'x-message-id': 'm_0',
+                'x-message-headers': {},
+                'x-message-body': {
+                    data: {
+                        choices: [{ message: { content: 'response' } }],
+                    },
+                },
+                'x-message-status': 200,
+                'x-message-status-text': 'OK',
+            })
+        )
+        
+        const generator = await adapter.getModelResponse(options)
+        await generator.next()
+        
+        // Get the request object directly from the mock call
+        const request = messageFn.mock.calls[0][0]
+        const body = request["x-message-body"]
+        expect(body.rewrite_speculation).toBeUndefined()
+        expect(body.adaptive_speculation).toBeUndefined()
+        expect(body.speculation_length_on_strong_match).toBeUndefined()
+        expect(body.speculation_min_length_on_strong_match).toBeUndefined()
+        expect(body.speculation_strong_match_threshold).toBeUndefined()
     })
 
     it('sends correct request parameters for chat model', async () => {

--- a/vscode/src/autoedits/adapters/fireworks-websocket.ts
+++ b/vscode/src/autoedits/adapters/fireworks-websocket.ts
@@ -15,6 +15,7 @@ import type { FireworksResponse } from './model-response/fireworks'
 import {
     type AutoeditsRequestBody,
     type FireworksCompatibleRequestParams,
+    getFireworksCompatibleRewriteSpeculationParams,
     getMaxOutputTokensForAutoedits,
     getOpenaiCompatibleChatPrompt,
 } from './utils'
@@ -119,6 +120,7 @@ export class FireworksWebSocketAdapter implements AutoeditsModelAdapter {
                 content: options.codeToRewrite,
             },
             user: options.userId || undefined,
+            ...getFireworksCompatibleRewriteSpeculationParams(),
         }
 
         if (options.isChatModel) {

--- a/vscode/src/autoedits/adapters/fireworks.test.ts
+++ b/vscode/src/autoedits/adapters/fireworks.test.ts
@@ -44,6 +44,50 @@ describe('FireworksAdapter', () => {
         vi.restoreAllMocks()
     })
 
+    it('includes speculation parameters when hot streak is enabled', async () => {
+        vi.spyOn(autoeditsConfig, 'isHotStreakEnabled').mockReturnValue(true)
+
+        mockFetchSpy.mockResolvedValueOnce({
+            status: 200,
+            headers: new Headers(),
+            json: () => Promise.resolve({ choices: [{ message: { content: 'response' } }] }),
+        })
+
+        const generator = await adapter.getModelResponse(options)
+        await generator.next() // Trigger the API call
+
+        const requestBody = JSON.parse(mockFetchSpy.mock.calls[0][1].body)
+        expect(requestBody).toEqual(
+            expect.objectContaining({
+                rewrite_speculation: true,
+                adaptive_speculation: true,
+                speculation_length_on_strong_match: 500,
+                speculation_min_length_on_strong_match: 500,
+                speculation_strong_match_threshold: 20
+            })
+        )
+    })
+
+    it('does not include speculation parameters when hot streak is disabled', async () => {
+        vi.spyOn(autoeditsConfig, 'isHotStreakEnabled').mockReturnValue(false)
+
+        mockFetchSpy.mockResolvedValueOnce({
+            status: 200,
+            headers: new Headers(),
+            json: () => Promise.resolve({ choices: [{ message: { content: 'response' } }] }),
+        })
+
+        const generator = await adapter.getModelResponse(options)
+        await generator.next() // Trigger the API call
+
+        const requestBody = JSON.parse(mockFetchSpy.mock.calls[0][1].body)
+        expect(requestBody.rewrite_speculation).toBeUndefined()
+        expect(requestBody.adaptive_speculation).toBeUndefined()
+        expect(requestBody.speculation_length_on_strong_match).toBeUndefined()
+        expect(requestBody.speculation_min_length_on_strong_match).toBeUndefined()
+        expect(requestBody.speculation_strong_match_threshold).toBeUndefined()
+    })
+
     it('sends correct request parameters for chat model', async () => {
         mockFetchSpy.mockResolvedValueOnce({
             status: 200,

--- a/vscode/src/autoedits/adapters/fireworks.test.ts
+++ b/vscode/src/autoedits/adapters/fireworks.test.ts
@@ -63,7 +63,7 @@ describe('FireworksAdapter', () => {
                 adaptive_speculation: true,
                 speculation_length_on_strong_match: 500,
                 speculation_min_length_on_strong_match: 500,
-                speculation_strong_match_threshold: 20
+                speculation_strong_match_threshold: 20,
             })
         )
     })

--- a/vscode/src/autoedits/adapters/fireworks.ts
+++ b/vscode/src/autoedits/adapters/fireworks.ts
@@ -7,6 +7,7 @@ import { getFireworksModelResponse } from './model-response/fireworks'
 import {
     type AutoeditsRequestBody,
     type FireworksCompatibleRequestParams,
+    getFireworksCompatibleRewriteSpeculationParams,
     getMaxOutputTokensForAutoedits,
     getOpenaiCompatibleChatPrompt,
 } from './utils'
@@ -83,6 +84,7 @@ export class FireworksAdapter implements AutoeditsModelAdapter {
                 content: options.codeToRewrite,
             },
             user: options.userId || undefined,
+            ...getFireworksCompatibleRewriteSpeculationParams(),
         }
 
         if (options.isChatModel) {

--- a/vscode/src/autoedits/adapters/sourcegraph-chat.test.ts
+++ b/vscode/src/autoedits/adapters/sourcegraph-chat.test.ts
@@ -4,6 +4,8 @@ import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { AutoeditModelOptions, SuccessModelResponse } from './base'
 import { SourcegraphChatAdapter } from './sourcegraph-chat'
 import { getMaxOutputTokensForAutoedits } from './utils'
+import * as autoeditsConfig from '../autoedits-config'
+
 
 describe('SourcegraphChatAdapter', () => {
     let adapter: SourcegraphChatAdapter
@@ -39,6 +41,60 @@ describe('SourcegraphChatAdapter', () => {
 
     afterAll(() => {
         vi.restoreAllMocks()
+    })
+
+    it('includes rewrite speculation parameters when hot streak is enabled', async () => {
+        vi.spyOn(autoeditsConfig, 'isHotStreakEnabled').mockReturnValue(true)
+
+        const mockChat = vi.fn().mockResolvedValue({
+            async *[Symbol.asyncIterator]() {
+                yield { type: 'change', text: 'response' }
+                yield { type: 'complete' }
+            },
+        })
+
+        mockChatClient.chat = mockChat
+
+        const generator = await adapter.getModelResponse(options)
+        await generator.next()
+
+        // Extract the options passed to chat
+        const [_, chatOptions] = mockChat.mock.calls[0]
+
+        // Verify rewrite speculation parameters
+        expect(chatOptions).toMatchObject({
+            rewriteSpeculation: true,
+            adaptiveSpeculation: true,
+            speculationLengthOnStrongMatch: 500,
+            speculationMinLengthOnStrongMatch: 500,
+            speculationStrongMatchThreshold: 20
+        })
+    })
+
+    it('does not include rewrite speculation parameters when hot streak is disabled', async () => {
+        vi.spyOn(autoeditsConfig, 'isHotStreakEnabled').mockReturnValue(false)
+
+        const mockChat = vi.fn().mockResolvedValue({
+            async *[Symbol.asyncIterator]() {
+                yield { type: 'change', text: 'response' }
+                yield { type: 'complete' }
+            },
+        })
+
+        mockChatClient.chat = mockChat
+
+        const generator = await adapter.getModelResponse(options)
+        await generator.next()
+
+        // Extract the options passed to chat
+        const [_, chatOptions] = mockChat.mock.calls[0]
+
+        // Verify no rewrite speculation parameters
+        expect(chatOptions.rewriteSpeculation).toBeUndefined()
+        expect(chatOptions.adaptiveSpeculation).toBeUndefined()
+        expect(chatOptions.speculationLengthOnStrongMatch).toBeUndefined()
+        expect(chatOptions.speculationMinLengthOnStrongMatch).toBeUndefined()
+        expect(chatOptions.speculationStrongMatchThreshold).toBeUndefined()
     })
 
     it('sends correct request parameters', async () => {

--- a/vscode/src/autoedits/adapters/sourcegraph-chat.test.ts
+++ b/vscode/src/autoedits/adapters/sourcegraph-chat.test.ts
@@ -1,11 +1,10 @@
 import { ps } from '@sourcegraph/cody-shared'
 import type { ChatClient } from '@sourcegraph/cody-shared'
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as autoeditsConfig from '../autoedits-config'
 import type { AutoeditModelOptions, SuccessModelResponse } from './base'
 import { SourcegraphChatAdapter } from './sourcegraph-chat'
 import { getMaxOutputTokensForAutoedits } from './utils'
-import * as autoeditsConfig from '../autoedits-config'
-
 
 describe('SourcegraphChatAdapter', () => {
     let adapter: SourcegraphChatAdapter
@@ -67,7 +66,7 @@ describe('SourcegraphChatAdapter', () => {
             adaptiveSpeculation: true,
             speculationLengthOnStrongMatch: 500,
             speculationMinLengthOnStrongMatch: 500,
-            speculationStrongMatchThreshold: 20
+            speculationStrongMatchThreshold: 20,
         })
     })
 

--- a/vscode/src/autoedits/adapters/sourcegraph-chat.ts
+++ b/vscode/src/autoedits/adapters/sourcegraph-chat.ts
@@ -6,7 +6,11 @@ import {
     type AutoeditsModelAdapter,
     type ModelResponse,
 } from './base'
-import { getMaxOutputTokensForAutoedits, getSourcegraphCompatibleChatPrompt } from './utils'
+import {
+    getMaxOutputTokensForAutoedits,
+    getSourcegraphCompatibleChatPrompt,
+    getSourcegraphRewriteSpeculationParams,
+} from './utils'
 
 export class SourcegraphChatAdapter implements AutoeditsModelAdapter {
     constructor(private readonly chatClient: ChatClient) {}
@@ -48,6 +52,7 @@ export class SourcegraphChatAdapter implements AutoeditsModelAdapter {
                     type: 'content',
                     content: option.codeToRewrite,
                 },
+                ...getSourcegraphRewriteSpeculationParams(),
             },
             option.abortSignal
         )

--- a/vscode/src/autoedits/adapters/sourcegraph-completions.test.ts
+++ b/vscode/src/autoedits/adapters/sourcegraph-completions.test.ts
@@ -4,6 +4,7 @@ import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { AutoeditModelOptions, SuccessModelResponse } from './base'
 import { SourcegraphCompletionsAdapter } from './sourcegraph-completions'
 import { getMaxOutputTokensForAutoedits } from './utils'
+import * as autoeditsConfig from '../autoedits-config'
 
 describe('SourcegraphCompletionsAdapter', () => {
     let adapter: SourcegraphCompletionsAdapter
@@ -37,6 +38,60 @@ describe('SourcegraphCompletionsAdapter', () => {
 
     afterAll(() => {
         vi.restoreAllMocks()
+    })
+    
+    it('includes rewrite speculation parameters when hot streak is enabled', async () => {
+        vi.spyOn(autoeditsConfig, 'isHotStreakEnabled').mockReturnValue(true)
+        
+        const mockComplete = vi.fn().mockResolvedValue({
+            async *[Symbol.asyncIterator]() {
+                yield { completionResponse: { completion: 'response' } }
+            },
+        })
+        
+        mockCompletionsClient.complete = mockComplete
+        // @ts-ignore - accessing private property for testing
+        adapter.client = mockCompletionsClient
+        
+        await adapter.getModelResponse(options)
+        
+        // Extract parameters passed to complete
+        const [params] = mockComplete.mock.calls[0]
+        
+        // Verify rewrite speculation parameters
+        expect(params).toMatchObject({
+            rewriteSpeculation: true,
+            adaptiveSpeculation: true,
+            speculationLengthOnStrongMatch: 500,
+            speculationMinLengthOnStrongMatch: 500,
+            speculationStrongMatchThreshold: 20
+        })
+    })
+    
+    it('does not include rewrite speculation parameters when hot streak is disabled', async () => {
+        vi.spyOn(autoeditsConfig, 'isHotStreakEnabled').mockReturnValue(false)
+        
+        const mockComplete = vi.fn().mockResolvedValue({
+            async *[Symbol.asyncIterator]() {
+                yield { completionResponse: { completion: 'response' } }
+            },
+        })
+        
+        mockCompletionsClient.complete = mockComplete
+        // @ts-ignore - accessing private property for testing
+        adapter.client = mockCompletionsClient
+        
+        await adapter.getModelResponse(options)
+        
+        // Extract parameters passed to complete
+        const [params] = mockComplete.mock.calls[0]
+        
+        // Verify no rewrite speculation parameters
+        expect(params.rewriteSpeculation).toBeUndefined()
+        expect(params.adaptiveSpeculation).toBeUndefined()
+        expect(params.speculationLengthOnStrongMatch).toBeUndefined()
+        expect(params.speculationMinLengthOnStrongMatch).toBeUndefined()
+        expect(params.speculationStrongMatchThreshold).toBeUndefined()
     })
 
     it('sends correct request parameters', async () => {

--- a/vscode/src/autoedits/adapters/sourcegraph-completions.test.ts
+++ b/vscode/src/autoedits/adapters/sourcegraph-completions.test.ts
@@ -1,10 +1,10 @@
 import type { CodeCompletionsClient } from '@sourcegraph/cody-shared'
 import { ps } from '@sourcegraph/cody-shared'
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as autoeditsConfig from '../autoedits-config'
 import type { AutoeditModelOptions, SuccessModelResponse } from './base'
 import { SourcegraphCompletionsAdapter } from './sourcegraph-completions'
 import { getMaxOutputTokensForAutoedits } from './utils'
-import * as autoeditsConfig from '../autoedits-config'
 
 describe('SourcegraphCompletionsAdapter', () => {
     let adapter: SourcegraphCompletionsAdapter
@@ -39,53 +39,53 @@ describe('SourcegraphCompletionsAdapter', () => {
     afterAll(() => {
         vi.restoreAllMocks()
     })
-    
+
     it('includes rewrite speculation parameters when hot streak is enabled', async () => {
         vi.spyOn(autoeditsConfig, 'isHotStreakEnabled').mockReturnValue(true)
-        
+
         const mockComplete = vi.fn().mockResolvedValue({
             async *[Symbol.asyncIterator]() {
                 yield { completionResponse: { completion: 'response' } }
             },
         })
-        
+
         mockCompletionsClient.complete = mockComplete
         // @ts-ignore - accessing private property for testing
         adapter.client = mockCompletionsClient
-        
+
         await adapter.getModelResponse(options)
-        
+
         // Extract parameters passed to complete
         const [params] = mockComplete.mock.calls[0]
-        
+
         // Verify rewrite speculation parameters
         expect(params).toMatchObject({
             rewriteSpeculation: true,
             adaptiveSpeculation: true,
             speculationLengthOnStrongMatch: 500,
             speculationMinLengthOnStrongMatch: 500,
-            speculationStrongMatchThreshold: 20
+            speculationStrongMatchThreshold: 20,
         })
     })
-    
+
     it('does not include rewrite speculation parameters when hot streak is disabled', async () => {
         vi.spyOn(autoeditsConfig, 'isHotStreakEnabled').mockReturnValue(false)
-        
+
         const mockComplete = vi.fn().mockResolvedValue({
             async *[Symbol.asyncIterator]() {
                 yield { completionResponse: { completion: 'response' } }
             },
         })
-        
+
         mockCompletionsClient.complete = mockComplete
         // @ts-ignore - accessing private property for testing
         adapter.client = mockCompletionsClient
-        
+
         await adapter.getModelResponse(options)
-        
+
         // Extract parameters passed to complete
         const [params] = mockComplete.mock.calls[0]
-        
+
         // Verify no rewrite speculation parameters
         expect(params.rewriteSpeculation).toBeUndefined()
         expect(params.adaptiveSpeculation).toBeUndefined()

--- a/vscode/src/autoedits/adapters/sourcegraph-completions.ts
+++ b/vscode/src/autoedits/adapters/sourcegraph-completions.ts
@@ -16,7 +16,11 @@ import {
     type AutoeditsModelAdapter,
     type ModelResponse,
 } from './base'
-import { getMaxOutputTokensForAutoedits, getSourcegraphCompatibleChatPrompt } from './utils'
+import {
+    getMaxOutputTokensForAutoedits,
+    getSourcegraphCompatibleChatPrompt,
+    getSourcegraphRewriteSpeculationParams,
+} from './utils'
 
 export class SourcegraphCompletionsAdapter implements AutoeditsModelAdapter {
     private client: CodeCompletionsClient
@@ -27,6 +31,7 @@ export class SourcegraphCompletionsAdapter implements AutoeditsModelAdapter {
     dispose() {}
 
     async getModelResponse(options: AutoeditModelOptions): Promise<AsyncGenerator<ModelResponse>> {
+        const speculationParams = getSourcegraphRewriteSpeculationParams()
         try {
             const maxTokens = getMaxOutputTokensForAutoedits(options.codeToRewrite)
             const messages: Message[] = getSourcegraphCompatibleChatPrompt({
@@ -43,8 +48,8 @@ export class SourcegraphCompletionsAdapter implements AutoeditsModelAdapter {
                     type: 'content',
                     content: options.codeToRewrite,
                 },
+                ...speculationParams,
             }
-
             const abortController = forkSignal(options.abortSignal)
             const completionResponseGenerator = await this.client.complete(requestBody, abortController)
             return this.processCompletionResponse(completionResponseGenerator, options, requestBody)

--- a/vscode/src/autoedits/adapters/utils.ts
+++ b/vscode/src/autoedits/adapters/utils.ts
@@ -1,7 +1,21 @@
-import { type Message, type PromptString, charsToTokens } from '@sourcegraph/cody-shared'
+import {
+    type CompletionsRewriteSpeculationParams,
+    type Message,
+    type PromptString,
+    charsToTokens,
+} from '@sourcegraph/cody-shared'
+import { isHotStreakEnabled } from '../autoedits-config'
 import type { InceptionLabsRequestParams } from './inceptionlabs'
 
-export interface FireworksCompatibleRequestParams {
+export interface FireworksCompatibleRewriteSpeculationArgs {
+    rewrite_speculation?: boolean
+    adaptive_speculation?: boolean
+    speculation_length_on_strong_match?: number
+    speculation_min_length_on_strong_match?: number
+    speculation_strong_match_threshold?: number
+}
+
+export interface FireworksCompatibleRequestParams extends FireworksCompatibleRewriteSpeculationArgs {
     stream: boolean
     model: string
     temperature: number
@@ -13,8 +27,6 @@ export interface FireworksCompatibleRequestParams {
         type: string
         content: string
     }
-    rewrite_speculation?: boolean
-    adaptive_speculation?: boolean
     user?: string
 }
 
@@ -64,4 +76,30 @@ export function getSourcegraphCompatibleChatPrompt(param: {
     }
     prompt.push({ speaker: 'human', text: param.userMessage })
     return prompt
+}
+
+export function getFireworksCompatibleRewriteSpeculationParams(): FireworksCompatibleRewriteSpeculationArgs {
+    if (!isHotStreakEnabled()) {
+        return {}
+    }
+    return {
+        rewrite_speculation: true,
+        adaptive_speculation: true,
+        speculation_length_on_strong_match: 500,
+        speculation_min_length_on_strong_match: 500,
+        speculation_strong_match_threshold: 20,
+    }
+}
+
+export function getSourcegraphRewriteSpeculationParams(): CompletionsRewriteSpeculationParams {
+    if (!isHotStreakEnabled()) {
+        return {}
+    }
+    return {
+        rewriteSpeculation: true,
+        adaptiveSpeculation: true,
+        speculationLengthOnStrongMatch: 500,
+        speculationMinLengthOnStrongMatch: 500,
+        speculationStrongMatchThreshold: 20,
+    }
 }

--- a/vscode/src/autoedits/adapters/utils.ts
+++ b/vscode/src/autoedits/adapters/utils.ts
@@ -8,10 +8,15 @@ import { isHotStreakEnabled } from '../autoedits-config'
 import type { InceptionLabsRequestParams } from './inceptionlabs'
 
 export interface FireworksCompatibleRewriteSpeculationArgs {
+    // Rewrite speculation enabled speculating the tokens from predicted outputs even after first token mis-match.
     rewrite_speculation?: boolean
+    // Adaptive speculation adjust the length of speculation tokens dynamically.
     adaptive_speculation?: boolean
+    // Number of tokens to speculate.
     speculation_length_on_strong_match?: number
+    // Minimum number of tokens to speculate.
     speculation_min_length_on_strong_match?: number
+    // Speculation threshold.
     speculation_strong_match_threshold?: number
 }
 
@@ -82,6 +87,8 @@ export function getFireworksCompatibleRewriteSpeculationParams(): FireworksCompa
     if (!isHotStreakEnabled()) {
         return {}
     }
+    // The rewrite speculation parameter values are decided based on the offline experiments.
+    // Check the PR https://github.com/sourcegraph/cody-chat-eval/pull/157 for more details.
     return {
         rewrite_speculation: true,
         adaptive_speculation: true,

--- a/vscode/src/autoedits/autoedits-config.ts
+++ b/vscode/src/autoedits/autoedits-config.ts
@@ -66,7 +66,7 @@ featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.CodyAutoEditHotStreak).subs
 /**
  * Determines if hot streak mode should be enabled based on feature flag and settings.
  */
-function isHotStreakEnabled(): boolean {
+export function isHotStreakEnabled(): boolean {
     return hotStreakEnabled || isHotStreakEnabledInSettings()
 }
 


### PR DESCRIPTION
- Fix the NCP `auto-edit` model configuration as per latency evaluation.
- Backend PR https://github.com/sourcegraph/sourcegraph/pull/5190
- Evaluation PRs:
  - https://github.com/sourcegraph/cody-chat-eval/pull/157
  - https://github.com/sourcegraph/cody-chat-eval/pull/159

![CleanShot 2025-05-05 at 1  22 33@2x](https://github.com/user-attachments/assets/625dd577-afd2-4b46-b9f2-898b72d344ff)

![CleanShot 2025-05-05 at 1  22 54@2x](https://github.com/user-attachments/assets/2c82aab6-130d-4a47-8d2c-ab120116dfd8)

## Test plan
Added unit tests

