### PR TITLE
feat(chat): open mcp settings in json

### DIFF
--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -409,7 +409,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                 }
                 break
             case 'command':
-                vscode.commands.executeCommand(message.id, message.arg)
+                vscode.commands.executeCommand(message.id, message.arg ?? message.args)
                 break
             case 'mcp': {
                 try {

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -94,7 +94,12 @@ export type WebviewMessage =
           command: 'show-page'
           page: string
       }
-    | { command: 'command'; id: string; arg?: string | undefined | null }
+    | {
+          command: 'command'
+          id: string
+          arg?: string | undefined | null
+          args?: Record<string, any> | undefined | null
+      }
     | ({ command: 'edit' } & WebviewEditMessage)
     | { command: 'insert'; text: string }
     | { command: 'newFile'; text: string }

--- a/vscode/webviews/components/mcp/ServerHome.tsx
+++ b/vscode/webviews/components/mcp/ServerHome.tsx
@@ -185,8 +185,12 @@ export function ServerHome({ mcpServers }: ServerHomeProps) {
                     onClick={() =>
                         getVSCodeAPI().postMessage({
                             command: 'command',
-                            id: 'workbench.action.openSettings',
-                            arg: '@ext:sourcegraph.cody-ai cody.mcpServers',
+                            id: 'workbench.action.openSettingsJson',
+                            args: {
+                                revealSetting: {
+                                    key: 'cody.mcpServers',
+                                },
+                            },
                         })
                     }
                 >
@@ -195,103 +199,115 @@ export function ServerHome({ mcpServers }: ServerHomeProps) {
                     </div>
                 </Button>
             </header>
-            <div className="tw-flex tw-items-center tw-justify-between tw-px-2 tw-py-1">
-                <CommandList className="tw-flex-1">
-                    <CommandInput
-                        value={searchQuery}
-                        onValueChange={setSearchQuery}
-                        placeholder="Search..."
-                        autoFocus={true}
-                        className="tw-m-[0.5rem] !tw-p-[0.5rem] tw-rounded tw-bg-input-background tw-text-input-foreground focus:tw-shadow-[0_0_0_0.125rem_var(--vscode-focusBorder)]"
-                    />
-                </CommandList>
-            </div>
-            <CommandList className="tw-flex-1 tw-overflow-y-auto tw-m-2 tw-gap-6 !tw-bg-transparent focus:tw-bg-inherit">
-                {filteredServers.map(server => (
-                    <CommandItem
-                        key={server.id}
-                        className="tw-text-left tw-truncate tw-w-full tw-rounded-md tw-text-sm tw-overflow-hidden tw-text-sidebar-foreground tw-align-baseline hover:tw-bg-transparent [&[aria-selected='true']]:tw-bg-transparent tw-my-2"
-                        onSelect={() => setSelectedServer(server)}
-                    >
-                        <div className="tw-truncate tw-w-full tw-flex tw-flex-col tw-gap-2">
-                            <div className="tw-flex tw-items-center tw-justify-between tw-gap-2">
-                                <div className="tw-flex tw-self-end tw-gap-2">
-                                    <PencilRulerIcon
-                                        className="tw-w-8 tw-h-8"
-                                        strokeWidth={1.25}
-                                        size={16}
-                                    />
-                                    <strong>{server.name}</strong>
-                                </div>
-                                {server.name === selectedServer?.name && (
-                                    <Button
-                                        variant="ghost"
-                                        size="sm"
-                                        className="tw-p-2 tw-z-10"
-                                        onClick={e => {
-                                            e.stopPropagation()
-                                            removeServer(server.name)
-                                        }}
-                                        title="Delete server"
-                                    >
-                                        <Minus size={16} />
-                                    </Button>
-                                )}
-                            </div>
-                            <div className="tw-flex tw-align-top tw-justify-between tw-my-1 tw-flex-wrap">
-                                {server.error && (
-                                    <div className="tw-mt-2 tw-mb-1 tw-w-full">
-                                        <p
-                                            className="tw-text-xs tw-text-pink-300 tw-mt-1 tw-truncate"
-                                            title={server.error}
-                                        >
-                                            {server.error}
-                                        </p>
-                                    </div>
-                                )}
-                                {server.tools && server.tools?.length > 0 && (
-                                    <div className="tw-mt-2">
-                                        <div className="tw-flex tw-flex-wrap tw-gap-4">
-                                            {server.tools.map(tool => (
-                                                <Badge
-                                                    key={`${server.name}-${tool.name}-tool`}
-                                                    variant={tool.disabled ? 'disabled' : 'outline'}
-                                                    className={`tw-truncate tw-max-w-[250px] tw-text-foreground tw-cursor-pointer tw-font-thin ${
-                                                        tool.disabled
-                                                            ? 'tw-opacity-50 tw-line-through'
-                                                            : ''
-                                                    }`}
-                                                    onClick={e => {
-                                                        e.stopPropagation()
-                                                        toggleTool(
-                                                            server.name,
-                                                            tool.name,
-                                                            tool.disabled !== true
-                                                        )
-                                                    }}
-                                                    title={`${tool.disabled ? '[Disabled] ' : ''} ${
-                                                        tool.description
-                                                    }`}
-                                                >
-                                                    {tool.name}
-                                                </Badge>
-                                            ))}
-                                        </div>
-                                    </div>
-                                )}
-                            </div>
-                        </div>
-                    </CommandItem>
-                ))}
-                <div className="tw-flex tw-flex-col tw-justify-center tw-mt-4 tw-w-full">
-                    <AddServerView
-                        onAddServer={addServer}
-                        className="tw-my-4 tw-w-full tw-px-2"
-                        serverToEdit={selectedServer}
-                        setServerToEdit={setSelectedServer}
-                    />
+            {!mcpServers.length ? (
+                <div className="tw-w-full tw-col-span-full tw-text-center tw-py-12 tw-border tw-rounded-lg tw-border-none">
+                    <Server className="tw-h-12 tw-w-12 tw-mx-auto tw-mb-4 tw-text-muted-foreground" />
+                    <h3 className="tw-text-md tw-font-medium">Waiting for server connections...</h3>
+                    <p className="tw-text-muted-foreground tw-mt-1">Add a new server to get started</p>
                 </div>
-            </CommandList>
+            ) : (
+                <div>
+                    <div className="tw-flex tw-items-center tw-justify-between tw-px-2 tw-py-1">
+                        <CommandList className="tw-flex-1">
+                            <CommandInput
+                                value={searchQuery}
+                                onValueChange={setSearchQuery}
+                                placeholder="Search..."
+                                autoFocus={true}
+                                className="tw-m-[0.5rem] !tw-p-[0.5rem] tw-rounded tw-bg-input-background tw-text-input-foreground focus:tw-shadow-[0_0_0_0.125rem_var(--vscode-focusBorder)]"
+                            />
+                        </CommandList>
+                    </div>
+                    <CommandList className="tw-flex-1 tw-overflow-y-auto tw-m-2 tw-gap-6 !tw-bg-transparent focus:tw-bg-inherit">
+                        {filteredServers.map(server => (
+                            <CommandItem
+                                key={server.id}
+                                className="tw-text-left tw-truncate tw-w-full tw-rounded-md tw-text-sm tw-overflow-hidden tw-text-sidebar-foreground tw-align-baseline hover:tw-bg-transparent [&[aria-selected='true']]:tw-bg-transparent tw-my-2"
+                                onSelect={() => setSelectedServer(server)}
+                            >
+                                <div className="tw-truncate tw-w-full tw-flex tw-flex-col tw-gap-2">
+                                    <div className="tw-flex tw-items-center tw-justify-between tw-gap-2">
+                                        <div className="tw-flex tw-self-end tw-gap-2">
+                                            <PencilRulerIcon
+                                                className="tw-w-8 tw-h-8"
+                                                strokeWidth={1.25}
+                                                size={16}
+                                            />
+                                            <strong>{server.name}</strong>
+                                        </div>
+                                        {server.name === selectedServer?.name && (
+                                            <Button
+                                                variant="ghost"
+                                                size="sm"
+                                                className="tw-p-2 tw-z-10"
+                                                onClick={e => {
+                                                    e.stopPropagation()
+                                                    removeServer(server.name)
+                                                }}
+                                                title="Delete server"
+                                            >
+                                                <Minus size={16} />
+                                            </Button>
+                                        )}
+                                    </div>
+                                    <div className="tw-flex tw-align-top tw-justify-between tw-my-1 tw-flex-wrap">
+                                        {server.error && (
+                                            <div className="tw-mt-2 tw-mb-1 tw-w-full">
+                                                <p
+                                                    className="tw-text-xs tw-text-pink-300 tw-mt-1 tw-truncate"
+                                                    title={server.error}
+                                                >
+                                                    {server.error}
+                                                </p>
+                                            </div>
+                                        )}
+                                        {server.tools && server.tools?.length > 0 && (
+                                            <div className="tw-mt-2">
+                                                <div className="tw-flex tw-flex-wrap tw-gap-4">
+                                                    {server.tools.map(tool => (
+                                                        <Badge
+                                                            key={`${server.name}-${tool.name}-tool`}
+                                                            variant={
+                                                                tool.disabled ? 'disabled' : 'outline'
+                                                            }
+                                                            className={`tw-truncate tw-max-w-[250px] tw-text-foreground tw-cursor-pointer tw-font-thin ${
+                                                                tool.disabled
+                                                                    ? 'tw-opacity-50 tw-line-through'
+                                                                    : ''
+                                                            }`}
+                                                            onClick={e => {
+                                                                e.stopPropagation()
+                                                                toggleTool(
+                                                                    server.name,
+                                                                    tool.name,
+                                                                    tool.disabled !== true
+                                                                )
+                                                            }}
+                                                            title={`${
+                                                                tool.disabled ? '[Disabled] ' : ''
+                                                            } ${tool.description}`}
+                                                        >
+                                                            {tool.name}
+                                                        </Badge>
+                                                    ))}
+                                                </div>
+                                            </div>
+                                        )}
+                                    </div>
+                                </div>
+                            </CommandItem>
+                        ))}
+                        <div className="tw-flex tw-flex-col tw-justify-center tw-mt-4 tw-w-full">
+                            <AddServerView
+                                onAddServer={addServer}
+                                className="tw-my-4 tw-w-full tw-px-2"
+                                serverToEdit={selectedServer}
+                                setServerToEdit={setSelectedServer}
+                            />
+                        </div>
+                    </CommandList>
+                </div>
+            )}
         </Command>
     )
 }

--- a/vscode/webviews/components/mcp/ServerHome.tsx
+++ b/vscode/webviews/components/mcp/ServerHome.tsx
@@ -151,24 +151,6 @@ export function ServerHome({ mcpServers }: ServerHomeProps) {
         )
     }, [searchQuery, servers])
 
