### PR TITLE
fix(auto-edit): Handle stuck decorations, refactor decorators

### DIFF
--- a/vscode/src/autoedits/autoedits-provider.test.ts
+++ b/vscode/src/autoedits/autoedits-provider.test.ts
@@ -386,6 +386,14 @@ describe('AutoeditsProvider', () => {
             [
               "setContext",
               "cody.supersuggest.active",
+              false,
+            ],
+            [
+              "editor.action.inlineSuggest.hide",
+            ],
+            [
+              "setContext",
+              "cody.supersuggest.active",
               true,
             ],
             [
@@ -409,57 +417,96 @@ describe('AutoeditsProvider', () => {
         const prediction = 'const x = 1\n'
         await autoeditResultFor('const x = █\n', { prediction })
         expect(executedCommands).toMatchInlineSnapshot(`
-            []
+          [
+            [
+              "setContext",
+              "cody.supersuggest.active",
+              false,
+            ],
+            [
+              "editor.action.inlineSuggest.hide",
+            ],
+          ]
         `)
     })
 
     it('set the cody.supersuggest.active context for inline decoration items', async () => {
         const prediction = 'const a = 1\n'
         await autoeditResultFor('const x = █\n', { prediction })
-        expect(executedCommands).toMatchInlineSnapshot(`
-            [
-              [
-                "setContext",
-                "cody.supersuggest.active",
-                true,
-              ],
-            ]
-        `)
-        await acceptSuggestionCommand()
-
-        // Deactives the context after accepting the suggestion
-        expect(executedCommands.length).toBe(3)
-        expect(executedCommands[1]).toMatchInlineSnapshot(`
+        const currentExecutedCommands = [...executedCommands]
+        expect(currentExecutedCommands).toMatchInlineSnapshot(`
+          [
             [
               "setContext",
               "cody.supersuggest.active",
               false,
-            ]
+            ],
+            [
+              "editor.action.inlineSuggest.hide",
+            ],
+            [
+              "setContext",
+              "cody.supersuggest.active",
+              true,
+            ],
+          ]
+        `)
+        await acceptSuggestionCommand()
+
+        // Deactives the context after accepting the suggestion
+        const nextExecutedCommands = executedCommands.slice(currentExecutedCommands.length)
+        expect(nextExecutedCommands.length).toBe(2)
+        expect(nextExecutedCommands).toMatchInlineSnapshot(`
+          [
+            [
+              "setContext",
+              "cody.supersuggest.active",
+              false,
+            ],
+            [
+              "editor.action.inlineSuggest.hide",
+            ],
+          ]
         `)
     })
 
     it('unset the cody.supersuggest.active context for inline decoration rejection', async () => {
         const prediction = 'const a = 1\n'
         await autoeditResultFor('const x = █\n', { prediction })
-        expect(executedCommands).toMatchInlineSnapshot(`
-            [
-              [
-                "setContext",
-                "cody.supersuggest.active",
-                true,
-              ],
-            ]
-        `)
-        await rejectSuggestionCommand()
-
-        // Deactives the context after accepting the suggestion
-        expect(executedCommands.length).toBe(3)
-        expect(executedCommands[1]).toMatchInlineSnapshot(`
+        const currentExecutedCommands = [...executedCommands]
+        expect(currentExecutedCommands).toMatchInlineSnapshot(`
+          [
             [
               "setContext",
               "cody.supersuggest.active",
               false,
-            ]
+            ],
+            [
+              "editor.action.inlineSuggest.hide",
+            ],
+            [
+              "setContext",
+              "cody.supersuggest.active",
+              true,
+            ],
+          ]
+        `)
+        await rejectSuggestionCommand()
+
+        const nextExecutedCommands = executedCommands.slice(currentExecutedCommands.length)
+        // Deactives the context after accepting the suggestion
+        expect(nextExecutedCommands.length).toBe(2)
+        expect(nextExecutedCommands).toMatchInlineSnapshot(`
+          [
+            [
+              "setContext",
+              "cody.supersuggest.active",
+              false,
+            ],
+            [
+              "editor.action.inlineSuggest.hide",
+            ],
+          ]
         `)
     })
 

--- a/vscode/src/autoedits/autoedits-provider.ts
+++ b/vscode/src/autoedits/autoedits-provider.ts
@@ -57,7 +57,6 @@ import type { AutoeditsUserPromptStrategy } from './prompt/base'
 import { createPromptProvider } from './prompt/create-prompt-provider'
 import { getCodeToReplaceData } from './prompt/prompt-utils/code-to-replace'
 import { getCurrentFilePath } from './prompt/prompt-utils/common'
-import { InlineDiffDecorator } from './renderer/decorators/inline-diff-decorator'
 import { getAddedLines, getDecorationInfoFromPrediction } from './renderer/diff-utils'
 import { initImageSuggestionService } from './renderer/image-gen'
 import { AutoEditsRendererManager } from './renderer/manager'
@@ -224,11 +223,7 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
             allowUsingWebSocket: this.features.allowUsingWebSocket,
         })
 
-        this.rendererManager = new AutoEditsRendererManager(
-            editor => new InlineDiffDecorator(editor),
-            fixupController,
-            this.requestManager
-        )
+        this.rendererManager = new AutoEditsRendererManager(fixupController, this.requestManager)
 
         this.onSelectionChangeDebounced = debounce(
             (event: vscode.TextEditorSelectionChangeEvent) => this.onSelectionChange(event),

--- a/vscode/src/autoedits/autoedits-provider.ts
+++ b/vscode/src/autoedits/autoedits-provider.ts
@@ -667,7 +667,10 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
             }
 
             if ('decorations' in renderOutput) {
-                await this.rendererManager.renderInlineDecorations(renderOutput.decorations)
+                await this.rendererManager.renderInlineDecorations(
+                    document.uri,
+                    renderOutput.decorations
+                )
             }
 
             if ('inlineCompletionItems' in renderOutput) {

--- a/vscode/src/autoedits/renderer/decorators/base.ts
+++ b/vscode/src/autoedits/renderer/decorators/base.ts
@@ -64,8 +64,6 @@ export interface AutoEditsDecorator extends vscode.Disposable {
 
     /**
      * Hides decorations from all editors where they might be shown
-     *
-     * @param uri The document URI where decorations should be applied
      */
     hideDecorations(): void
 }

--- a/vscode/src/autoedits/renderer/decorators/base.ts
+++ b/vscode/src/autoedits/renderer/decorators/base.ts
@@ -63,11 +63,11 @@ export interface AutoEditsDecorator extends vscode.Disposable {
     setDecorations(uri: vscode.Uri, decorations: AutoEditDecorations): void
 
     /**
-     * Hides decorations from an editor
+     * Hides decorations from all editors where they might be shown
      *
      * @param uri The document URI where decorations should be applied
      */
-    hideDecorations(uri: vscode.Uri): void
+    hideDecorations(): void
 }
 
 /**

--- a/vscode/src/autoedits/renderer/decorators/base.ts
+++ b/vscode/src/autoedits/renderer/decorators/base.ts
@@ -56,10 +56,18 @@ export interface AutoEditsDecorator extends vscode.Disposable {
     /**
      * Applies decorations to the editor based on the provided decoration information.
      *
+     * @param uri The document URI where decorations should be applied
      * @param decorationInfo Contains the line-by-line information about text changes
      *        and how they should be decorated in the editor.
      */
-    setDecorations(decorations: AutoEditDecorations): void
+    setDecorations(uri: vscode.Uri, decorations: AutoEditDecorations): void
+
+    /**
+     * Hides decorations from an editor
+     *
+     * @param uri The document URI where decorations should be applied
+     */
+    hideDecorations(uri: vscode.Uri): void
 }
 
 /**

--- a/vscode/src/autoedits/renderer/decorators/inline-diff-decorator.ts
+++ b/vscode/src/autoedits/renderer/decorators/inline-diff-decorator.ts
@@ -20,15 +20,12 @@ export class InlineDiffDecorator implements vscode.Disposable, AutoEditsDecorato
         editor.setDecorations(this.insertMarkerDecorationType, decorations.insertMarkerDecorations)
     }
 
-    public hideDecorations(uri: vscode.Uri): void {
-        const editor = this.getEditorForUri(uri)
-        if (!editor) {
-            return
+    public hideDecorations(): void {
+        for (const editor of vscode.window.visibleTextEditors) {
+            editor.setDecorations(this.addedTextDecorationType, [])
+            editor.setDecorations(this.removedTextDecorationType, [])
+            editor.setDecorations(this.insertMarkerDecorationType, [])
         }
-
-        editor.setDecorations(this.addedTextDecorationType, [])
-        editor.setDecorations(this.removedTextDecorationType, [])
-        editor.setDecorations(this.insertMarkerDecorationType, [])
     }
 
     private getEditorForUri(uri: vscode.Uri): vscode.TextEditor | undefined {

--- a/vscode/src/autoedits/renderer/decorators/inline-diff-decorator.ts
+++ b/vscode/src/autoedits/renderer/decorators/inline-diff-decorator.ts
@@ -9,15 +9,32 @@ export class InlineDiffDecorator implements vscode.Disposable, AutoEditsDecorato
         borderWidth: '1px 1px 0 0',
     })
 
-    constructor(private readonly editor: vscode.TextEditor) {}
-
-    setDecorations(decorations: AutoEditDecorations): void {
-        if (!decorations) {
-            throw new Error('InlineDiffDecorator relies on pre-computed decorations')
+    public setDecorations(uri: vscode.Uri, decorations: AutoEditDecorations): void {
+        const editor = this.getEditorForUri(uri)
+        if (!editor) {
+            return
         }
-        this.editor.setDecorations(this.addedTextDecorationType, decorations.insertionDecorations)
-        this.editor.setDecorations(this.removedTextDecorationType, decorations.deletionDecorations)
-        this.editor.setDecorations(this.insertMarkerDecorationType, decorations.insertMarkerDecorations)
+
+        editor.setDecorations(this.addedTextDecorationType, decorations.insertionDecorations)
+        editor.setDecorations(this.removedTextDecorationType, decorations.deletionDecorations)
+        editor.setDecorations(this.insertMarkerDecorationType, decorations.insertMarkerDecorations)
+    }
+
+    public hideDecorations(uri: vscode.Uri): void {
+        const editor = this.getEditorForUri(uri)
+        if (!editor) {
+            return
+        }
+
+        editor.setDecorations(this.addedTextDecorationType, [])
+        editor.setDecorations(this.removedTextDecorationType, [])
+        editor.setDecorations(this.insertMarkerDecorationType, [])
+    }
+
+    private getEditorForUri(uri: vscode.Uri): vscode.TextEditor | undefined {
+        return vscode.window.visibleTextEditors.find(
+            editor => editor.document.uri.toString() === uri.toString()
+        )
     }
 
     public dispose(): void {

--- a/vscode/src/autoedits/renderer/diff-utils.ts
+++ b/vscode/src/autoedits/renderer/diff-utils.ts
@@ -300,6 +300,63 @@ export function isSimpleLineDiff(changes: LineChange[]): boolean {
 }
 
 /**
+ * Checks if the changes are clean replacements.
+ * For example:
+ * 1. Unchanged -> Insertion/Deletion -> Unchanged
+ * 2. Unchanged -> Insertion -> Deletion -> Unchanged
+ * 3. Unchanged -> Deletion -> Insertion -> Unchanged
+ *
+ * A "dirty" replacement is where we end up with 3 or more deletions/insertions that are adjacent
+ * For example:
+ * 1. Insertion -> Deletion -> Insertion -> Unchanged
+ */
+function hasCleanReplacements(changes: LineChange[]): boolean {
+    const segments: { type: 'unchanged' | 'modification'; changes: LineChange[] }[] = []
+    let currentSegment: { type: 'unchanged' | 'modification'; changes: LineChange[] } | null = null
+
+    for (const change of changes) {
+        const isModification = change.type === 'insert' || change.type === 'delete'
+        const segmentType = isModification ? 'modification' : 'unchanged'
+
+        if (!currentSegment || currentSegment.type !== segmentType) {
+            if (currentSegment) {
+                segments.push(currentSegment)
+            }
+            currentSegment = { type: segmentType, changes: [change] }
+        } else {
+            currentSegment.changes.push(change)
+        }
+    }
+
+    if (currentSegment) {
+        segments.push(currentSegment)
+    }
+
+    // Check for clean replacement patterns:
+    // 1. Unchanged -> Modification -> Unchanged
+    // 2. Unchanged? -> Modification -> Unchanged?
+    if (segments.length <= 3) {
+        if (segments.length === 1) {
+            return segments[0].type === 'unchanged'
+        }
+
+        if (segments.length === 2) {
+            return segments.some(segment => segment.type === 'unchanged')
+        }
+
+        // For 3 segments, we expect: Unchanged -> Modification -> Unchanged
+        return (
+            segments[0].type === 'unchanged' &&
+            segments[1].type === 'modification' &&
+            segments[2].type === 'unchanged'
+        )
+    }
+
+    // Too many segments or unexpected pattern
+    return false
+}
+
+/**
  * Creates a ModifiedLineInfo object by computing insertions and deletions within a line.
  */
 function createModifiedLineInfo(params: {

--- a/vscode/src/autoedits/renderer/diff-utils.ts
+++ b/vscode/src/autoedits/renderer/diff-utils.ts
@@ -300,62 +300,6 @@ export function isSimpleLineDiff(changes: LineChange[]): boolean {
 }
 
 /**
- * Checks if the changes are clean replacements.
- * For example:
- * 1. Unchanged -> Insertion/Deletion -> Unchanged
- * 2. Unchanged -> Insertion -> Deletion -> Unchanged
- * 3. Unchanged -> Deletion -> Insertion -> Unchanged
- *
- * A "dirty" replacement is where we end up with 3 or more deletions/insertions that are adjacent
- * For example:
- * 1. Insertion -> Deletion -> Insertion -> Unchanged
- */
-function hasCleanReplacements(changes: LineChange[]): boolean {
-    const segments: { type: 'unchanged' | 'modification'; changes: LineChange[] }[] = []
-    let currentSegment: { type: 'unchanged' | 'modification'; changes: LineChange[] } | null = null
-
-    for (const change of changes) {
-        const isModification = change.type === 'insert' || change.type === 'delete'
-        const segmentType = isModification ? 'modification' : 'unchanged'
-
-        if (!currentSegment || currentSegment.type !== segmentType) {
-            if (currentSegment) {
-                segments.push(currentSegment)
-            }
-            // First change, always simple at this point
-            continue
-        }
-
-        const incomingModification = incomingChange.type !== 'unchanged'
-        if (lastChange.isReplacement && incomingModification) {
-            // We just had a replacement and now we have another change.
-            // This creates a diff that is difficult to read
-            return false
-        }
-
-        if (incomingChange.type === 'unchanged') {
-            // Check if the unchanged text contains some whitespace, this is an indicator
-            // that we can use this to seperate multiple changes without worrying about
-            // the diff splitting words into multiple change chunks
-            const isSuitableSeparator = /\s/.test(incomingChange.text)
-            const isLastChange = i === changes.length - 1
-            if (!isSuitableSeparator && !isLastChange) {
-                return false
-            }
-            lastChange = { type: incomingChange.type, isReplacement: false }
-            continue
-        }
-
-        lastChange = {
-            type: incomingChange.type,
-            isReplacement: lastChange.type !== 'unchanged',
-        }
-    }
-
-    return true
-}
-
-/**
  * Creates a ModifiedLineInfo object by computing insertions and deletions within a line.
  */
 function createModifiedLineInfo(params: {

--- a/vscode/src/autoedits/renderer/manager.test.ts
+++ b/vscode/src/autoedits/renderer/manager.test.ts
@@ -12,7 +12,6 @@ import { getCodeToReplaceForRenderer } from '../prompt/test-helper'
 import { AutoEditsRendererManager } from '../renderer/manager'
 
 import { RequestManager } from '../request-manager'
-import { InlineDiffDecorator } from './decorators/inline-diff-decorator'
 import type { TryMakeInlineCompletionsArgs } from './manager'
 import type { CompletionRenderOutput } from './render-output'
 
@@ -57,11 +56,7 @@ describe('AutoEditsDefaultRendererManager', () => {
         const fixupController = new FixupController(extensionClient)
 
         beforeEach(() => {
-            manager = new AutoEditsRendererManager(
-                (editor: vscode.TextEditor) => new InlineDiffDecorator(editor),
-                fixupController,
-                new RequestManager()
-            )
+            manager = new AutoEditsRendererManager(fixupController, new RequestManager())
         })
 
         const assertInlineCompletionItems = (

--- a/vscode/src/autoedits/renderer/manager.ts
+++ b/vscode/src/autoedits/renderer/manager.ts
@@ -21,6 +21,7 @@ import type { RequestManager } from '../request-manager'
 import { areSameUriDocs } from '../utils'
 
 import type { AutoEditDecorations, AutoEditsDecorator, DecorationInfo } from './decorators/base'
+import { InlineDiffDecorator } from './decorators/inline-diff-decorator'
 import { AutoEditsRenderOutput } from './render-output'
 
 export interface TryMakeInlineCompletionsArgs {
@@ -39,7 +40,7 @@ export class AutoEditsRendererManager extends AutoEditsRenderOutput {
     // Keeps track of the current active edit (there can only be one active edit at a time)
     protected activeRequestId: AutoeditRequestID | null = null
     protected disposables: vscode.Disposable[] = []
-    protected decorator: AutoEditsDecorator | null = null
+    protected decorator: AutoEditsDecorator = new InlineDiffDecorator()
 
     /**
      * The amount of time before we consider a suggestion to be "visible" to the user.
@@ -47,7 +48,6 @@ export class AutoEditsRendererManager extends AutoEditsRenderOutput {
     private autoeditSuggestedTimeoutId: NodeJS.Timeout | undefined
 
     constructor(
-        protected createDecorator: (editor: vscode.TextEditor) => AutoEditsDecorator,
         protected fixupController: FixupController,
         // Used to remove cached suggestions when one is accepted or rejected.
         protected requestManager: RequestManager
@@ -192,12 +192,7 @@ export class AutoEditsRendererManager extends AutoEditsRenderOutput {
     protected get activeRequest() {
         if (this.activeRequestId) {
             const request = autoeditAnalyticsLogger.getRequest(this.activeRequestId)
-            if (
-                request &&
-                'renderOutput' in request &&
-                request.renderOutput.type !== 'none' &&
-                this.decorator
-            ) {
+            if (request && 'renderOutput' in request && request.renderOutput.type !== 'none') {
                 return request
             }
         }
@@ -251,7 +246,6 @@ export class AutoEditsRendererManager extends AutoEditsRenderOutput {
             return
         }
 
-        this.decorator = this.createDecorator(vscode.window.activeTextEditor!)
         this.activeRequestId = requestId
         autoeditAnalyticsLogger.markAsSuggested(requestId)
 
@@ -336,27 +330,27 @@ export class AutoEditsRendererManager extends AutoEditsRenderOutput {
         })
     }
 
-    protected async handleDidHideSuggestion(decorator: AutoEditsDecorator | null): Promise<void> {
-        if (decorator) {
-            decorator.dispose()
-            // Hide inline decorations
-            await vscode.commands.executeCommand('setContext', 'cody.supersuggest.active', false)
-        }
+    protected async handleDidHideSuggestion(uri: vscode.Uri): Promise<void> {
+        // Hide inline decorations
+        this.decorator.hideDecorations()
+        await vscode.commands.executeCommand('setContext', 'cody.supersuggest.active', false)
 
         // Hide inline completion provider item ghost text
         await vscode.commands.executeCommand('editor.action.inlineSuggest.hide')
 
         this.activeRequestId = null
-        this.decorator = null
     }
 
     public handleDidAcceptCompletionItem(requestId: AutoeditRequestID): Promise<void> {
         return this.acceptActiveEdit(autoeditAcceptReason.acceptCommand)
     }
 
-    protected async acceptActiveEdit(acceptReason: AutoeditAcceptReasonMetadata): Promise<void> {
+    protected async acceptActiveEdit(
+        acceptReason: AutoeditAcceptReasonMetadata,
+        uri: vscode.Uri
+    ): Promise<void> {
         const editor = vscode.window.activeTextEditor
-        const { activeRequest, decorator } = this
+        const { activeRequest } = this
 
         // Compute this variable before the `handleDidHideSuggestion` call which removes the active request.
         const hasInlineDecorations = this.hasInlineDecorations()
@@ -366,7 +360,7 @@ export class AutoEditsRendererManager extends AutoEditsRenderOutput {
             !activeRequest ||
             !areSameUriDocs(editor.document, this.activeRequest?.document)
         ) {
-            return this.rejectActiveEdit(autoeditRejectReason.acceptActiveEdit)
+            return this.rejectActiveEdit(autoeditRejectReason.acceptActiveEdit, uri)
         }
 
         this.requestManager.removeFromCache(activeRequest.cacheId)
@@ -374,7 +368,7 @@ export class AutoEditsRendererManager extends AutoEditsRenderOutput {
         // Reset the testing promise when accepting
         this.testing_completionSuggestedPromise = undefined
 
-        await this.handleDidHideSuggestion(decorator)
+        await this.handleDidHideSuggestion(activeRequest.document.uri)
         autoeditAnalyticsLogger.markAsAccepted({
             requestId: activeRequest.requestId,
             acceptReason,
@@ -402,8 +396,11 @@ export class AutoEditsRendererManager extends AutoEditsRenderOutput {
         })
     }
 
-    protected async rejectActiveEdit(rejectReason: AutoeditRejectReasonMetadata): Promise<void> {
-        const { activeRequest, decorator } = this
+    protected async rejectActiveEdit(
+        rejectReason: AutoeditRejectReasonMetadata,
+        uri: vscode.Uri
+    ): Promise<void> {
+        const { activeRequest } = this
 
         if (activeRequest) {
             this.requestManager.removeFromCache(activeRequest.cacheId)
@@ -412,9 +409,7 @@ export class AutoEditsRendererManager extends AutoEditsRenderOutput {
         // Reset the testing promise when rejecting
         this.testing_completionSuggestedPromise = undefined
 
-        if (decorator) {
-            await this.handleDidHideSuggestion(decorator)
-        }
+        await this.handleDidHideSuggestion(uri)
 
         if (activeRequest) {
             autoeditAnalyticsLogger.markAsRejected({

--- a/vscode/src/autoedits/renderer/manager.ts
+++ b/vscode/src/autoedits/renderer/manager.ts
@@ -357,7 +357,7 @@ export class AutoEditsRendererManager extends AutoEditsRenderOutput {
             !activeRequest ||
             !areSameUriDocs(editor.document, this.activeRequest?.document)
         ) {
-            return this.rejectActiveEdit(autoeditRejectReason.acceptActiveEdit, uri)
+            return this.rejectActiveEdit(autoeditRejectReason.acceptActiveEdit)
         }
 
         this.requestManager.removeFromCache(activeRequest.cacheId)

--- a/vscode/src/autoedits/renderer/manager.ts
+++ b/vscode/src/autoedits/renderer/manager.ts
@@ -330,7 +330,7 @@ export class AutoEditsRendererManager extends AutoEditsRenderOutput {
         })
     }
 
-    protected async handleDidHideSuggestion(uri: vscode.Uri): Promise<void> {
+    protected async handleDidHideSuggestion(): Promise<void> {
         // Hide inline decorations
         this.decorator.hideDecorations()
         await vscode.commands.executeCommand('setContext', 'cody.supersuggest.active', false)
@@ -345,10 +345,7 @@ export class AutoEditsRendererManager extends AutoEditsRenderOutput {
         return this.acceptActiveEdit(autoeditAcceptReason.acceptCommand)
     }
 
-    protected async acceptActiveEdit(
-        acceptReason: AutoeditAcceptReasonMetadata,
-        uri: vscode.Uri
-    ): Promise<void> {
+    protected async acceptActiveEdit(acceptReason: AutoeditAcceptReasonMetadata): Promise<void> {
         const editor = vscode.window.activeTextEditor
         const { activeRequest } = this
 
@@ -368,7 +365,7 @@ export class AutoEditsRendererManager extends AutoEditsRenderOutput {
         // Reset the testing promise when accepting
         this.testing_completionSuggestedPromise = undefined
 
-        await this.handleDidHideSuggestion(activeRequest.document.uri)
+        await this.handleDidHideSuggestion()
         autoeditAnalyticsLogger.markAsAccepted({
             requestId: activeRequest.requestId,
             acceptReason,
@@ -396,10 +393,7 @@ export class AutoEditsRendererManager extends AutoEditsRenderOutput {
         })
     }
 
-    protected async rejectActiveEdit(
-        rejectReason: AutoeditRejectReasonMetadata,
-        uri: vscode.Uri
-    ): Promise<void> {
+    protected async rejectActiveEdit(rejectReason: AutoeditRejectReasonMetadata): Promise<void> {
         const { activeRequest } = this
 
         if (activeRequest) {
@@ -409,7 +403,7 @@ export class AutoEditsRendererManager extends AutoEditsRenderOutput {
         // Reset the testing promise when rejecting
         this.testing_completionSuggestedPromise = undefined
 
-        await this.handleDidHideSuggestion(uri)
+        await this.handleDidHideSuggestion()
 
         if (activeRequest) {
             autoeditAnalyticsLogger.markAsRejected({
@@ -419,12 +413,11 @@ export class AutoEditsRendererManager extends AutoEditsRenderOutput {
         }
     }
 
-    public async renderInlineDecorations(decorations: AutoEditDecorations): Promise<void> {
-        if (!this.decorator) {
-            // No decorator to render the decorations
-            return
-        }
-        this.decorator.setDecorations(decorations)
+    public async renderInlineDecorations(
+        uri: vscode.Uri,
+        decorations: AutoEditDecorations
+    ): Promise<void> {
+        this.decorator.setDecorations(uri, decorations)
         await vscode.commands.executeCommand('setContext', 'cody.supersuggest.active', true)
     }
 


### PR DESCRIPTION
## Description

closes https://linear.app/sourcegraph/issue/CODY-5799/auto-edits-not-dismissable-in-vim-mode
closes https://linear.app/sourcegraph/issue/CODY-5747/floating-window-in-auto-edit-is-unresponsive-and-stuck

Refactors the decoration logic so we no longer recreate the decorator entirely for each new suggestion. This is much easier to reason with as there can only ever be one instance of a decoration at a time, and we don't need to worry about cases where we might show multiple types of the same decoration

## Test plan

Manual testing on cody-chat-eval examples

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
