### PR TITLE
fix(auto-edit): dispose next cursor manager

### DIFF
--- a/vscode/src/autoedits/autoedits-provider.ts
+++ b/vscode/src/autoedits/autoedits-provider.ts
@@ -248,6 +248,7 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
             this.contextMixer,
             this.rendererManager,
             this.modelAdapter,
+            this.nextCursorManager,
             vscode.window.onDidChangeTextEditorSelection(this.onSelectionChangeDebounced),
             vscode.workspace.onDidChangeTextDocument(event => {
                 this.onDidChangeTextDocument(event)


### PR DESCRIPTION
Since we didn't unregister the next cursor manager, it caused a duplicate registered command runtime error. This error stopped autoedit from working right after switching accounts. This PR fixes it by adding the next cursor manager to the disposables list.

## Test plan

1. Trigger autoedit and verify that it works — suggestions are rendered.
2. Switch account
3. Trigger autoedit and verify that it works — suggestions are rendered.
