### PR TITLE
fix(analytics): enable characters logger for untitled doc

### DIFF
--- a/vscode/src/services/CharactersLogger.ts
+++ b/vscode/src/services/CharactersLogger.ts
@@ -165,7 +165,7 @@ export class CharactersLogger implements vscode.Disposable {
     }
 
     private async onDidChangeTextDocument(event: vscode.TextDocumentChangeEvent): Promise<void> {
-        if (!isFileURI(event.document.uri)) {
+        if (event.document.uri.scheme !== 'untitled' && !isFileURI(event.document.uri)) {
             return
         }
 


### PR DESCRIPTION
- Enables the Characters Logger support for untitled docs.
- Related [Slack thread](https://sourcegraph.slack.com/archives/C04MSD3DP5L/p1746564961790279).

## Test plan

CI + manually test the character logger locally:
- Open a new untitled document
- Insert N characters
- cmd+P to execute a debug command: "Log character logger counters"
- Verify that counters match the number of inserted chars.