-    // Empty state
-    if (!mcpServers?.length) {
-        return (
-            <div className="tw-w-full tw-p-4">
-                <div className="tw-w-full tw-col-span-full tw-text-center tw-py-12 tw-border tw-rounded-lg tw-border-none">
-                    <Server className="tw-h-12 tw-w-12 tw-mx-auto tw-mb-4 tw-text-muted-foreground" />
-                    <h3 className="tw-text-md tw-font-medium">Waiting for server connections...</h3>
-                    <p className="tw-text-muted-foreground tw-mt-1">Add a new server to get started</p>
-                </div>
-                <AddServerView
-                    onAddServer={addServer}
-                    className="tw-my-4 tw-w-full tw-py-1"
-                    setServerToEdit={setSelectedServer}
-                />
-            </div>
-        )
-    }
-
     return (
         <Command
             loop={true}
@@ -199,7 +181,7 @@ export function ServerHome({ mcpServers }: ServerHomeProps) {
                     </div>
                 </Button>
             </header>
-            {!mcpServers.length ? (
+            {!mcpServers?.length ? (
                 <div className="tw-w-full tw-col-span-full tw-text-center tw-py-12 tw-border tw-rounded-lg tw-border-none">
                     <Server className="tw-h-12 tw-w-12 tw-mx-auto tw-mb-4 tw-text-muted-foreground" />
                     <h3 className="tw-text-md tw-font-medium">Waiting for server connections...</h3>


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-5827/mcp-server-button-doesnt-show-settings

Updated to allow passing arguments to VS Code commands executed from the chat protocol by adding an optional `args` property to the `WebviewMessage` type for the 'command' case.
 The `ChatController` is updated to use `message.args` if `message.arg` is not provided, ensuring backward compatibility.

Additionally, the MCP server home component is updated to show the open config button even when there is no servers configured.

The settings button now opens the settings JSON directly to the `cody.mcpServers` key.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Button display on start up view:

<img width="773" alt="image" src="https://github.com/user-attachments/assets/c766a082-633c-4a53-9f78-b616fc5d62c6" />

Open json setting on click:

https://github.com/user-attachments/assets/faa43676-e135-49d6-b483-c8e2ed017852


