### PR TITLE
Recently Used Prompts

### DIFF
--- a/lib/shared/src/misc/rpc/webviewAPI.ts
+++ b/lib/shared/src/misc/rpc/webviewAPI.ts
@@ -200,6 +200,7 @@ export interface PromptsInput {
     owner?: string
     includeViewerDrafts?: boolean
     builtinOnly?: boolean
+    recentlyUsedOnly?: boolean
 }
 
 export type Action = PromptAction | CommandAction

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -1305,9 +1305,10 @@ export class SourcegraphGraphQLAPIClient {
         owner,
         includeViewerDrafts,
         builtinOnly,
+        include,
     }: {
         query?: string
-        first: number | undefined
+        first: number
         recommendedOnly?: boolean
         tags?: string[]
         signal?: AbortSignal
@@ -1315,6 +1316,7 @@ export class SourcegraphGraphQLAPIClient {
         owner?: string
         includeViewerDrafts?: boolean
         builtinOnly?: boolean
+        include?: string[]
     }): Promise<Prompt[]> {
         const [hasIncludeViewerDraftsArg, hasPromptTagsField, hasOrderByRelevance] = await Promise.all([
             this.isValidSiteVersion({
@@ -1325,7 +1327,6 @@ export class SourcegraphGraphQLAPIClient {
             }),
             this.isValidSiteVersion({
                 minimumVersion: '6.3.1',
-                insider: false,
             }),
         ])
 
@@ -1337,12 +1338,13 @@ export class SourcegraphGraphQLAPIClient {
 
         const input = {
             query,
-            first: first ?? 100,
+            first,
             recommendedOnly: recommendedOnly,
             tags: hasPromptTagsField ? tags : undefined,
             owner,
             includeViewerDrafts: includeViewerDrafts ?? true,
             builtinOnly,
+            include,
             orderBy: hasOrderByRelevance ? PromptsOrderBy.PROMPT_RELEVANCE : undefined,
             orderByMultiple: hasOrderByRelevance
                 ? undefined

--- a/lib/shared/src/sourcegraph-api/graphql/queries.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/queries.ts
@@ -364,8 +364,8 @@ export enum PromptsOrderBy {
 }
 
 export const LEGACY_PROMPTS_QUERY_6_3 = `
-query ViewerPrompts($query: String, $first: Int!, $recommendedOnly: Boolean!, $orderByMultiple: [PromptsOrderBy!], $tags: [ID!], $owner: ID, $includeViewerDrafts: Boolean!) {
-    prompts(query: $query, first: $first, includeDrafts: false, recommendedOnly: $recommendedOnly, includeViewerDrafts: $includeViewerDrafts, viewerIsAffiliated: true, orderByMultiple: $orderByMultiple, tags: $tags, owner: $owner) {
+query ViewerPrompts($query: String, $first: Int!, $recommendedOnly: Boolean!, $orderByMultiple: [PromptsOrderBy!], $tags: [ID!], $owner: ID, $includeViewerDrafts: Boolean!, $include: [ID!]) {
+    prompts(query: $query, first: $first, includeDrafts: false, recommendedOnly: $recommendedOnly, includeViewerDrafts: $includeViewerDrafts, viewerIsAffiliated: true, orderByMultiple: $orderByMultiple, tags: $tags, owner: $owner, include: $include) {
         nodes {
             id
             name
@@ -400,8 +400,8 @@ query ViewerPrompts($query: String, $first: Int!, $recommendedOnly: Boolean!, $o
 }`
 
 export const PROMPTS_QUERY = `
-query ViewerPrompts($query: String, $first: Int!, $recommendedOnly: Boolean!, $orderBy: PromptsOrderBy!, $tags: [ID!], $owner: ID, $includeViewerDrafts: Boolean!) {
-    prompts(query: $query, first: $first, includeDrafts: false, recommendedOnly: $recommendedOnly, includeViewerDrafts: $includeViewerDrafts, viewerIsAffiliated: true, orderBy: $orderBy, tags: $tags, owner: $owner) {
+query ViewerPrompts($query: String, $first: Int!, $recommendedOnly: Boolean!, $orderBy: PromptsOrderBy!, $tags: [ID!], $owner: ID, $includeViewerDrafts: Boolean!, $include: [ID!]) {
+    prompts(query: $query, first: $first, includeDrafts: false, recommendedOnly: $recommendedOnly, includeViewerDrafts: $includeViewerDrafts, viewerIsAffiliated: true, orderBy: $orderBy, tags: $tags, owner: $owner, include: $include) {
         nodes {
             id
             name

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -108,6 +108,7 @@ import { migrateAndNotifyForOutdatedModels } from '../../models/modelMigrator'
 import { logDebug, outputChannelLogger } from '../../output-channel-logger'
 import { hydratePromptText } from '../../prompts/prompt-hydration'
 import { listPromptTags, mergedPromptsAndLegacyCommands } from '../../prompts/prompts'
+import { saveRecentlyUsedPrompt } from '../../prompts/recent'
 import { workspaceFolderForRepo } from '../../repository/remoteRepos'
 import { repoNameResolver } from '../../repository/repo-name-resolver'
 import { authProvider } from '../../services/AuthProvider'
@@ -390,6 +391,15 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                 break
             case 'show-page':
                 await vscode.commands.executeCommand('cody.show-page', message.page)
+                break
+            case 'saveRecentlyUsedPrompt':
+                {
+                    const auth = currentAuthStatusAuthed()
+                    saveRecentlyUsedPrompt({
+                        authStatus: auth,
+                        id: message.id,
+                    })
+                }
                 break
             case 'attribution-search':
                 await this.handleAttributionSearch(message.snippet)

--- a/vscode/src/chat/chat-view/ChatsController.ts
+++ b/vscode/src/chat/chat-view/ChatsController.ts
@@ -103,10 +103,11 @@ export class ChatsController implements vscode.Disposable {
     }
 
     public async executePrompt({
+        id,
         text,
         mode,
         autoSubmit,
-    }: { text: string; mode: PromptMode; autoSubmit: boolean }): Promise<void> {
+    }: { id: string; text: string; mode: PromptMode; autoSubmit: boolean }): Promise<void> {
         await vscode.commands.executeCommand('cody.chat.new')
 
         const webviewPanelOrView =
@@ -116,7 +117,7 @@ export class ChatsController implements vscode.Disposable {
             () =>
                 webviewPanelOrView.webview.postMessage({
                     type: 'clientAction',
-                    setPromptAsInput: { text, mode, autoSubmit },
+                    setPromptAsInput: { id, text, mode, autoSubmit },
                 }),
             1000
         )

--- a/vscode/src/chat/chat-view/prompts-migration.ts
+++ b/vscode/src/chat/chat-view/prompts-migration.ts
@@ -98,7 +98,7 @@ export async function startPromptsMigration(): Promise<void> {
         try {
             const prompts = await graphqlClient.queryPrompts({
                 query: commandKey.replace(/\s+/g, '-'),
-                first: undefined,
+                first: 100,
                 recommendedOnly: false,
             })
 

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -85,6 +85,11 @@ export type WebviewMessage =
           tryLocal?: boolean | undefined | null
       }
     | {
+          // Save a recently used prompt ID
+          command: 'saveRecentlyUsedPrompt'
+          id: string
+      }
+    | {
           command: 'openFileLink'
           uri: Uri
           range?: RangeData | undefined | null
@@ -222,7 +227,7 @@ export type ExtensionMessage =
           smartApplyResult?: SmartApplyResult | undefined | null
           submitHumanInput?: boolean | undefined | null
           setPromptAsInput?:
-              | { text: string; mode?: PromptMode | undefined | null; autoSubmit: boolean }
+              | { id: string; text: string; mode?: PromptMode | undefined | null; autoSubmit: boolean }
               | undefined
               | null
           regenerateStatus?:

--- a/vscode/src/prompts/manager.ts
+++ b/vscode/src/prompts/manager.ts
@@ -53,14 +53,16 @@ export class PromptsManager implements vscode.Disposable {
                 }
 
                 const {
+                    id,
                     text,
                     mode,
                     autoSubmit,
-                }: { text: string; mode: PromptMode; autoSubmit: boolean } = JSON.parse(
+                }: { id: string; text: string; mode: PromptMode; autoSubmit: boolean } = JSON.parse(
                     (item as unknown as { value: string }).value
                 )
 
                 this.chatsController.executePrompt({
+                    id,
                     text,
                     mode,
                     autoSubmit,

--- a/vscode/src/prompts/prompts.ts
+++ b/vscode/src/prompts/prompts.ts
@@ -103,7 +103,6 @@ export async function mergedPromptsAndLegacyCommands(
     const auth = currentAuthStatus()
     const recentlyUsedPromptIds = auth.authenticated ? getRecentlyUsedPrompts({ authStatus: auth }) : []
 
-    // Create all promises for parallel execution
     const [recentlyUsedCustomPrompts, customPrompts, isUnifiedPromptsEnabled, isNewPromptsSgVersion] =
         await Promise.all([
             // Fetch recently used prompts
@@ -142,10 +141,10 @@ export async function mergedPromptsAndLegacyCommands(
     if (customPrompts === 'unsupported' || recentlyUsedCustomPrompts === 'unsupported') {
         actions = matchingCommands
     } else {
-        // Use all recently used prompts if filter is enabled, otherwise just the top 3
+        // Use all recently used prompts if filter is enabled, otherwise just the top 4
         const usableRecentPrompts = recentlyUsedOnly
             ? recentlyUsedCustomPrompts
-            : recentlyUsedCustomPrompts.slice(0, 3)
+            : recentlyUsedCustomPrompts.slice(0, 4)
 
         // Only include other prompts if we're not filtering to recently used only
         const otherPrompts = recentlyUsedOnly

--- a/vscode/src/prompts/recent.ts
+++ b/vscode/src/prompts/recent.ts
@@ -1,0 +1,62 @@
+import { localStorage } from '../services/LocalStorageProvider'
+
+// Constants
+const LOCAL_STORAGE_KEY = 'cody-recently-used-prompts'
+const MAX_STORED_PROMPTS = 50
+
+/**
+ * Get the local storage key for recently used prompts
+ */
+const getLocalStorageKey = ({
+    authStatus,
+}: { authStatus: { endpoint: string; username: string } }): string => {
+    return `${LOCAL_STORAGE_KEY}:${authStatus.endpoint}:${authStatus.username}`
+}
+
+/**
+ * Save a recently used prompt ID to local storage
+ * @param authStatus Authentication status containing endpoint and username
+ * @param id The prompt ID to save
+ */
+export function saveRecentlyUsedPrompt({
+    authStatus,
+    id,
+}: {
+    authStatus: { endpoint: string; username: string }
+    id: string
+}): Promise<void> {
+    // Get existing prompt IDs
+    const key = getLocalStorageKey({ authStatus })
+    const data = localStorage.get<string>(key)
+    let promptIds: string[] = data ? JSON.parse(data) : []
+
+    // Remove the ID if it already exists (to move it to the start)
+    promptIds = promptIds.filter(promptId => promptId !== id)
+
+    // Add the ID to the beginning of the array
+    promptIds.unshift(id)
+
+    // Truncate the list to max limit
+    promptIds = promptIds.slice(0, MAX_STORED_PROMPTS)
+
+    // Save the updated list
+    return localStorage.set(key, JSON.stringify(promptIds))
+}
+
+/**
+ * Get the list of recently used prompt IDs
+ * @param authStatus Authentication status containing endpoint and username
+ * @returns Array of prompt IDs ordered by recency (most recent first)
+ */
+export function getRecentlyUsedPrompts({
+    authStatus,
+}: {
+    authStatus: { endpoint: string; username: string }
+}): string[] {
+    const key = getLocalStorageKey({ authStatus })
+    const data = localStorage.get<string>(key)
+    if (!data) {
+        return []
+    }
+    return JSON.parse(data)
+}

--- a/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
@@ -31,6 +31,7 @@ import {
 import type { UserAccountInfo } from '../../../../../Chat'
 import { type ClientActionListener, useClientActionListener } from '../../../../../client/clientState'
 import { promptModeToIntent } from '../../../../../prompts/promptUtils'
+import { getVSCodeAPI } from '../../../../../utils/VSCodeApi'
 import { useTelemetryRecorder } from '../../../../../utils/telemetry'
 import { useConfig } from '../../../../../utils/useConfig'
 import { useLinkOpener } from '../../../../../utils/useLinkOpener'
@@ -299,6 +300,12 @@ export const HumanMessageEditor: FunctionComponent<{
                     // set the intent
                     promptIntent = promptModeToIntent(setPromptAsInput.mode)
                     manuallySelectIntent(promptIntent)
+
+                    // Save the prompt ID to recently used prompts
+                    getVSCodeAPI().postMessage({
+                        command: 'saveRecentlyUsedPrompt',
+                        id: setPromptAsInput.id,
+                    })
 
                     updates.push(
                         // biome-ignore lint/suspicious/noAsyncPromiseExecutor: <explanation>

--- a/vscode/webviews/chat/components/WelcomeMessage.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.tsx
@@ -25,7 +25,6 @@ export const WelcomeMessage: FunctionComponent<WelcomeMessageProps> = ({ setView
                 <PromptList
                     showSearch={false}
                     showFirstNItems={4}
-                    recommendedOnly={true}
                     showCommandOrigins={true}
                     showOnlyPromptInsertableCommands={false}
                     showPromptLibraryUnsupportedMessage={false}

--- a/vscode/webviews/components/promptList/PromptList.tsx
+++ b/vscode/webviews/components/promptList/PromptList.tsx
@@ -94,8 +94,6 @@ export const PromptList: FC<PromptListProps> = props => {
 
     const { value: result, error } = usePromptsQuery(promptInput)
 
-    console.log('result', result)
-
     const onSelect = useCallback(
         (rowValue: string): void => {
             const action = result?.actions.find(p => commandRowValue(p) === rowValue)
@@ -171,8 +169,6 @@ export const PromptList: FC<PromptListProps> = props => {
             const shouldExcludeBuiltinCommands =
                 promptFilters?.promoted || promptFilters?.owner || promptFilters?.tags
 
-            console.log('shouldExcludeBuiltinCommands', shouldExcludeBuiltinCommands)
-
             const isEditEnabled = clientCapabilities.edit === 'enabled'
             // Prompts that perform edits are not usable on clients that don't support editing.
             // To avoid cluttering the list with unusable prompts we ignore them completely.
@@ -185,7 +181,6 @@ export const PromptList: FC<PromptListProps> = props => {
                 return actions.filter(action => action.actionType === 'prompt' && !action.builtin)
             }
 
-            console.log('filteredActions', actions.length)
             return actions
         },
         [promptFilters, clientCapabilities.edit]
@@ -196,13 +191,8 @@ export const PromptList: FC<PromptListProps> = props => {
         ? result?.actions.filter(action => action.actionType === 'prompt' || action.mode === 'ask') ?? []
         : result?.actions ?? []
 
-    console.log('allActions', allActions?.length)
-
     const sortedActions = filteredActions(allActions)
     const actions = showFirstNItems ? sortedActions.slice(0, showFirstNItems) : sortedActions
-
-    console.log('sortedActions', sortedActions?.length)
-    console.log('actions', actions?.length)
 
     const inputPaddingClass =
         paddingLevels !== 'none' ? (paddingLevels === 'middle' ? '!tw-p-0' : '!tw-p-2') : ''

--- a/vscode/webviews/components/promptSelectField/PromptSelectField.tsx
+++ b/vscode/webviews/components/promptSelectField/PromptSelectField.tsx
@@ -11,7 +11,7 @@ import {
 import { useTelemetryRecorder } from '../../utils/telemetry'
 import { useConfig } from '../../utils/useConfig'
 import { PromptList, type PromptsFilterArgs } from '../promptList/PromptList'
-import type { Organization } from '../promptOwnerFilter/PromptOwnerFilter'
+import type { Organization, PromptFilterValue } from '../promptOwnerFilter/PromptOwnerFilter'
 import { PromptOwnerFilter } from '../promptOwnerFilter/PromptOwnerFilter'
 import { PromptTagsFilter } from '../promptTagsFilter/PromptTagsFilter'
 import { Button } from '../shadcn/ui/button'
@@ -36,7 +36,10 @@ export const PromptSelectField: React.FunctionComponent<{
 }> = ({ onSelect, onCloseByEscape, className, __storybook__open, promptSelectorRef }) => {
     const telemetryRecorder = useTelemetryRecorder()
     const [selectedTagId, setSelectedTagId] = useState<string | null>(null)
-    const [ownerFilterValue, setOwnerFilterValue] = useState<string | null>(null)
+    const [ownerFilterValue, setOwnerFilterValue] = useState<PromptFilterValue>({
+        owner: null,
+        recentlyUsedOnly: false,
+    })
     const { value: userId, error: userIdError } = useCurrentUserId()
     const { authStatus } = useConfig()
 
@@ -102,8 +105,12 @@ export const PromptSelectField: React.FunctionComponent<{
             filters.tags = [selectedTagId]
         }
 
-        if (ownerFilterValue) {
-            filters.owner = ownerFilterValue
+        if (ownerFilterValue.owner) {
+            filters.owner = ownerFilterValue.owner
+        }
+
+        if (ownerFilterValue.recentlyUsedOnly) {
+            filters.recentlyUsedOnly = true
         }
 
         return Object.keys(filters).length > 0 ? filters : undefined
@@ -146,8 +153,6 @@ export const PromptSelectField: React.FunctionComponent<{
                         telemetryLocation="PromptSelectField"
                         showOnlyPromptInsertableCommands={true}
                         showPromptLibraryUnsupportedMessage={true}
-                        lastUsedSorting={true}
-                        recommendedOnly={false}
                         inputClassName="tw-bg-popover"
                         promptFilters={promptFilters}
                     />

--- a/vscode/webviews/prompts/promptUtils.ts
+++ b/vscode/webviews/prompts/promptUtils.ts
@@ -40,6 +40,7 @@ export function useActionSelect() {
                 dispatchClientAction(
                     {
                         setPromptAsInput: {
+                            id: action.id,
                             text: action.definition.text,
                             mode: action.mode,
                             autoSubmit: action.autoSubmit || false,


### PR DESCRIPTION
closes: https://linear.app/sourcegraph/issue/CODY-5161/improve-organization-of-prompts

Implements recently used prompts tracking and sorting.
- Shows latest 3 recently used prompts at top in the prompt picker
- Adds filter for recently used prompts
- Replaces listing recommended prompts on the welcome screen with the new relevant prompts order

## Test plan

- select any prompt 
- check if the recently selected prompt is at the top on the list in the prompt picker
- check if the recently selected prompt is the first one on the new chat welcome screen
- check if the recently used filter is working correctly. 

<img width="486" alt="image" src="https://github.com/user-attachments/assets/d7fed376-a280-4e65-9d90-d892428f4c52" />
