### PR TITLE
chore(auto-edit): Prepare hot-streak for dogfooding

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -66,7 +66,7 @@ export enum FeatureFlag {
     CodyAutoEditExperimentEnabledFeatureFlag = 'cody-autoedit-experiment-enabled-flag',
 
     // Enables hot-streak for autoedit suggestions
-    CodyAutoEditHotStreak = 'cody-autoedit-hot-streak-v1',
+    CodyAutoEditHotStreak = 'cody-autoedit-hot-streak-v2',
 
     // Enables gpt-4o-mini as a default Edit model
     CodyEditDefaultToGpt4oMini = 'cody-edit-default-to-gpt-4o-mini',

--- a/vscode/src/autoedits/hot-streak/__snapshots__/index.test.ts.snap
+++ b/vscode/src/autoedits/hot-streak/__snapshots__/index.test.ts.snap
@@ -27,6 +27,7 @@ export function isEvenOrOdd(target: number): boolean {
     // Check if target is 1
     if (numberToChange === 1) {
         return false
+    }
 
 Prediction:
 
@@ -36,6 +37,7 @@ export function isEvenOrOdd(target: number): boolean {
     }
     if (target === 1) {
         return false
+    }
 
             
 Code to Rewrite:
@@ -50,6 +52,7 @@ export function isEvenOrOdd(target: number): boolean {
     // Check if target is 2
     if (numberToChange === 2) {
         return true
+    }
 
 Prediction:
 
@@ -62,6 +65,7 @@ export function isEvenOrOdd(target: number): boolean {
     }
     if (target === 2) {
         return true
+    }
 
             
 Code to Rewrite:
@@ -79,6 +83,7 @@ export function isEvenOrOdd(target: number): boolean {
     // Check if target is 3
     if (numberToChange === 3) {
         return false
+    }
 
 Prediction:
 
@@ -94,6 +99,7 @@ export function isEvenOrOdd(target: number): boolean {
     }
     if (target === 3) {
         return false
+    }
 
             
 Code to Rewrite:
@@ -114,6 +120,7 @@ export function isEvenOrOdd(target: number): boolean {
     // Check if target is 4
     if (numberToChange === 4) {
         return true
+    }
 
 Prediction:
 
@@ -132,6 +139,7 @@ export function isEvenOrOdd(target: number): boolean {
     }
     if (target === 4) {
         return true
+    }
 
             
 Code to Rewrite:
@@ -155,6 +163,7 @@ export function isEvenOrOdd(target: number): boolean {
     // Check if target is 5
     if (numberToChange === 5) {
         return false
+    }
 
 Prediction:
 
@@ -176,6 +185,7 @@ export function isEvenOrOdd(target: number): boolean {
     }
     if (target === 5) {
         return false
+    }
 
             "
 `;

--- a/vscode/src/autoedits/hot-streak/__snapshots__/index.test.ts.snap
+++ b/vscode/src/autoedits/hot-streak/__snapshots__/index.test.ts.snap
@@ -13,6 +13,7 @@ export function isEvenOrOdd(numberToChange: number): boolean {
 Prediction:
 
 export function isEvenOrOdd(target: number): boolean {
+    // Check if target is 0
     if (target === 0) {
         return true
     }
@@ -21,6 +22,7 @@ export function isEvenOrOdd(target: number): boolean {
 Code to Rewrite:
 
 export function isEvenOrOdd(target: number): boolean {
+    // Check if target is 0
     if (target === 0) {
         return true
     }
@@ -32,9 +34,11 @@ export function isEvenOrOdd(target: number): boolean {
 Prediction:
 
 export function isEvenOrOdd(target: number): boolean {
+    // Check if target is 0
     if (target === 0) {
         return true
     }
+    // Check if target is 1
     if (target === 1) {
         return false
     }
@@ -43,9 +47,11 @@ export function isEvenOrOdd(target: number): boolean {
 Code to Rewrite:
 
 export function isEvenOrOdd(target: number): boolean {
+    // Check if target is 0
     if (target === 0) {
         return true
     }
+    // Check if target is 1
     if (target === 1) {
         return false
     }
@@ -57,12 +63,15 @@ export function isEvenOrOdd(target: number): boolean {
 Prediction:
 
 export function isEvenOrOdd(target: number): boolean {
+    // Check if target is 0
     if (target === 0) {
         return true
     }
+    // Check if target is 1
     if (target === 1) {
         return false
     }
+    // Check if target is 2
     if (target === 2) {
         return true
     }
@@ -71,12 +80,15 @@ export function isEvenOrOdd(target: number): boolean {
 Code to Rewrite:
 
 export function isEvenOrOdd(target: number): boolean {
+    // Check if target is 0
     if (target === 0) {
         return true
     }
+    // Check if target is 1
     if (target === 1) {
         return false
     }
+    // Check if target is 2
     if (target === 2) {
         return true
     }
@@ -88,15 +100,19 @@ export function isEvenOrOdd(target: number): boolean {
 Prediction:
 
 export function isEvenOrOdd(target: number): boolean {
+    // Check if target is 0
     if (target === 0) {
         return true
     }
+    // Check if target is 1
     if (target === 1) {
         return false
     }
+    // Check if target is 2
     if (target === 2) {
         return true
     }
+    // Check if target is 3
     if (target === 3) {
         return false
     }
@@ -105,15 +121,19 @@ export function isEvenOrOdd(target: number): boolean {
 Code to Rewrite:
 
 export function isEvenOrOdd(target: number): boolean {
+    // Check if target is 0
     if (target === 0) {
         return true
     }
+    // Check if target is 1
     if (target === 1) {
         return false
     }
+    // Check if target is 2
     if (target === 2) {
         return true
     }
+    // Check if target is 3
     if (target === 3) {
         return false
     }
@@ -125,18 +145,23 @@ export function isEvenOrOdd(target: number): boolean {
 Prediction:
 
 export function isEvenOrOdd(target: number): boolean {
+    // Check if target is 0
     if (target === 0) {
         return true
     }
+    // Check if target is 1
     if (target === 1) {
         return false
     }
+    // Check if target is 2
     if (target === 2) {
         return true
     }
+    // Check if target is 3
     if (target === 3) {
         return false
     }
+    // Check if target is 4
     if (target === 4) {
         return true
     }
@@ -145,18 +170,23 @@ export function isEvenOrOdd(target: number): boolean {
 Code to Rewrite:
 
 export function isEvenOrOdd(target: number): boolean {
+    // Check if target is 0
     if (target === 0) {
         return true
     }
+    // Check if target is 1
     if (target === 1) {
         return false
     }
+    // Check if target is 2
     if (target === 2) {
         return true
     }
+    // Check if target is 3
     if (target === 3) {
         return false
     }
+    // Check if target is 4
     if (target === 4) {
         return true
     }
@@ -168,21 +198,27 @@ export function isEvenOrOdd(target: number): boolean {
 Prediction:
 
 export function isEvenOrOdd(target: number): boolean {
+    // Check if target is 0
     if (target === 0) {
         return true
     }
+    // Check if target is 1
     if (target === 1) {
         return false
     }
+    // Check if target is 2
     if (target === 2) {
         return true
     }
+    // Check if target is 3
     if (target === 3) {
         return false
     }
+    // Check if target is 4
     if (target === 4) {
         return true
     }
+    // Check if target is 5
     if (target === 5) {
         return false
     }

--- a/vscode/src/autoedits/hot-streak/constants.ts
+++ b/vscode/src/autoedits/hot-streak/constants.ts
@@ -6,27 +6,10 @@
 export const SHOULD_ATTEMPT_HOT_STREAK_CHUNK_THRESHOLD = 5
 
 /**
- * Minimum number of lines that should be present in a hot-streak chunk before it is suggested to the user.
- * This is to avoid suggesting a hot-streak chunk that is too small and atomic.
- *
- * Note: This differs from `SHOULD_ATTEMPT_HOT_STREAK_CHUNK_THRESHOLD` in that the chunk is trimmed based on the
- * first stable "unchanged" area. This means that, even if the prediction meets this threshold, the actual chunk may
- * be smaller.
- *
- * Example for the above scenario:
- * 1. LLM produces a response that is 5 lines long, we deem it suitable to attempt a hot-streak chunk.
- * 2. Our diff logic finds that the first line changed, then we had 3 unchanged lines, then 1 changed line.
- * 3. To ensure we can reliably use the hot-streak chunk, our diff logic trims to chunk to the first unchanged area.
- *    This results in a total chunk length of 4.
- * 4. We don't want to use this chunk as it is too small.
- */
-export const SHOULD_USE_HOT_STREAK_CHUNK_THRESHOLD = 5
-
-/**
  * The amount of lines that should be present in a stable "unchanged" hunk before it is considered stable.
  * This is to help avoid false positives where the LLM produces new code which we similar to existing code below that
  * we mark as stable.
  *
  * Note: This can be tweaked to improve the stability of the partial diff.
  */
-export const SHOULD_USE_STABLE_UNCHANGED_HUNK_THRESHOLD = 2
+export const SHOULD_USE_STABLE_UNCHANGED_HUNK_THRESHOLD = 3

--- a/vscode/src/autoedits/hot-streak/constants.ts
+++ b/vscode/src/autoedits/hot-streak/constants.ts
@@ -21,3 +21,12 @@ export const SHOULD_ATTEMPT_HOT_STREAK_CHUNK_THRESHOLD = 5
  * 4. We don't want to use this chunk as it is too small.
  */
 export const SHOULD_USE_HOT_STREAK_CHUNK_THRESHOLD = 5
+
+/**
+ * The amount of lines that should be present in a stable "unchanged" hunk before it is considered stable.
+ * This is to help avoid false positives where the LLM produces new code which we similar to existing code below that
+ * we mark as stable.
+ *
+ * Note: This can be tweaked to improve the stability of the partial diff.
+ */
+export const SHOULD_USE_STABLE_UNCHANGED_HUNK_THRESHOLD = 2

--- a/vscode/src/autoedits/hot-streak/get-chunk.test.ts
+++ b/vscode/src/autoedits/hot-streak/get-chunk.test.ts
@@ -201,6 +201,14 @@ describe('getHotStreakChunk', () => {
               if (target === 0) {
                   return true
               }
+
+              // We are adding some comments
+              // To make a ...wonderful diff!
+
+              // Check if numberToChange is 1
+              if (numberToChange === 1) {
+                  return false
+              }
           "
         `)
         expect(document.getText(result.range)).toMatchInlineSnapshot(`
@@ -208,6 +216,11 @@ describe('getHotStreakChunk', () => {
               // Check if numberToChange is 0
               if (numberToChange === 0) {
                   return true
+              }
+
+              // Check if numberToChange is 1
+              if (numberToChange === 1) {
+                  return false
               }
           "
         `)

--- a/vscode/src/autoedits/hot-streak/index.test.ts
+++ b/vscode/src/autoedits/hot-streak/index.test.ts
@@ -78,21 +78,27 @@ const MOCK_CODE_WITHOUT_CURSOR = MOCK_CODE.replace('█', '')
 
 const MOCK_PREDICTION = `
 export function isEvenOrOdd(target: number): boolean {
+    // Check if target is 0
     if (target === 0) {
         return true
     }
+    // Check if target is 1
     if (target === 1) {
         return false
     }
+    // Check if target is 2
     if (target === 2) {
         return true
     }
+    // Check if target is 3
     if (target === 3) {
         return false
     }
+    // Check if target is 4
     if (target === 4) {
         return true
     }
+    // Check if target is 5
     if (target === 5) {
         return false
     }
@@ -111,7 +117,7 @@ function createHotStreakParams(
         maxPrefixLinesInArea: 2,
         maxSuffixLinesInArea: 2,
         codeToRewritePrefixLines: 1,
-        codeToRewriteSuffixLines: 30,
+        codeToRewriteSuffixLines: 40,
         prefixTokens: 100,
         suffixTokens: 100,
     })

--- a/vscode/src/autoedits/hot-streak/stable-suggestion.test.ts
+++ b/vscode/src/autoedits/hot-streak/stable-suggestion.test.ts
@@ -1,11 +1,23 @@
 import { describe, expect, it } from 'vitest'
 import { isStableUnchangedHunk } from './stable-suggestion'
 
+const STABLE_CHUNK = ['const a = 5;', 'const b = 6;', 'const c = 7;']
+
 describe('isStableUnchangedHunk', () => {
     it('should identify stable hunks with meaningful content', () => {
-        expect(isStableUnchangedHunk(['const a = 5;'])).toBe(true)
+        expect(isStableUnchangedHunk(STABLE_CHUNK)).toBe(true)
         expect(isStableUnchangedHunk(['function test() {', '  return true;', '}'])).toBe(true)
-        expect(isStableUnchangedHunk(['// A meaningful comment'])).toBe(true)
+        expect(
+            isStableUnchangedHunk([
+                '// A meaningful comment',
+                '// Another comment',
+                '// A final comment',
+            ])
+        ).toBe(true)
+    })
+
+    it('should reject hunks with meaningful content but not enough lines', () => {
+        expect(isStableUnchangedHunk(STABLE_CHUNK.slice(0, 2))).toBe(false)
     })
 
     it('should reject hunks with only brackets or delimiters', () => {
@@ -22,11 +34,11 @@ describe('isStableUnchangedHunk', () => {
         expect(isStableUnchangedHunk(['  '])).toBe(false)
         expect(isStableUnchangedHunk(['\n'])).toBe(false)
         expect(isStableUnchangedHunk(['  \n'])).toBe(false)
-        expect(isStableUnchangedHunk(['', 'const a = 5;'])).toBe(true)
+        expect(isStableUnchangedHunk(['', ...STABLE_CHUNK])).toBe(true)
     })
 
     it('should handle mixed content correctly', () => {
-        expect(isStableUnchangedHunk(['{', 'const a = 5;'])).toBe(true)
+        expect(isStableUnchangedHunk(['{', ...STABLE_CHUNK])).toBe(true)
         expect(isStableUnchangedHunk(['{}', '[]', 'const a = 5;'])).toBe(true)
         expect(isStableUnchangedHunk(['{', '}', '[]'])).toBe(false)
     })

--- a/vscode/src/autoedits/hot-streak/stable-suggestion.ts
+++ b/vscode/src/autoedits/hot-streak/stable-suggestion.ts
@@ -7,10 +7,7 @@ import type { PartialModelResponse, SuccessModelResponse } from '../adapters/bas
 import { shrinkPredictionUntilSuffix } from '../shrink-prediction'
 
 import { getNewLineChar } from '../../completions/text-processing'
-import {
-    SHOULD_USE_HOT_STREAK_CHUNK_THRESHOLD,
-    SHOULD_USE_STABLE_UNCHANGED_HUNK_THRESHOLD,
-} from './constants'
+import { SHOULD_USE_STABLE_UNCHANGED_HUNK_THRESHOLD } from './constants'
 
 // Helper enum for code readability when handling slices
 enum SliceKind {
@@ -101,10 +98,7 @@ export function getStableSuggestion({
                 continue
             }
 
-            const meetsLineThreshold =
-                response.type === 'success' ||
-                state.predictionLines.length >= SHOULD_USE_HOT_STREAK_CHUNK_THRESHOLD
-            if (state.predictionIncludesChange && meetsLineThreshold) {
+            if (state.predictionIncludesChange) {
                 state.canSuggestDiff = true
                 // We already have a change further up in the diff.
                 // As we have now reached an unchanged "stable" hunk, it means we can reliably

--- a/vscode/src/autoedits/hot-streak/stable-suggestion.ts
+++ b/vscode/src/autoedits/hot-streak/stable-suggestion.ts
@@ -7,7 +7,10 @@ import type { PartialModelResponse, SuccessModelResponse } from '../adapters/bas
 import { shrinkPredictionUntilSuffix } from '../shrink-prediction'
 
 import { getNewLineChar } from '../../completions/text-processing'
-import { SHOULD_USE_HOT_STREAK_CHUNK_THRESHOLD } from './constants'
+import {
+    SHOULD_USE_HOT_STREAK_CHUNK_THRESHOLD,
+    SHOULD_USE_STABLE_UNCHANGED_HUNK_THRESHOLD,
+} from './constants'
 
 // Helper enum for code readability when handling slices
 enum SliceKind {
@@ -171,6 +174,11 @@ const CODE_DELIMITER_REGEX = /^[\[\]{}().,;:]+$/
  * designed to improve the stability of a partial diff.
  */
 export function isStableUnchangedHunk(hunk: string[]): boolean {
+    if (hunk.length < SHOULD_USE_STABLE_UNCHANGED_HUNK_THRESHOLD) {
+        // Hunk isn't classed as big enough to be considered stable.
+        return false
+    }
+
     /**
      * Filter hunk lines to find relevant ones that:
      * 1. Contain more than just whitespace


### PR DESCRIPTION
## Description

Changes to prep hot streak for dogfooding:
1. Updates the hot-streak feature flag so we can enable it in the prerelease and ensure it's only used for people who have the latest stable version installed
2. Adds `SHOULD_USE_STABLE_UNCHANGED_HUNK_THRESHOLD` to help increase the stability of the partial diff

## Test plan

Enable flag, check hot streak shows

Unit tests

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
