### PR TITLE
feat(auto-edit): add `readyToBeRendered` state to the analytics logger

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/AutoeditRequestStateForAgentTesting.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/AutoeditRequestStateForAgentTesting.kt
@@ -2,7 +2,7 @@
 package com.sourcegraph.cody.agent.protocol_generated;
 
 data class AutoeditRequestStateForAgentTesting(
-  val phase: Phase? = null, // Oneof: started, contextLoaded, loaded, postProcessed, suggested, read, accepted, rejected, discarded
+  val phase: Phase? = null, // Oneof: started, contextLoaded, loaded, postProcessed, readyToBeRendered, suggested, read, accepted, rejected, discarded
   val read: Boolean? = null,
 )
 

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/Constants.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/Constants.kt
@@ -99,6 +99,7 @@ object Constants {
   const val priority = "priority"
   const val pro = "pro"
   const val read = "read"
+  const val readyToBeRendered = "readyToBeRendered"
   const val reasoning = "reasoning"
   const val `recently-used` = "recently used"
   const val recommended = "recommended"

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/Phase.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/Phase.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
 package com.sourcegraph.cody.agent.protocol_generated;
 
-typealias Phase = String // One of: started, contextLoaded, loaded, postProcessed, suggested, read, accepted, rejected, discarded
+typealias Phase = String // One of: started, contextLoaded, loaded, postProcessed, readyToBeRendered, suggested, read, accepted, rejected, discarded
 

--- a/vscode/src/autoedits/adapters/sourcegraph-completions.ts
+++ b/vscode/src/autoedits/adapters/sourcegraph-completions.ts
@@ -64,18 +64,15 @@ export class SourcegraphCompletionsAdapter implements AutoeditsModelAdapter {
         requestBody: CodeCompletionsParams
     ): AsyncGenerator<ModelResponse> {
         let prediction = ''
-        let responseBody: any = null
-        let responseHeaders: Record<string, string> = {}
-        let requestHeaders: Record<string, string> = {}
-        let requestUrl = options.url
         let isAborted = false
 
+        // Create a shared result object that will be updated
         const sharedResult = {
-            responseHeaders,
-            requestHeaders,
-            requestUrl,
+            responseHeaders: {} as Record<string, string>,
+            requestHeaders: {} as Record<string, string>,
+            requestUrl: options.url,
             requestBody,
-            responseBody,
+            responseBody: null as any,
         }
 
         for await (const msg of completionResponseGenerator) {
@@ -88,19 +85,19 @@ export class SourcegraphCompletionsAdapter implements AutoeditsModelAdapter {
             if (msg.metadata) {
                 if (msg.metadata.response) {
                     // Extract headers into a plain object
-                    responseHeaders = {}
+                    sharedResult.responseHeaders = {}
                     msg.metadata.response.headers.forEach((value, key) => {
-                        responseHeaders[key] = value
+                        sharedResult.responseHeaders[key] = value
                     })
                 }
 
                 // Capture request metadata
                 if (msg.metadata.requestHeaders) {
-                    requestHeaders = msg.metadata.requestHeaders
+                    sharedResult.requestHeaders = msg.metadata.requestHeaders
                 }
 
                 if (msg.metadata.requestUrl) {
-                    requestUrl = msg.metadata.requestUrl
+                    sharedResult.requestUrl = msg.metadata.requestUrl
                 }
 
                 if (msg.metadata.isAborted) {
@@ -109,7 +106,7 @@ export class SourcegraphCompletionsAdapter implements AutoeditsModelAdapter {
 
                 // Store the full response body if available
                 if (msg.completionResponse) {
-                    responseBody = msg.completionResponse
+                    sharedResult.responseBody = msg.completionResponse
                 }
             }
 

--- a/vscode/src/autoedits/analytics-logger/analytics-logger.test.ts
+++ b/vscode/src/autoedits/analytics-logger/analytics-logger.test.ts
@@ -117,11 +117,7 @@ describe('AutoeditAnalyticsLogger', () => {
 
         autoeditLogger.markAsLoaded({
             requestId,
-            cacheId: uuid.v4() as AutoeditCacheID,
             prompt: modelOptions.prompt,
-            codeToReplaceData: codeToReplace,
-            predictionDocContext: docContext,
-            editPosition: position,
             modelResponse: {
                 type: 'success',
                 stopReason: AutoeditStopReason.RequestFinished,
@@ -135,11 +131,18 @@ describe('AutoeditAnalyticsLogger', () => {
                 prediction,
                 source: autoeditSource.network,
                 isFuzzyMatch: false,
-                codeToRewrite: 'Code to rewrite',
             },
         })
 
         autoeditLogger.markAsPostProcessed({
+            requestId,
+            cacheId: uuid.v4() as AutoeditCacheID,
+            codeToReplaceData: codeToReplace,
+            predictionDocContext: docContext,
+            editPosition: position,
+        })
+
+        autoeditLogger.markAsReadyToBeRendered({
             requestId,
             prediction,
             renderOutput: { type: 'none' },
@@ -209,7 +212,7 @@ describe('AutoeditAnalyticsLogger', () => {
               "category": "billable",
               "product": "cody",
             },
-            "interactionID": "stable-id-for-tests-3",
+            "interactionID": "stable-id-for-tests-2",
             "metadata": {
               "acceptReason": 1,
               "contextSummary.duration": 1.234,
@@ -261,7 +264,7 @@ describe('AutoeditAnalyticsLogger', () => {
                 "unchangedLines": 1,
               },
               "gatewayLatency": undefined,
-              "id": "stable-id-for-tests-3",
+              "id": "stable-id-for-tests-2",
               "inlineCompletionStats": undefined,
               "languageId": "typescript",
               "model": "autoedit-model",

--- a/vscode/src/autoedits/analytics-logger/analytics-logger.ts
+++ b/vscode/src/autoedits/analytics-logger/analytics-logger.ts
@@ -47,7 +47,7 @@ import {
     type SuggestedState,
     validRequestTransitions,
 } from './types'
-import type { AutoeditFeedbackData, HotStreakChunk } from './types'
+import type { AutoeditFeedbackData, HotStreakChunk, PostProcessedState } from './types'
 
 /**
  * Using the validTransitions definition, we can derive which "from phases" lead to a given next phase,
@@ -169,26 +169,14 @@ export class AutoeditAnalyticsLogger {
      */
     public markAsLoaded({
         requestId,
-        cacheId,
-        hotStreakId,
         prompt,
         payload,
         modelResponse,
-        codeToReplaceData,
-        predictionDocContext,
-        editPosition,
     }: {
         modelResponse: SuccessModelResponse | PartialModelResponse
-        codeToReplaceData: CodeToReplaceData
-        predictionDocContext: DocumentContext
         requestId: AutoeditRequestID
-        cacheId: AutoeditCacheID
-        hotStreakId?: AutoeditHotStreakID
         prompt: AutoeditsPrompt
-        editPosition: vscode.Position
-        payload: Required<
-            Pick<LoadedState['payload'], 'source' | 'isFuzzyMatch' | 'prediction' | 'codeToRewrite'>
-        >
+        payload: Required<Pick<LoadedState['payload'], 'source' | 'isFuzzyMatch' | 'prediction'>>
     }): void {
         const { prediction, source, isFuzzyMatch } = payload
         const stableId = autoeditIdRegistry.getOrCreate(prompt, prediction)
@@ -199,11 +187,6 @@ export class AutoeditAnalyticsLogger {
                 ...request,
                 loadedAt,
                 modelResponse,
-                codeToReplaceData,
-                predictionDocContext,
-                cacheId,
-                hotStreakId,
-                editPosition,
                 payload: {
                     ...request.payload,
                     id: stableId,
@@ -226,22 +209,48 @@ export class AutoeditAnalyticsLogger {
     }: {
         requestId: AutoeditRequestID
         hotStreakId: AutoeditHotStreakID
-        chunk: Omit<HotStreakChunk, 'loadedAt'>
+        chunk: Omit<HotStreakChunk, 'loadedAt' | 'hotStreakId'>
     }) {
-        const request = this.activeRequests.get(requestId)
-        if (request && 'hotStreakId' in request && request.hotStreakId === hotStreakId) {
-            const hotStreakChunks = request.hotStreakChunks ?? []
-            hotStreakChunks.push({
-                loadedAt: getTimeNowInMillis(),
-                prediction: chunk.prediction,
-                modelResponse: chunk.modelResponse,
-                fullPrediction: chunk.fullPrediction,
-            })
-            this.activeRequests.set(requestId, { ...request, hotStreakChunks })
-        }
+        const request = this.activeRequests.get(requestId) as PostProcessedState
+        const hotStreakChunks = request.hotStreakChunks ?? []
+        hotStreakChunks.push({
+            hotStreakId,
+            loadedAt: getTimeNowInMillis(),
+            prediction: chunk.prediction,
+            modelResponse: chunk.modelResponse,
+            fullPrediction: chunk.fullPrediction,
+        })
+        this.activeRequests.set(requestId, { ...request, hotStreakChunks })
     }
 
     public markAsPostProcessed({
+        requestId,
+        cacheId,
+        hotStreakId,
+        codeToReplaceData,
+        predictionDocContext,
+        editPosition,
+    }: {
+        requestId: AutoeditRequestID
+        cacheId: AutoeditCacheID
+        hotStreakId?: AutoeditHotStreakID
+        codeToReplaceData: CodeToReplaceData
+        predictionDocContext: DocumentContext
+        editPosition: vscode.Position
+    }): void {
+        this.tryTransitionTo(requestId, 'postProcessed', request => {
+            return {
+                ...request,
+                codeToReplaceData,
+                predictionDocContext,
+                cacheId,
+                hotStreakId,
+                editPosition,
+            }
+        })
+    }
+
+    public markAsReadyToBeRendered({
         requestId,
         decorationInfo,
         prediction,
@@ -252,7 +261,7 @@ export class AutoeditAnalyticsLogger {
         decorationInfo: DecorationInfo | null
         renderOutput: AutoEditRenderOutput
     }) {
-        this.tryTransitionTo(requestId, 'postProcessed', request => {
+        this.tryTransitionTo(requestId, 'readyToBeRendered', request => {
             const completion =
                 'inlineCompletionItems' in renderOutput
                     ? renderOutput.inlineCompletionItems[0]

--- a/vscode/src/autoedits/debug-panel/autoedit-data-sdk.ts
+++ b/vscode/src/autoedits/debug-panel/autoedit-data-sdk.ts
@@ -1,5 +1,10 @@
 import type { InlineCompletionItemRetrievedContext } from '../../completions/analytics-logger'
 import type { ModelResponse, PartialModelResponse, SuccessModelResponse } from '../adapters/base'
+import type {
+    AutoeditDiscardReasonMetadata,
+    AutoeditTriggerKindMetadata,
+    HotStreakChunk,
+} from '../analytics-logger'
 import type { AutoEditRenderOutput } from '../renderer/render-output'
 import { getDetailedTimingInfo } from './autoedit-latency-utils'
 import type { AutoeditRequestDebugState } from './debug-store'
@@ -135,7 +140,7 @@ export const getContext = (entry: AutoeditRequestDebugState): InlineCompletionIt
  */
 export const getTriggerKind = (entry: AutoeditRequestDebugState): string => {
     if ('payload' in entry.state && 'triggerKind' in entry.state.payload) {
-        const triggerMap: Record<number, string> = {
+        const triggerMap: Record<AutoeditTriggerKindMetadata, string> = {
             1: 'Automatic',
             2: 'Manual',
             3: 'Suggest Widget',
@@ -163,7 +168,7 @@ export const getPositionInfo = (entry: AutoeditRequestDebugState): string => {
 /**
  * Map of discard reason codes to human-readable messages
  */
-export const DISCARD_REASONS: Record<number, string> = {
+export const DISCARD_REASONS: Record<AutoeditDiscardReasonMetadata, string> = {
     1: 'Client Aborted',
     2: 'Empty Prediction',
     3: 'Prediction Equals Code to Rewrite',
@@ -174,6 +179,7 @@ export const DISCARD_REASONS: Record<number, string> = {
     8: 'Conflicting Decoration With Edits',
     9: 'Not Enough Lines in Editor',
     10: 'Stale Throttled Request',
+    11: 'Next Cursor Suggestion Shown Instead',
 }
 
 /**
@@ -245,21 +251,6 @@ export const getRequestId = (entry: AutoeditRequestDebugState): string => {
 }
 
 /**
- * Format a trigger kind number into a readable string
- */
-export const formatTriggerKind = (triggerKind?: number): string => {
-    if (!triggerKind) return 'Unknown'
-
-    const triggerMap: Record<number, string> = {
-        1: 'Automatic',
-        2: 'Manual',
-        3: 'Suggest Widget',
-        4: 'Cursor',
-    }
-    return triggerMap[triggerKind] || 'Unknown'
-}
-
-/**
  * Get the prediction text if available
  */
 export const getPrediction = (entry: AutoeditRequestDebugState): string | null => {
@@ -307,11 +298,7 @@ export const getSuccessModelResponse = (
 /**
  * Get hot streak chunks if available
  */
-export const getHotStreakChunks = (
-    entry: AutoeditRequestDebugState
-):
-    | { prediction: string; loadedAt: number; modelResponse: ModelResponse; fullPrediction?: string }[]
-    | null => {
+export const getHotStreakChunks = (entry: AutoeditRequestDebugState): HotStreakChunk[] | null => {
     if (
         'hotStreakChunks' in entry.state &&
         Array.isArray(entry.state.hotStreakChunks) &&
@@ -379,7 +366,6 @@ export const AutoeditDataSDK = {
     getDecorationStats,
     getPayload,
     getRequestId,
-    formatTriggerKind,
     getPrediction,
     getDocument,
     getPosition,

--- a/vscode/src/completions/analytics-logger.ts
+++ b/vscode/src/completions/analytics-logger.ts
@@ -44,11 +44,11 @@ import {
 } from './get-inline-completions'
 import type { RequestParams } from './request-manager'
 import * as statistics from './statistics'
+import { lines } from './text-processing'
 import type {
     InlineCompletionItemWithAnalytics,
     InlineCompletionResponseHeaders,
 } from './text-processing/process-inline-completions'
-import { lines } from './text-processing/utils'
 import type { InlineCompletionItem } from './types'
 
 // A completion ID is a unique identifier for a specific completion text displayed at a specific

--- a/vscode/webviews/autoedit-debug/AutoeditDebugPanel.tsx
+++ b/vscode/webviews/autoedit-debug/AutoeditDebugPanel.tsx
@@ -68,6 +68,11 @@ export const AutoeditDebugPanel: FC<{
                     'editPosition' in a.state ? a.state.editPosition.line : a.state.position.line
                 const posB =
                     'editPosition' in b.state ? b.state.editPosition.line : b.state.position.line
+
+                if (posA === posB) {
+                    return a.state.startedAt - b.state.startedAt
+                }
+
                 return posA - posB
             })
         }


### PR DESCRIPTION
- Introduced new phases (`postProcessed` and `readyToBeRendered`) to better track the lifecycle of autoedit suggestions, along with corresponding state interfaces (`PostProcessedState` and `ReadyToBeRenderedState`). Updated valid state transitions to include these new phases. 
- Fixed the problem where response headers and body were not propagated to the auto-edit debug panel from the Sourcegraph completions adapter.
- Integrated the new analytics logger methods (`markAsLoaded`, `markAsPostProcessed`, and `markAsReadyToBeRendered`) into the `AutoeditsProvider` to align with the updated state management. This ensures we can view model responses for ignored/empty suggestions in the debug panel
- To ensure the correct order, sort hot-streak chunks in the debug panel by timestamp if the line number is identical.
- Closes [CODY-5721: Request body not showing in autoedit debug panel](https://linear.app/sourcegraph/issue/CODY-5721/request-body-not-showing-in-autoedit-debug-panel)

## Test plan

CI + manually test the auto-edit debug panel.