### PR TITLE
fix(autocomplete): fix stop reason in the default completions client

### DIFF
--- a/vscode/src/completions/default-client.ts
+++ b/vscode/src/completions/default-client.ts
@@ -221,7 +221,10 @@ class DefaultCodeCompletionsClient implements CodeCompletionsClient {
                             throw new TracedError('No completion response received', traceId)
                         }
 
-                        if (!result.completionResponse.stopReason) {
+                        if (
+                            !result.completionResponse.stopReason ||
+                            result.completionResponse.stopReason === CompletionStopReason.StreamingChunk
+                        ) {
                             result.completionResponse.stopReason = CompletionStopReason.RequestFinished
                         }
 

--- a/vscode/src/completions/fast-path-client.ts
+++ b/vscode/src/completions/fast-path-client.ts
@@ -227,7 +227,10 @@ export function createFastPathClient(
                 throw new TracedError('No completion response received', traceId)
             }
 
-            if (!result.completionResponse.stopReason) {
+            if (
+                !result.completionResponse.stopReason ||
+                result.completionResponse.stopReason === CompletionStopReason.StreamingChunk
+            ) {
                 result.completionResponse.stopReason = CompletionStopReason.RequestFinished
             }
 

--- a/vscode/src/completions/providers/shared/fetch-and-process-completions.ts
+++ b/vscode/src/completions/providers/shared/fetch-and-process-completions.ts
@@ -119,6 +119,7 @@ export async function* fetchAndProcessDynamicMultilineCompletions(
             multiline,
             currentLinePrefix: docContext.currentLinePrefix,
             text: rawCompletion,
+            stopReason,
         })
 
         if (hotStreakExtractor) {


### PR DESCRIPTION
- While playing with https://github.com/sourcegraph/cody/pull/7871 I noticed that we do not yield the correct stop reason from the default completions client. Sometimes this prevents completions from being emitted to the inline completion items provider. 

## Test plan

CI + manual testing
