### PR TITLE
Enable prompts sort by relevance for insider builds

### DIFF
--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -1325,7 +1325,6 @@ export class SourcegraphGraphQLAPIClient {
             }),
             this.isValidSiteVersion({
                 minimumVersion: '6.3.1',
-                insider: false,
             }),
         ])
 

--- a/vscode/webviews/components/promptOwnerFilter/PromptOwnerFilter.tsx
+++ b/vscode/webviews/components/promptOwnerFilter/PromptOwnerFilter.tsx
@@ -65,18 +65,21 @@ export const PromptOwnerFilter: FC<PromptOwnerFilterProps> = ({
                         variant="outline"
                         className="tw-inline-flex tw-justify-between tw-items-center tw-w-full"
                     >
-                        <div className="tw-flex tw-items-center">
-                            <FilterIcon size={14} className="tw-mr-2 tw-text-muted-foreground" />
+                        <div className="tw-flex tw-items-center tw-min-w-0 tw-mr-2">
+                            <FilterIcon
+                                size={14}
+                                className="tw-mr-2 tw-text-muted-foreground tw-flex-shrink-0"
+                            />
                             <Tooltip>
                                 <TooltipTrigger asChild>
-                                    <span className="tw-truncate tw-inline-block tw-max-w-[100px]">
+                                    <span className="tw-truncate tw-inline-block tw-max-w-[95px]">
                                         {filterText}
                                     </span>
                                 </TooltipTrigger>
                                 <TooltipContent side="bottom">{filterText}</TooltipContent>
                             </Tooltip>
                         </div>
-                        <ChevronDown size={14} className="tw-ml-2 tw-text-muted-foreground" />
+                        <ChevronDown size={14} className="tw-text-muted-foreground tw-flex-shrink-0" />
                     </Button>
                 </PopoverTrigger>
                 <PopoverContent className="tw-w-[220px] !tw-p-0" side="bottom" align="start">

--- a/vscode/webviews/components/promptOwnerFilter/PromptOwnerFilter.tsx
+++ b/vscode/webviews/components/promptOwnerFilter/PromptOwnerFilter.tsx
@@ -69,7 +69,9 @@ export const PromptOwnerFilter: FC<PromptOwnerFilterProps> = ({
                             <FilterIcon size={14} className="tw-mr-2 tw-text-muted-foreground" />
                             <Tooltip>
                                 <TooltipTrigger asChild>
-                                    <span className="tw-truncate tw-inline-block tw-max-w-[100px]">{filterText}</span>
+                                    <span className="tw-truncate tw-inline-block tw-max-w-[100px]">
+                                        {filterText}
+                                    </span>
                                 </TooltipTrigger>
                                 <TooltipContent side="bottom">{filterText}</TooltipContent>
                             </Tooltip>

--- a/vscode/webviews/components/promptOwnerFilter/PromptOwnerFilter.tsx
+++ b/vscode/webviews/components/promptOwnerFilter/PromptOwnerFilter.tsx
@@ -3,6 +3,7 @@ import { type FC, useMemo, useState } from 'react'
 import { Button } from '../shadcn/ui/button'
 import { Command, CommandGroup, CommandItem, CommandList } from '../shadcn/ui/command'
 import { Popover, PopoverContent, PopoverTrigger } from '../shadcn/ui/popover'
+import { Tooltip, TooltipContent, TooltipTrigger } from '../shadcn/ui/tooltip'
 
 export interface Organization {
     id: string
@@ -62,11 +63,16 @@ export const PromptOwnerFilter: FC<PromptOwnerFilterProps> = ({
                 <PopoverTrigger asChild onClick={() => setIsOpen(!isOpen)}>
                     <Button
                         variant="outline"
-                        className="tw-inline-flex tw-justify-between tw-items-center tw-w-auto"
+                        className="tw-inline-flex tw-justify-between tw-items-center tw-w-full"
                     >
                         <div className="tw-flex tw-items-center">
                             <FilterIcon size={14} className="tw-mr-2 tw-text-muted-foreground" />
-                            <span>{filterText}</span>
+                            <Tooltip>
+                                <TooltipTrigger asChild>
+                                    <span className="tw-truncate tw-inline-block tw-max-w-[100px]">{filterText}</span>
+                                </TooltipTrigger>
+                                <TooltipContent side="bottom">{filterText}</TooltipContent>
+                            </Tooltip>
                         </div>
                         <ChevronDown size={14} className="tw-ml-2 tw-text-muted-foreground" />
                     </Button>

--- a/vscode/webviews/components/promptSelectField/PromptSelectField.tsx
+++ b/vscode/webviews/components/promptSelectField/PromptSelectField.tsx
@@ -122,18 +122,22 @@ export const PromptSelectField: React.FunctionComponent<{
                 <div className="tw-flex tw-flex-col tw-max-h-[500px] tw-overflow-auto tw-relative">
                     <div className="tw-flex tw-flex-row tw-gap-4 tw-px-2 tw-py-3 tw-border-b tw-border-border tw-mb-1">
                         <div className="tw-flex tw-flex-row tw-gap-2 tw-justify-start">
-                            <PromptOwnerFilter
-                                value={ownerFilterValue}
-                                onFilterChange={setOwnerFilterValue}
-                                className="!tw-px-0 !tw-py-0 !tw-border-b-0"
-                                organizations={organizations}
-                                userId={userId && !userIdError ? (userId as string) : undefined}
-                            />
-                            <PromptTagsFilter
-                                selectedTagId={selectedTagId}
-                                onTagChange={setSelectedTagId}
-                                className="!tw-px-0 !tw-py-0 !tw-border-b-0"
-                            />
+                            <div className="tw-w-1/2">
+                                <PromptOwnerFilter
+                                    value={ownerFilterValue}
+                                    onFilterChange={setOwnerFilterValue}
+                                    className="!tw-px-0 !tw-py-0 !tw-border-b-0"
+                                    organizations={organizations}
+                                    userId={userId && !userIdError ? (userId as string) : undefined}
+                                />
+                            </div>
+                            <div className="tw-w-1/2">
+                                <PromptTagsFilter
+                                    selectedTagId={selectedTagId}
+                                    onTagChange={setSelectedTagId}
+                                    className="!tw-px-0 !tw-py-0 !tw-border-b-0"
+                                />
+                            </div>
                         </div>
                     </div>
                     <PromptList

--- a/vscode/webviews/components/promptTagsFilter/PromptTagsFilter.tsx
+++ b/vscode/webviews/components/promptTagsFilter/PromptTagsFilter.tsx
@@ -31,11 +31,14 @@ export const PromptTagsFilter: FC<PromptTagsFilterProps> = ({
                         variant="outline"
                         className="tw-inline-flex tw-justify-between tw-items-center tw-w-full"
                     >
-                        <div className="tw-flex tw-items-center">
-                            <Tag size={14} className="tw-mr-2 tw-text-muted-foreground" />
+                        <div className="tw-flex tw-items-center tw-min-w-0 tw-mr-2">
+                            <Tag
+                                size={14}
+                                className="tw-mr-2 tw-text-muted-foreground tw-flex-shrink-0"
+                            />
                             <Tooltip>
                                 <TooltipTrigger asChild>
-                                    <span className="tw-truncate tw-inline-block tw-max-w-[100px]">
+                                    <span className="tw-truncate tw-inline-block tw-max-w-[95px]">
                                         {selectedTagName || 'All tags'}
                                     </span>
                                 </TooltipTrigger>
@@ -44,7 +47,7 @@ export const PromptTagsFilter: FC<PromptTagsFilterProps> = ({
                                 </TooltipContent>
                             </Tooltip>
                         </div>
-                        <ChevronDown size={14} className="tw-ml-2 tw-text-muted-foreground" />
+                        <ChevronDown size={14} className="tw-text-muted-foreground tw-flex-shrink-0" />
                     </Button>
                 </PopoverTrigger>
                 <PopoverContent className="tw-w-[220px] !tw-p-0" side="bottom" align="start">

--- a/vscode/webviews/components/promptTagsFilter/PromptTagsFilter.tsx
+++ b/vscode/webviews/components/promptTagsFilter/PromptTagsFilter.tsx
@@ -35,7 +35,9 @@ export const PromptTagsFilter: FC<PromptTagsFilterProps> = ({
                             <Tag size={14} className="tw-mr-2 tw-text-muted-foreground" />
                             <Tooltip>
                                 <TooltipTrigger asChild>
-                                    <span className="tw-truncate tw-inline-block tw-max-w-[100px]">{selectedTagName || 'All tags'}</span>
+                                    <span className="tw-truncate tw-inline-block tw-max-w-[100px]">
+                                        {selectedTagName || 'All tags'}
+                                    </span>
                                 </TooltipTrigger>
                                 <TooltipContent side="bottom">
                                     {selectedTagName || 'All tags'}

--- a/vscode/webviews/components/promptTagsFilter/PromptTagsFilter.tsx
+++ b/vscode/webviews/components/promptTagsFilter/PromptTagsFilter.tsx
@@ -3,6 +3,7 @@ import { type FC, useState } from 'react'
 import { Button } from '../shadcn/ui/button'
 import { Command, CommandGroup, CommandItem, CommandList } from '../shadcn/ui/command'
 import { Popover, PopoverContent, PopoverTrigger } from '../shadcn/ui/popover'
+import { Tooltip, TooltipContent, TooltipTrigger } from '../shadcn/ui/tooltip'
 import { usePromptTagsQuery } from './usePromptTagsQuery'
 
 interface PromptTagsFilterProps {
@@ -28,11 +29,18 @@ export const PromptTagsFilter: FC<PromptTagsFilterProps> = ({
                 <PopoverTrigger asChild onClick={() => setIsOpen(!isOpen)}>
                     <Button
                         variant="outline"
-                        className="tw-inline-flex tw-justify-between tw-items-center tw-w-auto"
+                        className="tw-inline-flex tw-justify-between tw-items-center tw-w-full"
                     >
                         <div className="tw-flex tw-items-center">
                             <Tag size={14} className="tw-mr-2 tw-text-muted-foreground" />
-                            <span>{selectedTagName || 'All tags'}</span>
+                            <Tooltip>
+                                <TooltipTrigger asChild>
+                                    <span className="tw-truncate tw-inline-block tw-max-w-[100px]">{selectedTagName || 'All tags'}</span>
+                                </TooltipTrigger>
+                                <TooltipContent side="bottom">
+                                    {selectedTagName || 'All tags'}
+                                </TooltipContent>
+                            </Tooltip>
                         </div>
                         <ChevronDown size={14} className="tw-ml-2 tw-text-muted-foreground" />
                     </Button>


### PR DESCRIPTION
Enables using latest gql query to sort prompts by relevance on the insider builds as well, given now the backend changes are deployed to S2. 

Also fixes the css issue with prompt filter components which didn't have text truncation. 

## Test plan

- Open prompts picker make sure that the prompts are sorted by relevance. https://linear.app/sourcegraph/issue/CODY-5752/update-prompts-sorting-in-web