### PR TITLE
Fix handling of client-side temporary settings in cody_settings.json

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/CodyAgentClient.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/CodyAgentClient.kt
@@ -41,7 +41,7 @@ interface CodyAgentClient {
   @JsonNotification("debug/message")
   fun debug_message(params: DebugMessage)
   @JsonNotification("extensionConfiguration/didUpdate")
-  fun extensionConfiguration_didUpdate(params: String)
+  fun extensionConfiguration_didUpdate(params: ExtensionConfiguration_DidUpdateParams)
   @JsonNotification("extensionConfiguration/openSettings")
   fun extensionConfiguration_openSettings(params: Null?)
   @JsonNotification("editTask/didUpdate")

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/ExtensionConfiguration_DidUpdateParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/ExtensionConfiguration_DidUpdateParams.kt
@@ -1,0 +1,8 @@
+@file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
+package com.sourcegraph.cody.agent.protocol_generated;
+
+data class ExtensionConfiguration_DidUpdateParams(
+  val key: String,
+  val value: String? = null,
+)
+

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -380,16 +380,6 @@ export class Agent extends MessageHandler implements ExtensionClient {
         super(params.conn)
         vscode_shim.setAgent(this)
 
-        vscode_shim.onDidChangeConfiguration.event(() => {
-            const config = vscode_shim.workspace.getConfiguration().get('cody')
-            if (config) {
-                const codyConfig = {
-                    cody: config,
-                }
-                this.notify('extensionConfiguration/didUpdate', JSON.stringify(codyConfig))
-            }
-        })
-
         this.registerRequest('initialize', async clientInfo => {
             vscode.languages.registerFoldingRangeProvider(
                 '*',

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -177,7 +177,20 @@ const configuration = new AgentWorkspaceConfiguration(
     [],
     () => clientInfo,
     () => extensionConfiguration,
-    onDidChangeConfiguration
+    async (section, value) => {
+        if (onDidChangeConfiguration) {
+            await onDidChangeConfiguration.cody_fireAsync({
+                affectsConfiguration: key => key.includes(section),
+            })
+        }
+
+        if (agent && section.startsWith('cody')) {
+            agent.notify('extensionConfiguration/didUpdate', {
+                key: section,
+                value: value === undefined ? undefined : JSON.stringify(value),
+            })
+        }
+    }
 )
 
 export interface WorkspaceDocuments {

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentClient.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentClient.kt
@@ -289,9 +289,9 @@ class CodyAgentClient(private val project: Project, private val webview: NativeW
   }
 
   @JsonNotification("extensionConfiguration/didUpdate")
-  fun extensionConfiguration_didUpdate(params: String) {
+  fun extensionConfiguration_didUpdate(params: ExtensionConfiguration_DidUpdateParams) {
     if (!project.isDisposed) {
-      ConfigUtil.setCustomConfiguration(project, params)
+      ConfigUtil.updateCustomConfiguration(project, params.key, params.value)
     }
   }
 

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/migration/ClientConfigCleanupMigration.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/migration/ClientConfigCleanupMigration.kt
@@ -1,0 +1,102 @@
+package com.sourcegraph.cody.config.migration
+
+import com.intellij.ide.util.RunOnceUtil
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.Project
+import com.sourcegraph.cody.initialization.Activity
+import com.sourcegraph.config.ConfigUtil
+import com.typesafe.config.ConfigFactory
+import kotlin.io.path.exists
+import kotlin.io.path.readText
+import kotlin.io.path.writeText
+
+/**
+ * Migration to clean up temporary client-side configuration variables that were incorrectly written
+ * back to cody_settings.json.
+ */
+class ClientConfigCleanupMigration : Activity {
+  companion object {
+    private val LOG = logger<ClientConfigCleanupMigration>()
+
+    // List of paths to always remove from configuration (temporary client-side values)
+    private val pathsToAlwaysRemove =
+        listOf("cody.advanced.agent", "cody.advanced.hasNativeWebview", "cody.customHeaders")
+
+    // Map of paths with their default values
+    // If these are found with these default values, they'll be removed
+    private val defaultValues =
+        mapOf(
+            "cody.autocomplete.advanced.model" to null,
+            "cody.autocomplete.advanced.provider" to null,
+            "cody.codebase" to null,
+            "cody.debug.verbose" to false,
+            "cody.experimental.foldingRanges" to "indentation-based",
+            "cody.experimental.tracing" to false,
+            "cody.serverEndpoint" to null,
+            "cody.suggestions.mode" to "autocomplete",
+            "cody.telemetry.clientName" to null,
+            "cody.telemetry.level" to "agent")
+  }
+
+  override fun runActivity(project: Project) {
+    RunOnceUtil.runOnceForProject(project, "ClientConfigCleanupMigration") {
+      cleanupTemporaryClientConfig(project)
+    }
+  }
+
+  fun cleanupTemporaryClientConfig(project: Project) {
+    val settingsFile = ConfigUtil.getSettingsFile(project)
+
+    if (!settingsFile.exists()) {
+      LOG.info("No cody_settings.json file found for cleanup")
+      return
+    }
+
+    try {
+      val fileContent = settingsFile.readText()
+      val config = ConfigFactory.parseString(fileContent).resolve()
+
+      var modified = false
+      var updatedConfig = config
+
+      // 1. First remove the client-side temporary values that should always be removed
+      for (path in pathsToAlwaysRemove) {
+        if (config.hasPath(path)) {
+          LOG.info("Removing temporary client configuration from settings: $path")
+          updatedConfig = updatedConfig.withoutPath(path)
+          modified = true
+        }
+      }
+
+      // 2. Now check for default values that can be cleaned up
+      for ((path, defaultValue) in defaultValues) {
+        if (config.hasPath(path)) {
+          val value =
+              when (defaultValue) {
+                is Boolean -> config.getBoolean(path)
+                is String -> config.getString(path)
+                null -> null
+                else -> "not-null"
+              }
+
+          if (value == defaultValue) {
+            LOG.info("Removing default value from settings: $path")
+            updatedConfig = updatedConfig.withoutPath(path)
+            modified = true
+          }
+        }
+      }
+
+      if (modified) {
+        LOG.info("Writing cleaned up configuration to $settingsFile")
+        val content = updatedConfig.root().render(ConfigUtil.renderOptions)
+        settingsFile.writeText(content)
+        ConfigUtil.setCustomConfiguration(project, content)
+      } else {
+        LOG.info("No configuration to clean up found")
+      }
+    } catch (e: Exception) {
+      LOG.warn("Failed to clean up configuration", e)
+    }
+  }
+}

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/initialization/PostStartupActivity.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/initialization/PostStartupActivity.kt
@@ -10,6 +10,7 @@ import com.intellij.util.concurrency.AppExecutorUtil
 import com.sourcegraph.cody.agent.CodyAgentService
 import com.sourcegraph.cody.config.CodySettingsFileChangeListener
 import com.sourcegraph.cody.config.CodyWindowAdapter
+import com.sourcegraph.cody.config.migration.ClientConfigCleanupMigration
 import com.sourcegraph.cody.config.migration.SettingsMigration
 import com.sourcegraph.cody.config.notification.CodySettingChangeListener
 import com.sourcegraph.cody.config.ui.CheckUpdatesTask
@@ -33,6 +34,7 @@ class PostStartupActivity : ProjectActivity {
         .getInstance() // Initialize Sentry as early as possible to report early unhandled errors
     VerifyJavaBootRuntimeVersion().runActivity(project)
     SettingsMigration().runActivity(project)
+    ClientConfigCleanupMigration().runActivity(project)
     CodyWindowAdapter.addWindowFocusListener(project)
 
     AppExecutorUtil.getAppScheduledExecutorService()

--- a/jetbrains/src/main/kotlin/com/sourcegraph/config/ConfigUtil.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/config/ConfigUtil.kt
@@ -35,8 +35,7 @@ object ConfigUtil {
   const val CODE_SEARCH_DISPLAY_NAME = "Code Search"
   const val SOURCEGRAPH_DISPLAY_NAME = "Sourcegraph"
   private const val FEATURE_FLAGS_ENV_VAR = "CODY_JETBRAINS_FEATURES"
-  private val renderOptions =
-      ConfigRenderOptions.defaults().setComments(false).setOriginComments(false)
+  val renderOptions = ConfigRenderOptions.defaults().setComments(false).setOriginComments(false)
 
   private val logger = Logger.getInstance(ConfigUtil::class.java)
 

--- a/jetbrains/src/main/kotlin/com/sourcegraph/config/ConfigUtil.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/config/ConfigUtil.kt
@@ -195,6 +195,18 @@ object ConfigUtil {
   }
 
   @JvmStatic
+  fun updateCustomConfiguration(project: Project, key: String, value: String? = null) {
+    val config = ConfigFactory.parseString(getSettingsFile(project).readText()).resolve()
+    val updatedConfig =
+        if (value == null) {
+          config.withoutPath(key)
+        } else {
+          config.withValue(key, ConfigValueFactory.fromAnyRef(value))
+        }
+    setCustomConfiguration(project, updatedConfig.root().render(renderOptions))
+  }
+
+  @JvmStatic
   fun setCustomConfiguration(project: Project, customConfigContent: String): VirtualFile? {
     val config = ConfigFactory.parseString(customConfigContent).resolve()
     val content = config.root().render(renderOptions)

--- a/jetbrains/src/test/kotlin/com/sourcegraph/cody/config/migration/ClientConfigCleanupMigrationTest.kt
+++ b/jetbrains/src/test/kotlin/com/sourcegraph/cody/config/migration/ClientConfigCleanupMigrationTest.kt
@@ -1,0 +1,172 @@
+package com.sourcegraph.cody.config.migration
+
+import com.intellij.openapi.project.Project
+import com.intellij.testFramework.LightPlatformTestCase
+import com.sourcegraph.config.ConfigUtil
+import com.typesafe.config.ConfigFactory
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.exists
+import kotlin.io.path.readText
+import kotlin.io.path.writeText
+
+class ClientConfigCleanupMigrationTest : LightPlatformTestCase() {
+
+  private lateinit var settingsFile: Path
+  private lateinit var migration: ClientConfigCleanupMigration
+  private lateinit var project: Project
+
+  override fun setUp() {
+    super.setUp()
+    project = getProject()
+
+    val configDir = ConfigUtil.getConfigDir(project)
+    Files.createDirectories(configDir)
+    settingsFile = ConfigUtil.getSettingsFile(project)
+
+    migration = ClientConfigCleanupMigration()
+  }
+
+  fun testCleanupTemporaryClientConfig() {
+    val tempConfig =
+        """
+      {
+        "cody": {
+          "advanced": {
+            "agent": {
+              "capabilities": {
+                "storage": true
+              },
+              "extension": {
+                "version": "7.91.2-nightly"
+              },
+              "ide": {
+                "name": "JetBrains",
+                "productCode": 1,
+                "version": "IU-242.20224.300"
+              },
+              "running": true
+            },
+            "hasNativeWebview": true
+          },
+          "autocomplete": {
+            "enabled": true,
+            "advanced": {
+              "model": null,
+              "provider": null
+            }
+          },
+          "debug": {
+            "verbose": false
+          },
+          "customHeaders": {},
+          "telemetry": {
+            "clientName": null,
+            "level": "agent"
+          },
+          "experimental": {
+            "foldingRanges": "indentation-based",
+            "tracing": false
+          }
+        }
+      }
+    """
+            .trimIndent()
+
+    settingsFile.writeText(tempConfig)
+
+    migration.cleanupTemporaryClientConfig(project)
+
+    val configAfterMigration = ConfigFactory.parseString(settingsFile.readText()).resolve()
+
+    // Check that temporary client-side configuration has been removed
+    assertFalse(
+        "Should have removed cody.advanced.agent",
+        configAfterMigration.hasPath("cody.advanced.agent"))
+    assertFalse(
+        "Should have removed cody.advanced.hasNativeWebview",
+        configAfterMigration.hasPath("cody.advanced.hasNativeWebview"))
+
+    // Check that default values have been removed
+    assertFalse(
+        "Should have removed cody.autocomplete.advanced.model",
+        configAfterMigration.hasPath("cody.autocomplete.advanced.model"))
+    assertFalse(
+        "Should have removed cody.autocomplete.advanced.provider",
+        configAfterMigration.hasPath("cody.autocomplete.advanced.provider"))
+    assertFalse(
+        "Should have removed cody.debug.verbose",
+        configAfterMigration.hasPath("cody.debug.verbose"))
+    assertFalse(
+        "Should have removed cody.customHeaders",
+        configAfterMigration.hasPath("cody.customHeaders"))
+    assertFalse(
+        "Should have removed cody.telemetry.clientName",
+        configAfterMigration.hasPath("cody.telemetry.clientName"))
+    assertFalse(
+        "Should have removed cody.telemetry.level",
+        configAfterMigration.hasPath("cody.telemetry.level"))
+    assertFalse(
+        "Should have removed cody.experimental.foldingRanges",
+        configAfterMigration.hasPath("cody.experimental.foldingRanges"))
+    assertFalse(
+        "Should have removed cody.experimental.tracing",
+        configAfterMigration.hasPath("cody.experimental.tracing"))
+
+    // Check that non-default configuration remains intact
+    assertTrue(
+        "Should not remove cody.autocomplete.enabled",
+        configAfterMigration.hasPath("cody.autocomplete.enabled"))
+    assertEquals(true, configAfterMigration.getBoolean("cody.autocomplete.enabled"))
+  }
+
+  fun testNoErrorOnMissingSettingsFile() {
+    // Ensure settings file doesn't exist
+    if (settingsFile.exists()) {
+      Files.delete(settingsFile)
+    }
+
+    // Run the migration - it should not throw any exceptions
+    migration.cleanupTemporaryClientConfig(project)
+
+    // Verify the file still doesn't exist
+    assertFalse("Settings file should not be created if it didn't exist", settingsFile.exists())
+  }
+
+  fun testNoErrorWhenTemporarySettingsNotPresent() {
+    // Create a settings file without temporary client-side configuration
+    // but with a non-default value
+    val cleanConfig =
+        """
+      {
+        "cody": {
+          "autocomplete": {
+            "enabled": true
+          },
+          "experimental": {
+            "tracing": true
+          }
+        }
+      }
+    """
+            .trimIndent()
+
+    settingsFile.writeText(cleanConfig)
+
+    migration.cleanupTemporaryClientConfig(project)
+
+    // Verify the result is unchanged for custom values
+    val configAfterMigration = ConfigFactory.parseString(settingsFile.readText()).resolve()
+
+    assertTrue(
+        "Should keep cody.autocomplete.enabled",
+        configAfterMigration.hasPath("cody.autocomplete.enabled"))
+    assertEquals(true, configAfterMigration.getBoolean("cody.autocomplete.enabled"))
+
+    // Non-default experimental.tracing value should be preserved
+    assertTrue(
+        "Should keep non-default cody.experimental.tracing",
+        configAfterMigration.hasPath("cody.experimental.tracing"))
+    assertEquals(true, configAfterMigration.getBoolean("cody.experimental.tracing"))
+  }
+}

--- a/jetbrains/src/test/kotlin/com/sourcegraph/cody/config/migration/ClientConfigCleanupMigrationTest.kt
+++ b/jetbrains/src/test/kotlin/com/sourcegraph/cody/config/migration/ClientConfigCleanupMigrationTest.kt
@@ -1,16 +1,15 @@
 package com.sourcegraph.cody.config.migration
 
 import com.intellij.openapi.project.Project
-import com.intellij.testFramework.LightPlatformTestCase
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import com.sourcegraph.config.ConfigUtil
-import com.typesafe.config.ConfigFactory
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.exists
 import kotlin.io.path.readText
 import kotlin.io.path.writeText
 
-class ClientConfigCleanupMigrationTest : LightPlatformTestCase() {
+class ClientConfigCleanupMigrationTest : BasePlatformTestCase() {
 
   private lateinit var settingsFile: Path
   private lateinit var migration: ClientConfigCleanupMigration
@@ -50,7 +49,7 @@ class ClientConfigCleanupMigrationTest : LightPlatformTestCase() {
             "hasNativeWebview": true
           },
           "autocomplete": {
-            "enabled": true,
+            "enabled": false,
             "advanced": {
               "model": null,
               "provider": null
@@ -73,51 +72,22 @@ class ClientConfigCleanupMigrationTest : LightPlatformTestCase() {
     """
             .trimIndent()
 
-    settingsFile.writeText(tempConfig)
-
+    ConfigUtil.setCustomConfiguration(project, tempConfig)
     migration.cleanupTemporaryClientConfig(project)
 
-    val configAfterMigration = ConfigFactory.parseString(settingsFile.readText()).resolve()
+    assertEquals(
+        """
+      {
+          "cody" : {
+              "autocomplete" : {
+                  "enabled" : false
+              }
+          }
+      }
 
-    // Check that temporary client-side configuration has been removed
-    assertFalse(
-        "Should have removed cody.advanced.agent",
-        configAfterMigration.hasPath("cody.advanced.agent"))
-    assertFalse(
-        "Should have removed cody.advanced.hasNativeWebview",
-        configAfterMigration.hasPath("cody.advanced.hasNativeWebview"))
-
-    // Check that default values have been removed
-    assertFalse(
-        "Should have removed cody.autocomplete.advanced.model",
-        configAfterMigration.hasPath("cody.autocomplete.advanced.model"))
-    assertFalse(
-        "Should have removed cody.autocomplete.advanced.provider",
-        configAfterMigration.hasPath("cody.autocomplete.advanced.provider"))
-    assertFalse(
-        "Should have removed cody.debug.verbose",
-        configAfterMigration.hasPath("cody.debug.verbose"))
-    assertFalse(
-        "Should have removed cody.customHeaders",
-        configAfterMigration.hasPath("cody.customHeaders"))
-    assertFalse(
-        "Should have removed cody.telemetry.clientName",
-        configAfterMigration.hasPath("cody.telemetry.clientName"))
-    assertFalse(
-        "Should have removed cody.telemetry.level",
-        configAfterMigration.hasPath("cody.telemetry.level"))
-    assertFalse(
-        "Should have removed cody.experimental.foldingRanges",
-        configAfterMigration.hasPath("cody.experimental.foldingRanges"))
-    assertFalse(
-        "Should have removed cody.experimental.tracing",
-        configAfterMigration.hasPath("cody.experimental.tracing"))
-
-    // Check that non-default configuration remains intact
-    assertTrue(
-        "Should not remove cody.autocomplete.enabled",
-        configAfterMigration.hasPath("cody.autocomplete.enabled"))
-    assertEquals(true, configAfterMigration.getBoolean("cody.autocomplete.enabled"))
+      """
+            .trimIndent(),
+        settingsFile.readText())
   }
 
   fun testNoErrorOnMissingSettingsFile() {
@@ -134,39 +104,25 @@ class ClientConfigCleanupMigrationTest : LightPlatformTestCase() {
   }
 
   fun testNoErrorWhenTemporarySettingsNotPresent() {
-    // Create a settings file without temporary client-side configuration
-    // but with a non-default value
+    // Create a settings file without temporary client-side
+    // configuration but with a non-default value
     val cleanConfig =
         """
-      {
-        "cody": {
-          "autocomplete": {
-            "enabled": true
-          },
-          "experimental": {
-            "tracing": true
-          }
+        {
+            "cody" : {
+                "autocomplete.enabled" : false,
+                "experimental" : {
+                    "tracing" : true
+                }
+            }
         }
-      }
-    """
+
+        """
             .trimIndent()
 
     settingsFile.writeText(cleanConfig)
-
     migration.cleanupTemporaryClientConfig(project)
 
-    // Verify the result is unchanged for custom values
-    val configAfterMigration = ConfigFactory.parseString(settingsFile.readText()).resolve()
-
-    assertTrue(
-        "Should keep cody.autocomplete.enabled",
-        configAfterMigration.hasPath("cody.autocomplete.enabled"))
-    assertEquals(true, configAfterMigration.getBoolean("cody.autocomplete.enabled"))
-
-    // Non-default experimental.tracing value should be preserved
-    assertTrue(
-        "Should keep non-default cody.experimental.tracing",
-        configAfterMigration.hasPath("cody.experimental.tracing"))
-    assertEquals(true, configAfterMigration.getBoolean("cody.experimental.tracing"))
+    assertEquals(cleanConfig, settingsFile.readText())
   }
 }

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -415,7 +415,7 @@ export type ServerNotifications = {
 
     'debug/message': [DebugMessage]
 
-    'extensionConfiguration/didUpdate': [{ key: string; value: string | undefined }]
+    'extensionConfiguration/didUpdate': [{ key: string; value?: string | undefined | null }]
     'extensionConfiguration/openSettings': [null]
 
     // Certain properties of the task are updated:

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -415,7 +415,7 @@ export type ServerNotifications = {
 
     'debug/message': [DebugMessage]
 
-    'extensionConfiguration/didUpdate': [string]
+    'extensionConfiguration/didUpdate': [{ key: string; value: string | undefined }]
     'extensionConfiguration/openSettings': [null]
 
     // Certain properties of the task are updated:


### PR DESCRIPTION
## Changes

This PR fixes how client-side configuration variables are handled to prevent them from being written back to `cody_settings.json` and adds a migration to clean up any settings that were already incorrectly stored.

### Part 1: Prevent writing temporary variables to settings
- Modified the agent protocol and client to use a more granular update approach
- Changed the extension configuration update system to pass specific keys and values instead of the entire configuration object
- Updated the `ConfigUtil` with an additional method to handle targeted configuration updates

### Part 2: Clean up existing configuration files
- Added a migration that runs on plugin startup to clean up the `cody_settings.json` file by:
  - Removing temporary client-side configuration that should not be persisted (agent info, hasNativeWebview)
  - Removing default configuration values to reduce clutter in the settings file
  - Preserving all non-default, user-customized values
- Added comprehensive tests to veify all the functionality


## Test plan

See below for details

### Prerequisites
- IntelliJ IDEA or another JetBrains IDE
- A project with Cody configured

### Test 1: Verifying prevention of writing temporary variables
1. **Set up**: Delete or back up the current `.idea/.sourcegraph/cody_settings.json` file
2. **Launch IDE**: Start the IDE with the updated plugin
3. **Use Cody**: Perform some operations with Cody (e.g., generate code, ask a question)
4. **Verify**: Check `.idea/.sourcegraph/cody_settings.json` and confirm:
   - The file does not contain any `cody.advanced.agent` information
   - The file does not contain `cody.advanced.hasNativeWebview`

### Test 2: Cleaning up temporary client config
1. **Set up**: Create a `.idea/.sourcegraph/cody_settings.json` file with temporary client-side configuration:
   ```json
   {
     "cody": {
       "advanced": {
         "agent": {
           "capabilities": {
             "storage": true
           },
           "extension": {
             "version": "7.91.2-nightly"
           },
           "ide": {
             "name": "JetBrains",
             "productCode": 1,
             "version": "IU-242.20224.300"
           },
           "running": true
         },
         "hasNativeWebview": true
       },
       "autocomplete": {
         "enabled": false
       }
     }
   }
   ```

2. **Restart IDE**: Close and restart the IDE to trigger the migration

3. **Verify**: Check `.idea/.sourcegraph/cody_settings.json` and confirm:
   - The `cody.advanced.agent` section is removed
   - The `cody.advanced.hasNativeWebview` setting is removed
   - Non default settings like `cody.autocomplete.enabled` set to `false` remain intact

