### PR TITLE
fix(chat): Allow spaces in mcp server arguments

### DIFF
--- a/vscode/webviews/components/mcp/views/AddServerForm.tsx
+++ b/vscode/webviews/components/mcp/views/AddServerForm.tsx
@@ -112,7 +112,7 @@ export function AddServerForm({ onAddServer, _server }: AddServerFormProps) {
                     <input
                         id="arguments"
                         value={formData?.args}
-                        onChange={e => updateArg(e.target?.value?.trim())}
+                        onChange={e => updateArg(e.target?.value)}
                         className="tw-block tw-py-2.5 tw-px-0 tw-w-full tw-text-sm tw-text-input-foreground tw-bg-transparent tw-border-0 tw-border-b-2 tw-border-gray-300 tw-appearance-none dark:tw-border-gray-600 dark:focus:tw-border-blue-500 focus:tw-outline-none focus:tw-ring-0 focus:tw-border-blue-600 peer"
                         required={true}
                     />


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-5825/bug-mcp-arguments-dont-allow-spaces

The input field for server arguments was trimming spaces, preventing users from entering arguments that require spaces. This commit removes the `trim()` function from the `onChange` handler, allowing spaces to be included in the arguments.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Details in https://linear.app/sourcegraph/issue/CODY-5825/bug-mcp-arguments-dont-allow-spaces
