### PR TITLE
feat(autocomplete): better autocomplete support for gpt-4.1-mini

### DIFF
--- a/vscode/src/completions/model-helpers/index.ts
+++ b/vscode/src/completions/model-helpers/index.ts
@@ -6,6 +6,8 @@ import { DeepseekCoder } from './deepseek'
 import { DefaultModel } from './default'
 import { Gemini } from './gemini'
 import { Mistral } from './mistral'
+import { OpenAIV1 } from './openai'
+import { OpenAIV2 } from './openai-v2'
 import { StarCoder } from './starcoder'
 
 export * from './default'
@@ -45,6 +47,14 @@ export function getModelHelpers(model: string): DefaultModel {
 
     if (model.includes('claude')) {
         return new Claude()
+    }
+
+    if (model.includes('gpt-4.1-mini') || model.includes('gpt-4.1-nano')) {
+        return new OpenAIV2()
+    }
+
+    if (model.includes('openai')) {
+        return new OpenAIV1()
     }
 
     return new DefaultModel()

--- a/vscode/src/completions/providers/unstable-openai.ts
+++ b/vscode/src/completions/providers/unstable-openai.ts
@@ -1,7 +1,5 @@
 import type { CodeCompletionsParams } from '@sourcegraph/cody-shared'
 
-import { OpenAI } from '../model-helpers/openai'
-
 import {
     BYOK_MODEL_ID_FOR_LOGS,
     type GenerateCompletionsOptions,
@@ -10,8 +8,6 @@ import {
 } from './shared/provider'
 
 class UnstableOpenAIProvider extends Provider {
-    protected modelHelper = new OpenAI()
-
     public getRequestParams(generateOptions: GenerateCompletionsOptions): CodeCompletionsParams {
         const { document, docContext, snippets } = generateOptions
 

--- a/vscode/src/completions/text-processing/utils.ts
+++ b/vscode/src/completions/text-processing/utils.ts
@@ -21,7 +21,11 @@ export const CLOSING_CODE_TAG = ps`</CODE5711>`
  * @param completion The raw completion result received from Anthropic
  * @returns the extracted code block
  */
-export function extractFromCodeBlock(completion: string): string {
+export function extractFromCodeBlock(completion: string, allowOpeningCodeTag = false): string {
+    if (allowOpeningCodeTag && completion.startsWith(OPENING_CODE_TAG.toString())) {
+        completion = completion.slice(OPENING_CODE_TAG.length)
+    }
+
     if (completion.includes(OPENING_CODE_TAG.toString())) {
         logCompletionBookkeepingEvent('containsOpeningTag')
         return ''


### PR DESCRIPTION
- Use https://sg02.sourcegraphcloud.com/, where the gpt-4.1-mini is currently set as a default completion model. The test account credentials are in the 1Password note "Cody - Test Accounts".
- Thanks @taras-yemets for [a beautiful summary](https://linear.app/sourcegraph/issue/PROD-510/azure-openai-autocomplete-model-gpt-4o-mini-mercedes-leidos#comment-b90872d7) on how to configure the model.

## Test plan

- Manually plan with the model.
