### PR TITLE
fix(auto-edit): Only trim hot streak predictions when codeToReplace is missing a final new line

### DIFF
--- a/vscode/src/autoedits/autoedits-config.ts
+++ b/vscode/src/autoedits/autoedits-config.ts
@@ -53,7 +53,7 @@ export const defaultTokenLimit: AutoEditsTokenLimit = {
 
 export const hotStreakTokenLimit: AutoEditsTokenLimit = {
     ...defaultTokenLimit,
-    codeToRewritePrefixLines: 1,
+    codeToRewritePrefixLines: 4,
     codeToRewriteSuffixLines: 24,
     contextSpecificTokenLimit: {
         [RetrieverIdentifier.RecentEditsRetriever]: 1000,

--- a/vscode/src/autoedits/autoedits-config.ts
+++ b/vscode/src/autoedits/autoedits-config.ts
@@ -53,7 +53,7 @@ export const defaultTokenLimit: AutoEditsTokenLimit = {
 
 export const hotStreakTokenLimit: AutoEditsTokenLimit = {
     ...defaultTokenLimit,
-    codeToRewritePrefixLines: 4,
+    codeToRewritePrefixLines: 1,
     codeToRewriteSuffixLines: 24,
     contextSpecificTokenLimit: {
         [RetrieverIdentifier.RecentEditsRetriever]: 1000,

--- a/vscode/src/autoedits/hot-streak/get-chunk.test.ts
+++ b/vscode/src/autoedits/hot-streak/get-chunk.test.ts
@@ -301,7 +301,6 @@ describe('getHotStreakChunk', () => {
               // Check if numberToChange is 1
               if (numberToChange === 1) {
                   return false
-              }
           "
         `)
         expect(document.getText(result.range)).toMatchInlineSnapshot(`
@@ -314,7 +313,6 @@ describe('getHotStreakChunk', () => {
               // Check if numberToChange is 1
               if (numberToChange === 1) {
                   return false
-              }
           "
         `)
     })

--- a/vscode/src/autoedits/hot-streak/index.test.ts
+++ b/vscode/src/autoedits/hot-streak/index.test.ts
@@ -330,6 +330,7 @@ ${result.response.prediction}
               parser.add_argument('--project_id', help='Project ID')
 
               args = parser.parse_args()
+
           "
         `)
 


### PR DESCRIPTION
## Description

`codeToReplaceData` almost always ends in a new line, except for cases where the last line is at the very end of the document. This is because the range uses `rangeIncludingLineBreak` ([code](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/cody/-/blob/vscode/src/autoedits/prompt/prompt-utils/code-to-replace.ts?L74-80))

Instead of always trimming the final new line from the prediction, we should do it conditionally based on if the code to replace also has a new line

## Test plan

Manual testing.
Unit tests

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
