### PR TITLE
fix(chat): add MCP tool schema to tool config prompt

### DIFF
--- a/vscode/src/chat/agentic/CodyToolFactory.ts
+++ b/vscode/src/chat/agentic/CodyToolFactory.ts
@@ -160,7 +160,7 @@ export class ToolFactory {
                 instruction: PromptString.unsafe_fromUserQuery(
                     ((tool as any).description as string) || ''
                 ),
-                placeholder: ps`ARGS`,
+                placeholder: PromptString.unsafe_fromUserQuery(JSON.stringify(tool.input_schema)),
                 examples: [],
             },
             // Add metadata to identify tools from the same MCP server

--- a/vscode/src/chat/agentic/DeepCody.ts
+++ b/vscode/src/chat/agentic/DeepCody.ts
@@ -193,12 +193,16 @@ export class DeepCodyAgent {
             this.stats.loop++
             const step = this.stepsManager.addStep({ title: 'Reflecting' })
             const newContext = await this.review(requestID, span, chatAbortSignal)
-            this.statusCallback.onComplete(step.id)
-            if (!newContext.length) break
+            // Make sure the review is completed
+            if (!newContext?.length) {
+                this.statusCallback.onComplete(step.id)
+                break
+            }
             // Filter and add new context items in one pass
             const validItems = newContext.filter(c => c.title !== 'TOOLCONTEXT')
             this.context.push(...validItems)
             this.stats.context += validItems.length
+            this.statusCallback.onComplete(step.id)
             if (newContext.every(isUserAddedItem)) break
         }
         this.statusCallback.onComplete()

--- a/vscode/src/chat/agentic/prompts.ts
+++ b/vscode/src/chat/agentic/prompts.ts
@@ -61,7 +61,8 @@ In this environment you have access to this set of tools you can use to fetch co
 <user_input>
 
 ## IMPORTANT
-Skip preamble. ONLY include the expected tags in your response and nothing else.
+Skip preamble. ONLY include the expected tags in your response and nothing else. DO NOT enclose your answers in markdown code blocks.
+Always follow the instruction for each tool and their expected schema!
 This is an auto-generated message and your response will be processed by a bot using the expected tags.`
     .replace(/{{ANSWER_TAG}}/g, ACTIONS_TAGS.ANSWER)
     .replace(/{{CONTEXT_TAG}}/g, ACTIONS_TAGS.CONTEXT)

--- a/vscode/src/chat/chat-view/tools/MCPServerManager.ts
+++ b/vscode/src/chat/chat-view/tools/MCPServerManager.ts
@@ -525,7 +525,7 @@ export function createMCPToolState(
         toolId: `mcp-${toolName}-${Date.now()}`,
         status,
         toolName: `${serverName}_${toolName}`,
-        content: textContent,
+        content: `<TOOLRESULT tool='${toolName}'>${textContent}\n[Please communicate the result to the user]</TOOLRESULT>`,
         outputType: 'mcp',
         uri: URI.parse(''),
         title: serverName + ' - ' + toolName,


### PR DESCRIPTION
Some minor fixes and improves for deep cody / agentic chat to use mcp tools for retrieving context:

- Includes the tool's input schema as the placeholder in the prompt, providing the agent with more context on how to use the tool instead of "ARGS" that was causing the gemini agent to some times returns "ARGS" for all mcp tool call.
- The agent prompt has been updated to emphasize the importance of following tool instructions and schemas, and to avoid enclosing answers in markdown code blocks.
- Ensures that the review step in `DeepCody` is marked as complete AFTER agent has replied.
- Update  to handle server updates in webview correctly. It now distinguishes between updates where only the configuration changes and updates where the server name also changes, ensuring that the old server is removed and a new server is added in the latter case.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

1. Add `playwright` to your mcp settings:

```json
        "playwright": {
            "command": "npx",
            "args": [
                "-y",
                "@playwright/mcp@latest",
                "--headless"
            ],
            "disabled": true
        },
```

2. Make sure the server is connected and the tools are loaded
3. Ask Cody "Use the tool to open my browser to bbc uk websire and tell me what you see" :


<img width="2047" alt="Screenshot 2025-05-09 at 5 33 30 PM" src="https://github.com/user-attachments/assets/f1e2c3c9-fd3b-4d86-935a-34e64ecc7c6b" />


