### PR TITLE
fix(chat): Hide copy button in non-chat mode

### DIFF
--- a/vscode/webviews/chat/cells/messageCell/assistant/AssistantMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/assistant/AssistantMessageCell.tsx
@@ -164,11 +164,15 @@ export const AssistantMessageCell: FunctionComponent<{
                                 </div>
                             </div>
                         )}
-                        <div
-                            className={`tw-flex tw-items-center tw-justify-end tw-gap-4  ${styles.buttonsContainer}`}
-                        >
-                            {!isLoading && (!message.error || isAborted) && !isSearchIntent && (
-                                <>
+                        {!isLoading &&
+                            (!message.error || isAborted) &&
+                            !isSearchIntent &&
+                            // Do not display copy button for non-chat mode.
+                            // NOTE: Empty intent is defaulted to chat.
+                            (humanMessage?.intent || humanMessage?.intent !== 'chat') && (
+                                <div
+                                    className={`tw-flex tw-items-center tw-justify-end tw-gap-4  ${styles.buttonsContainer}`}
+                                >
                                     <CopyButton
                                         text={message.text?.toString() || ''}
                                         onCopy={copyButtonOnSubmit}
@@ -176,9 +180,8 @@ export const AssistantMessageCell: FunctionComponent<{
                                         className={'tw-transition tw-opacity-65 hover:tw-opacity-100'}
                                         title="Copy Message"
                                     />
-                                </>
+                                </div>
                             )}
-                        </div>
                     </div>
                 }
             />


### PR DESCRIPTION
This commit hides the copy button in the assistant message cell when not in chat mode. The copy button is only relevant when the assistant is responding to a chat-based query. This change ensures that the copy button is not displayed when the assistant is used for other purposes, such as edit or search or agent.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Use non chat mode and confirm the copy button is not showing up