### PR TITLE
Fix issue with duplicated models in the model selection

### DIFF
--- a/lib/shared/src/models/sync.ts
+++ b/lib/shared/src/models/sync.ts
@@ -207,8 +207,9 @@ export function syncModels({
                                                                 m.status !== 'deprecated' &&
                                                                 (isDotComUser || m.status !== 'waitlist')
                                                         )
-                                                    data.primaryModels.push(
-                                                        ...maybeAdjustContextWindows(filteredModels, {
+                                                    data.primaryModels = maybeAdjustContextWindows(
+                                                        filteredModels,
+                                                        {
                                                             tier: isDotComUser
                                                                 ? isCodyProUser(
                                                                       authStatus,
@@ -219,13 +220,14 @@ export function syncModels({
                                                                 : 'enterprise',
                                                             enhancedContextWindowFlagEnabled:
                                                                 enhancedContextWindowFlag,
-                                                        }).map(model =>
-                                                            createModelFromServerModel(
-                                                                model,
-                                                                enhancedContextWindowFlag
-                                                            )
+                                                        }
+                                                    ).map(model =>
+                                                        createModelFromServerModel(
+                                                            model,
+                                                            enhancedContextWindowFlag
                                                         )
                                                     )
+
                                                     data.preferences!.defaults =
                                                         defaultModelPreferencesFromServerModelsConfig(
                                                             serverModelsConfig


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/CODY-5800
## Changes

This PR fixes the bug when we were appending to model list (instead of overwriting it).
It was happening only if feature flags were changing, but that can easily happen in case of lost network connectivity (see testplan).

![image](https://github.com/user-attachments/assets/9a0e3322-895f-4440-865e-ee1d726e9fdf)


## Test plan

1. Apply the diff bellow to increase frequency of feature flags refresh
```diff
Wait for Cody to load and then disable network for 15 sec and enable it again :slightly_smiling_face:
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -170,7 +170,7 @@ export enum FeatureFlag {
     AgenticContextDisabled = 'agentic-context-disabled',
 }

-const ONE_HOUR = 60 * 60 * 1000
+const ONE_HOUR = 10 * 1000
```

2. Wait for Cody to load
3. Disable network for 15 sec (you should notice UI blinking shortly during model refresh) and enable it again 

Before this fix models list should be duplicated, with it it should remain correct.