### PR TITLE
refactor(chat): MCP server management and tool state

### DIFF
--- a/lib/shared/src/llm-providers/mcp/types.ts
+++ b/lib/shared/src/llm-providers/mcp/types.ts
@@ -5,11 +5,13 @@ export interface McpTool extends Tool {
     disabled?: boolean
 }
 
+export type McpConnectionStatus = 'connecting' | 'connected' | 'disconnected' | 'removed'
+
 // Define types for MCP entities
 export interface McpServer {
     name: string
     config: string
-    status: 'connecting' | 'connected' | 'disconnected'
+    status: McpConnectionStatus
     disabled?: boolean
     error?: string
     tools?: McpTool[]

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -471,21 +471,16 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                     }
                 } catch (error) {
                     const errorMessage = error instanceof Error ? error.message : String(error)
+                    logDebug('ChatController', `Failed to ${message.type} server`, errorMessage)
 
-                    if (message.type === 'addServer') {
-                        vscode.window.showErrorMessage(`Failed to add server: ${errorMessage}`)
-                    } else {
-                        logDebug('ChatController', `Failed to ${message.type} server`, errorMessage)
-
-                        void this.postMessage({
-                            type: 'clientAction',
-                            mcpServerError: {
-                                name: 'name' in message ? serverName : '',
-                                error: errorMessage,
-                            },
-                            mcpServerChanged: null,
-                        })
-                    }
+                    void this.postMessage({
+                        type: 'clientAction',
+                        mcpServerError: {
+                            name: 'name' in message ? serverName : '',
+                            error: errorMessage,
+                        },
+                        mcpServerChanged: null,
+                    })
                 }
                 break
             }

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -412,96 +412,80 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                 vscode.commands.executeCommand(message.id, message.arg ?? message.args)
                 break
             case 'mcp': {
+                const mcpManager = MCPManager.instance
+                if (!mcpManager) {
+                    logDebug('ChatController', 'MCP Manager is not initialized')
+                    break
+                }
+                const serverName = message.name
                 try {
-                    const mcpManager = MCPManager.instance
-                    if (!mcpManager) {
-                        throw new Error('MCP Manager is not initialized')
+                    // Special case for updateServer without name (to refresh server list)
+                    if (message.type === 'updateServer' && !serverName) {
+                        mcpManager.refreshServers()
+                        break
                     }
                     // All other operations require a server name
-                    if (!message.name) {
-                        // Special case for updateServer without name (to refresh server list)
-                        if (message.type === 'updateServer') {
-                            await mcpManager.refreshServers()
-                            break
-                        }
-                        throw new Error('Missing name property in MCP message')
+                    if (!serverName) {
+                        break
                     }
                     switch (message.type) {
-                        case 'addServer':
+                        case 'addServer': {
                             if (!message.config) {
-                                throw new Error('Missing config for addServer operation')
+                                break
                             }
-                            try {
-                                await mcpManager.addServer(message.name, message.config)
-
-                                // Send specific message to the UI about the new server
-                                const newServer = mcpManager
-                                    .getServers()
-                                    .find(s => s.name === message.name)
-                                if (newServer) {
-                                    void this.postMessage({
-                                        type: 'clientAction',
-                                        mcpServerChanged: {
-                                            name: newServer.name,
-                                            server: newServer,
-                                        },
-                                    })
-                                }
-                            } catch (error) {
-                                const errorMessage =
-                                    error instanceof Error ? error.message : String(error)
-                                vscode.window.showErrorMessage(`Failed to add server: ${errorMessage}`)
-                                throw error
-                            }
-                            break
-                        case 'updateServer':
-                            if (message.config) {
-                                // Update with full config
-                                await mcpManager.updateServer(message.name, message.config)
-                            } else if (message.toolName) {
-                                // Toggle single tool state
-                                const isDisabled = message.toolDisabled === true
-                                await mcpManager.setToolState(message.name, message.toolName, isDisabled)
-                            }
-                            break
-                        case 'removeServer':
-                            if (!message.name) {
-                                throw new Error('Missing name for removeServer operation')
-                            }
-                            try {
-                                // Store server name before deleting it
-                                const serverName = message.name
-                                await mcpManager.deleteServer(serverName)
-                                this.postMessage({
+                            await mcpManager.addServer(serverName, message.config)
+                            // Send specific message to the UI about the new server
+                            const newServer = mcpManager.getServers().find(s => s.name === serverName)
+                            if (newServer) {
+                                void this.postMessage({
                                     type: 'clientAction',
                                     mcpServerChanged: {
-                                        name: serverName,
-                                        server: null,
+                                        name: newServer.name,
+                                        server: newServer,
                                     },
                                 })
-                            } catch (error) {
-                                const errorMessage =
-                                    error instanceof Error ? error.message : String(error)
-                                vscode.window.showErrorMessage(
-                                    `Failed to remove server: ${errorMessage}`
-                                )
-                                throw error
                             }
                             break
-
+                        }
+                        case 'updateServer':
+                            if (message.config) {
+                                await mcpManager.updateServer(serverName, message.config)
+                            } else if (message.toolName) {
+                                const isDisabled = message.toolDisabled === true
+                                await mcpManager.setToolState(serverName, message.toolName, isDisabled)
+                            }
+                            break
+                        case 'removeServer': {
+                            await mcpManager.deleteServer(serverName)
+                            this.postMessage({
+                                type: 'clientAction',
+                                mcpServerChanged: {
+                                    name: serverName,
+                                    server: null,
+                                },
+                            })
+                            break
+                        }
                         default:
-                            throw new Error(`Unknown MCP operation: ${message.type}`)
+                            logDebug('ChatController', `Unknown MCP operation: ${message.type}`)
                     }
                 } catch (error) {
                     const errorMessage = error instanceof Error ? error.message : String(error)
-                    void this.postMessage({
-                        type: 'clientAction',
-                        mcpServerError: {
-                            name: 'name' in message ? message.name : '',
-                            error: errorMessage,
-                        },
-                        mcpServerChanged: null,
-                    })
+
+                    if (message.type === 'addServer') {
+                        vscode.window.showErrorMessage(`Failed to add server: ${errorMessage}`)
+                    } else {
+                        logDebug('ChatController', `Failed to ${message.type} server`, errorMessage)
+
+                        void this.postMessage({
+                            type: 'clientAction',
+                            mcpServerError: {
+                                name: 'name' in message ? serverName : '',
+                                error: errorMessage,
+                            },
+                            mcpServerChanged: null,
+                        })
+                    }
                 }
                 break
             }

--- a/vscode/src/chat/chat-view/tools/MCPConnectionManager.ts
+++ b/vscode/src/chat/chat-view/tools/MCPConnectionManager.ts
@@ -3,107 +3,114 @@ import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js'
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { logDebug } from '@sourcegraph/cody-shared'
 import type { McpServer } from '@sourcegraph/cody-shared/src/llm-providers/mcp/types'
+import { Subject } from 'observable-fns'
 import * as vscode from 'vscode'
 
-// Re-defined or imported types needed for connection management
 // See https://modelcontextprotocol.io/docs/concepts/transports for details on MCP transport types
 export type McpTransportType = 'stdio' | 'sse'
+export type McpTransport = StdioClientTransport | SSEClientTransport
 
 export type McpConnection = {
     server: McpServer
     client: Client
-    transport: StdioClientTransport | SSEClientTransport
+    transport: McpTransport
 }
 
 export type MCPServerSpec = {
     client: Client
-    transport: StdioClientTransport | SSEClientTransport
+    transport: McpTransport
 }
 
-// Event types for connection status changes
+export type ConnectionStatus = 'connecting' | 'connected' | 'disconnected'
+
 export type ConnectionStatusChangeEvent = {
     serverName: string
-    status: 'connecting' | 'connected' | 'disconnected'
+    status: ConnectionStatus
     error?: string
 }
 
-export class MCPConnectionManager {
-    private connections: McpConnection[] = []
-    private isConnectingFlags: Map<string, boolean> = new Map() // Track connecting state per server
-    private lastConnectionAttempt: Map<string, number> = new Map() // Track last connection attempt time
-    private static readonly CONNECTION_COOLDOWN = 5000 // 5 second cooldown between connection attempts
+export type ServerChangeNotification = {
+    type: 'server' | 'tool'
+    serverName?: string
+}
 
-    // Event emitter for connection status changes
+export class MCPConnectionManager {
+    public static instance: MCPConnectionManager = new MCPConnectionManager()
+
+    private connections: McpConnection[] = []
+
     private statusChangeEmitter = new vscode.EventEmitter<ConnectionStatusChangeEvent>()
     public onStatusChange = this.statusChangeEmitter.event
 
-    // Creates the appropriate MCP client and transport based on config
-    private createMCPClient(name: string, version: string, config: any): MCPServerSpec {
-        const client = new Client({
-            name,
-            version,
-        })
+    private serverChangeNotifications = new Subject<ServerChangeNotification>()
+    public readonly serverChanges = this.serverChangeNotifications
 
-        // SSE transport
+    public notifyServerChanged(serverName?: string): void {
+        this.serverChangeNotifications.next({ type: 'server', serverName })
+    }
+
+    public notifyToolChanged(serverName?: string): void {
+        this.serverChangeNotifications.next({ type: 'tool', serverName })
+    }
+
+    private createMCPClient(name: string, version: string, config: any): MCPServerSpec {
+        const client = new Client({ name, version })
+
         if (config.transportType === 'sse') {
             return {
                 client,
                 transport: new SSEClientTransport(new URL(config.url)),
             }
         }
-        // Default to stdio transport
+
         return {
             client,
             transport: new StdioClientTransport({
                 command: config.command,
                 args: config.args,
-                env: {
-                    ...process.env,
-                    ...config.env,
-                },
+                env: { ...process.env, ...config.env },
                 stderr: 'pipe',
             }),
         }
     }
 
     private setConnectionError(connection: McpConnection, error: string): void {
-        const newError = connection.server.error ? `${connection.server.error}\n${error}` : error
-        connection.server.error = newError
+        connection.server.error = connection.server.error
+            ? `${connection.server.error}\n${error}`
+            : error
     }
 
-    public async addConnection(name: string, config: any, disabled?: boolean): Promise<McpConnection> {
-        if (this.isConnectingFlags.get(name)) {
-            throw new Error(`Already attempting to connect to ${name}`)
+    private updateConnectionStatus(
+        connection: McpConnection,
+        status: ConnectionStatus,
+        error?: string
+    ): void {
+        const { name } = connection.server
+
+        connection.server.status = status
+
+        if (error) {
+            this.setConnectionError(connection, error)
         }
 
-        // Check if we've attempted to connect recently
-        const lastAttempt = this.lastConnectionAttempt.get(name) || 0
-        const now = Date.now()
-        if (now - lastAttempt < MCPConnectionManager.CONNECTION_COOLDOWN) {
-            const waitTime = (MCPConnectionManager.CONNECTION_COOLDOWN - (now - lastAttempt)) / 1000
-            logDebug(
-                'MCPConnectionManager',
-                `Throttling connection to ${name}, tried too recently (${waitTime.toFixed(1)}s ago)`
-            )
-            throw new Error(
-                `Connection attempt throttled. Please wait ${waitTime.toFixed(
-                    1
-                )} seconds before retrying.`
-            )
-        }
+        this.statusChangeEmitter.fire({
+            serverName: name,
+            status,
+            error: connection.server.error,
+        })
 
-        // Record this connection attempt time
-        this.lastConnectionAttempt.set(name, now)
-        this.isConnectingFlags.set(name, true)
+        this.notifyServerChanged(name)
+    }
 
-        // Remove existing connection if it exists (e.g., during restart or config update)
+    public async addConnection(name: string, config: any, disabled = false): Promise<McpConnection> {
+        // Remove existing connection if it exists
         const existingIndex = this.connections.findIndex(conn => conn.server.name === name)
         if (existingIndex !== -1) {
             await this.removeConnection(name)
         }
 
         let client: Client | undefined
-        let transport: StdioClientTransport | SSEClientTransport | undefined
+        let transport: McpTransport | undefined
         let connection: McpConnection | undefined
 
         try {
@@ -114,47 +121,38 @@ export class MCPConnectionManager {
                     name,
                     config: JSON.stringify(config),
                     status: 'connecting',
-                    disabled: disabled ?? false,
+                    disabled,
                 },
                 client,
                 transport,
             }
+
             this.connections.push(connection)
             this.statusChangeEmitter.fire({ serverName: name, status: 'connecting' })
 
+            // Set up transport event handlers
             transport.onclose = () => {
                 logDebug('MCPConnectionManager', `Transport closed for "${name}"`)
-                const conn = this.connections.find(c => c.server.name === name)
+                const conn = this.getConnection(name)
                 if (conn && conn.server.status !== 'disconnected') {
-                    conn.server.status = 'disconnected'
-                    this.statusChangeEmitter.fire({
-                        serverName: name,
-                        status: 'disconnected',
-                        error: conn.server.error,
-                    })
+                    this.updateConnectionStatus(conn, 'disconnected', 'Transport closed')
                 }
             }
 
             transport.onerror = (error: { message: string }) => {
-                logDebug('MCPConnectionManager', `Transport error for "${name}":`, {
+                logDebug('MCPConnectionManager', `Transport error for "${name}"`, {
                     verbose: { error },
                 })
-                const conn = this.connections.find(c => c.server.name === name)
+                const conn = this.getConnection(name)
                 if (conn) {
-                    conn.server.status = 'disconnected'
-                    this.setConnectionError(conn, error.message)
-                    this.statusChangeEmitter.fire({
-                        serverName: name,
-                        status: 'disconnected',
-                        error: conn.server.error,
-                    })
+                    this.updateConnectionStatus(conn, 'disconnected', error.message)
                 }
             }
 
-            // Start the transport first
+            // Connect to the server
             await transport.start()
 
-            // Handle connection attemps
+            // Log connection attempt info
             if (config.transportType === 'stdio' && transport instanceof StdioClientTransport) {
                 logDebug('MCPConnectionManager', `Connecting to stdio server "${name}"...`, {
                     verbose: { config },
@@ -165,17 +163,19 @@ export class MCPConnectionManager {
                 })
             }
 
-            // Monkey-patch start method so connect() doesn't try to start it again
+            // Prevent double-starting the transport
             transport.start = async () => {}
 
             // Connect the client
             await client.connect(transport)
 
-            // Update status on successful connection
+            // Update connection status on success
             connection.server.status = 'connected'
-            connection.server.error = '' // Clear any previous errors (like stderr noise)
+            connection.server.error = '' // Clear previous errors
+
             logDebug('MCPConnectionManager', `Connected to MCP server: ${name}`)
             this.statusChangeEmitter.fire({ serverName: name, status: 'connected' })
+            this.notifyServerChanged(name)
 
             return connection
         } catch (error) {
@@ -184,76 +184,63 @@ export class MCPConnectionManager {
                 verbose: { error },
             })
 
-            // Update status with error if connection object was created
-            const conn = this.connections.find(c => c.server.name === name) ?? connection
+            // Update connection status with error
+            const conn = this.getConnection(name) ?? connection
             if (conn) {
-                conn.server.status = 'disconnected'
-                this.setConnectionError(conn, errorMessage)
-                this.statusChangeEmitter.fire({
-                    serverName: name,
-                    status: 'disconnected',
-                    error: conn.server.error,
-                })
+                this.updateConnectionStatus(conn, 'disconnected', errorMessage)
             }
 
-            // Ensure transport is closed if connection failed mid-way
-            if (transport) {
-                try {
-                    await transport.close()
-                } catch (closeError) {
-                    logDebug(
-                        'MCPConnectionManager',
-                        `Error closing transport for ${name} after connection failure`,
-                        { verbose: { closeError } }
-                    )
-                }
-            }
-            // Ensure client is closed if connection failed mid-way
-            if (client) {
-                try {
-                    await client.close()
-                } catch (closeError) {
-                    logDebug(
-                        'MCPConnectionManager',
-                        `Error closing client for ${name} after connection failure`,
-                        { verbose: { closeError } }
-                    )
-                }
-            }
+            // Clean up resources on failure
+            await Promise.allSettled([
+                transport
+                    ?.close()
+                    .catch(closeError =>
+                        logDebug(
+                            'MCPConnectionManager',
+                            `Error closing transport for ${name} after connection failure`,
+                            { verbose: { closeError } }
+                        )
+                    ),
+                client
+                    ?.close()
+                    .catch(closeError =>
+                        logDebug(
+                            'MCPConnectionManager',
+                            `Error closing client for ${name} after connection failure`,
+                            { verbose: { closeError } }
+                        )
+                    ),
+            ])
 
             throw error // Re-throw the original error
-        } finally {
-            this.isConnectingFlags.delete(name)
         }
     }
 
     public async removeConnection(name: string): Promise<void> {
         const index = this.connections.findIndex(conn => conn.server.name === name)
-        if (index !== -1) {
-            const connection = this.connections[index]
-            this.connections.splice(index, 1) // Remove immediately
+        if (index === -1) return
 
-            try {
-                // Attempt to close transport and client gracefully
-                // close() is likely idempotent
-                await connection.transport.close()
-                await connection.client.close()
-                logDebug('MCPConnectionManager', `Closed connection for ${name}`)
-            } catch (error) {
-                logDebug('MCPConnectionManager', `Failed to cleanly close connection for ${name}:`, {
-                    verbose: { error },
-                })
-            } finally {
-                // Ensure status is updated even if close fails
-                if (connection.server.status !== 'disconnected') {
-                    connection.server.status = 'disconnected'
-                    this.statusChangeEmitter.fire({
-                        serverName: name,
-                        status: 'disconnected',
-                        error: connection.server.error,
-                    })
-                }
-            }
+        const connection = this.connections[index]
+        this.connections.splice(index, 1) // Remove immediately
+
+        try {
+            // Close transport and client gracefully
+            await Promise.all([connection.transport.close(), connection.client.close()])
+            logDebug('MCPConnectionManager', `Closed connection for ${name}`)
+        } catch (error) {
+            logDebug('MCPConnectionManager', `Failed to cleanly close connection for ${name}:`, {
+                verbose: { error },
+            })
+        }
+
+        this.notifyServerChanged(name)
+    }
+
+    public updateConnectionError(serverName: string, error: string): void {
+        const conn = this.getConnection(serverName)
+        if (conn) {
+            this.setConnectionError(conn, error)
+            this.notifyServerChanged(serverName)
         }
     }
 
@@ -262,13 +249,13 @@ export class MCPConnectionManager {
     }
 
     public getAllConnections(): McpConnection[] {
-        return [...this.connections] // Return a copy
+        return [...this.connections].sort((a, b) => a.server.name.localeCompare(b.server.name))
     }
 
     public async dispose(): Promise<void> {
-        const closePromises = this.connections.map(conn => this.removeConnection(conn.server.name))
-        await Promise.allSettled(closePromises)
+        await Promise.allSettled(this.connections.map(conn => this.removeConnection(conn.server.name)))
         this.connections = []
         this.statusChangeEmitter.dispose()
+        this.notifyServerChanged() // Notify about complete server reset
     }
 }

--- a/vscode/src/chat/chat-view/tools/MCPConnectionManager.ts
+++ b/vscode/src/chat/chat-view/tools/MCPConnectionManager.ts
@@ -2,7 +2,10 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js'
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { logDebug } from '@sourcegraph/cody-shared'
-import type { McpServer } from '@sourcegraph/cody-shared/src/llm-providers/mcp/types'
+import type {
+    McpConnectionStatus,
+    McpServer,
+} from '@sourcegraph/cody-shared/src/llm-providers/mcp/types'
 import { Subject } from 'observable-fns'
 import * as vscode from 'vscode'
 
@@ -21,11 +24,9 @@ export type MCPServerSpec = {
     transport: McpTransport
 }
 
-export type ConnectionStatus = 'connecting' | 'connected' | 'disconnected'
-
 export type ConnectionStatusChangeEvent = {
     serverName: string
-    status: ConnectionStatus
+    status: McpConnectionStatus
     error?: string
 }
 
@@ -82,7 +83,7 @@ export class MCPConnectionManager {
 
     private updateConnectionStatus(
         connection: McpConnection,
-        status: ConnectionStatus,
+        status: McpConnectionStatus,
         error?: string
     ): void {
         const { name } = connection.server
@@ -233,6 +234,7 @@ export class MCPConnectionManager {
             })
         }
 
+        this.statusChangeEmitter.fire({ serverName: name, status: 'removed' })
         this.notifyServerChanged(name)
     }
 

--- a/vscode/src/chat/chat-view/tools/MCPManager.ts
+++ b/vscode/src/chat/chat-view/tools/MCPManager.ts
@@ -243,7 +243,7 @@ export class MCPManager {
         if (!connection) return
         try {
             logDebug('MCPManager', `Initializing tools for server: ${serverName}`)
-            connection.server.tools = await this.serverManager.getToolList(serverName)
+            connection.server.tools = (await this.serverManager.getToolList(serverName)) || []
             logDebug('MCPManager', `Initialized tools for server: ${serverName}`, {
                 verbose: { toolCount: connection.server.tools.length },
             })

--- a/vscode/src/chat/chat-view/tools/MCPServerManager.ts
+++ b/vscode/src/chat/chat-view/tools/MCPServerManager.ts
@@ -45,6 +45,7 @@ export class MCPServerManager {
 
     constructor(private connectionManager: MCPConnectionManager) {}
 
+    // Update getToolList method to include disabled status
     public async getToolList(serverName: string): Promise<McpTool[]> {
         try {
             const connection = this.connectionManager.getConnection(serverName)
@@ -62,6 +63,7 @@ export class MCPServerManager {
                 response?.tools?.map(tool => {
                     const fullToolName = `${serverName}_${tool.name || ''}`
                     const isDisabled = this.disabledTools.has(fullToolName)
+
                     return {
                         name: tool.name || '',
                         description: tool.description || '',

--- a/vscode/webviews/components/mcp/ServerHome.tsx
+++ b/vscode/webviews/components/mcp/ServerHome.tsx
@@ -1,5 +1,13 @@
 import type { McpServer } from '@sourcegraph/cody-shared/src/llm-providers/mcp/types'
-import { DatabaseBackup, Minus, PencilRulerIcon, Server, ServerIcon, Settings } from 'lucide-react'
+import {
+    DatabaseBackup,
+    Minus,
+    PencilRulerIcon,
+    RefreshCw,
+    Server,
+    ServerIcon,
+    Settings,
+} from 'lucide-react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { getVSCodeAPI } from '../../utils/VSCodeApi'
 import { Badge } from '../shadcn/ui/badge'
@@ -186,24 +194,42 @@ export function ServerHome({ mcpServers }: ServerHomeProps) {
                 <div className="tw-flex tw-items-center tw-font-semibold tw-text-lg">
                     <ServerIcon size={16} className="tw-mr-3" /> MCP Servers
                 </div>
-                <Button
-                    variant="ghost"
-                    className="tw-h-8 tw-w-auto"
-                    onClick={() =>
-                        getVSCodeAPI().postMessage({
-                            command: 'command',
-                            id: 'workbench.action.openSettingsJson',
-                            args: {
-                                revealSetting: {
-                                    key: 'cody.mcpServers',
+                <div className=" tw-inline-flex tw-gap-2">
+                    <Button
+                        variant="outline"
+                        className="tw-px-2"
+                        onClick={() =>
+                            getVSCodeAPI().postMessage({
+                                command: 'command',
+                                id: 'workbench.action.openSettingsJson',
+                                args: {
+                                    revealSetting: {
+                                        key: 'cody.mcpServers',
+                                    },
                                 },
-                            },
-                        })
-                    }
-                    title="Configure settings in JSON"
-                >
-                    <Settings size={16} /> View JSON
-                </Button>
+                            })
+                        }
+                        title="Configure settings in JSON"
+                    >
+                        <Settings size={16} /> View JSON
+                    </Button>
+                    <Button
+                        variant="outline"
+                        className="tw-px-2"
+                        onClick={() => {
+                            setServers([])
+                            setSelectedServer(null)
+                            getVSCodeAPI().postMessage({
+                                command: 'mcp',
+                                type: 'updateServer',
+                                name: '',
+                            })
+                        }}
+                        title="Refresh server list"
+                    >
+                        <RefreshCw size={16} /> Reload
+                    </Button>
+                </div>
             </header>
             {!mcpServers?.length ? (
                 <div className="tw-w-full tw-col-span-full tw-text-center tw-py-12 tw-border tw-rounded-lg tw-border-none">

--- a/vscode/webviews/components/mcp/ServerHome.tsx
+++ b/vscode/webviews/components/mcp/ServerHome.tsx
@@ -26,6 +26,7 @@ export function ServerHome({ mcpServers }: ServerHomeProps) {
     const [searchQuery, setSearchQuery] = useState('')
     const [selectedServer, setSelectedServer] = useState<ServerType | null>(null)
     const [showSkeletonAnimation, setShowSkeletonAnimation] = useState(true)
+    const [pendingServer, setPendingServer] = useState<string | null>(null)
 
     // Effect to disable skeleton animation after 5 seconds
     useEffect(() => {
@@ -50,6 +51,13 @@ export function ServerHome({ mcpServers }: ServerHomeProps) {
 
             if (message.mcpServerChanged?.name) {
                 const { name, server } = message.mcpServerChanged
+                // Check if server is the same as the one in the state
+
+                if (pendingServer === name) {
+                    setPendingServer(null)
+                    return
+                }
+
                 setServers(prevServers => {
                     if (name && server === null) {
                         // Remove server if it doesn't exist
@@ -94,7 +102,7 @@ export function ServerHome({ mcpServers }: ServerHomeProps) {
 
         window.addEventListener('message', messageHandler)
         return () => window.removeEventListener('message', messageHandler)
-    }, [])
+    }, [pendingServer])
 
     const removeServer = useCallback((serverName: string) => {
         setSelectedServer(null)
@@ -163,6 +171,7 @@ export function ServerHome({ mcpServers }: ServerHomeProps) {
             toolName,
             toolDisabled: isDisabled,
         })
+        setPendingServer(serverName)
         // Update local state optimistically
         setServers(prevServers =>
             prevServers.map(server =>
@@ -261,11 +270,14 @@ export function ServerHome({ mcpServers }: ServerHomeProps) {
                                 />
                             </CommandList>
                         </div>
-                        <CommandList className="tw-flex-1 tw-overflow-y-auto tw-m-2 tw-gap-6 !tw-bg-transparent focus:tw-bg-inherit">
+                        <CommandList
+                            id="mcp-server-list"
+                            className="tw-flex tw-h-full tw-w-full tw-m-2 tw-gap-6 !tw-bg-transparent focus:tw-bg-inherit tw-overflow-y-auto tw-max-h-[60vh]"
+                        >
                             {filteredServers.map(server => (
                                 <CommandItem
                                     key={server.id}
-                                    className="tw-text-left tw-truncate tw-w-full tw-rounded-md tw-text-sm tw-overflow-hidden tw-text-sidebar-foreground tw-align-baseline hover:tw-bg-transparent [&[aria-selected='true']]:tw-bg-transparent tw-my-2"
+                                    className="tw-text-left tw-truncate tw-w-full tw-rounded-md tw-text-sm tw-text-sidebar-foreground tw-align-baseline hover:tw-bg-transparent [&[aria-selected='true']]:tw-bg-transparent tw-my-2"
                                     onSelect={() => setSelectedServer(server)}
                                 >
                                     <div className="tw-truncate tw-w-full tw-flex tw-flex-col tw-gap-2">

--- a/vscode/webviews/components/mcp/ServerHome.tsx
+++ b/vscode/webviews/components/mcp/ServerHome.tsx
@@ -106,11 +106,14 @@ export function ServerHome({ mcpServers }: ServerHomeProps) {
                 name,
                 transportType: server.url ? 'sse' : 'stdio',
             }
-
-            // Add command and args for stdio transport
-            // Only add non-empty args
-            if (server.args?.length) {
-                mcpServerConfig.args = server.args.filter(arg => arg.trim())
+            if (server.url) {
+                mcpServerConfig.url = server.url
+            } else if (server.command) {
+                mcpServerConfig.command = server.command
+                // Only add non-empty args
+                if (server.args?.length) {
+                    mcpServerConfig.args = server.args.filter(arg => arg.trim())
+                }
             }
             // Add environment variables
             if (server.env?.length) {
@@ -296,38 +299,41 @@ export function ServerHome({ mcpServers }: ServerHomeProps) {
                                         )}
                                         <div className="tw-mt-2">
                                             <div className="tw-flex tw-flex-wrap tw-gap-4">
-                                                {server.tools !== undefined ? (
-                                                    server.tools?.map(tool => (
-                                                        <Badge
-                                                            key={`${server.name}-${tool.name}-tool`}
-                                                            variant={
-                                                                tool.disabled ? 'disabled' : 'outline'
-                                                            }
-                                                            className={`tw-truncate tw-max-w-[250px] tw-text-foreground tw-cursor-pointer tw-font-thin ${
-                                                                tool.disabled
-                                                                    ? 'tw-opacity-50 tw-line-through'
-                                                                    : ''
-                                                            }`}
-                                                            onClick={e => {
-                                                                e.stopPropagation()
-                                                                toggleTool(
-                                                                    server.name,
-                                                                    tool.name,
-                                                                    tool.disabled !== true
-                                                                )
-                                                            }}
-                                                            title={`${
-                                                                tool.disabled ? '[Disabled] ' : ''
-                                                            } ${tool.description}`}
-                                                        >
-                                                            {tool.name}
-                                                        </Badge>
-                                                    ))
-                                                ) : (
-                                                    <div className="tw-w-full tw-flex tw-justify-center tw-container">
-                                                        <Loader className="tw-animate-spin" />
-                                                    </div>
-                                                )}
+                                                {server.tools !== undefined
+                                                    ? server.tools?.map(tool => (
+                                                          <Badge
+                                                              key={`${server.name}-${tool.name}-tool`}
+                                                              variant={
+                                                                  tool.disabled ? 'disabled' : 'outline'
+                                                              }
+                                                              className={`tw-truncate tw-max-w-[250px] tw-text-foreground tw-cursor-pointer tw-font-thin ${
+                                                                  tool.disabled
+                                                                      ? 'tw-opacity-50 tw-line-through'
+                                                                      : ''
+                                                              }`}
+                                                              onClick={e => {
+                                                                  e.stopPropagation()
+                                                                  toggleTool(
+                                                                      server.name,
+                                                                      tool.name,
+                                                                      tool.disabled !== true
+                                                                  )
+                                                              }}
+                                                              title={`${
+                                                                  tool.disabled ? '[Disabled] ' : ''
+                                                              } ${tool.description}`}
+                                                          >
+                                                              {tool.name}
+                                                          </Badge>
+                                                      ))
+                                                    : !server?.error && (
+                                                          <div className="tw-w-full tw-flex tw-justify-center tw-container">
+                                                              <Loader
+                                                                  className="tw-animate-spin"
+                                                                  size="sm"
+                                                              />
+                                                          </div>
+                                                      )}
                                             </div>
                                         </div>
                                     </div>

--- a/vscode/webviews/components/mcp/ServerHome.tsx
+++ b/vscode/webviews/components/mcp/ServerHome.tsx
@@ -190,184 +190,190 @@ export function ServerHome({ mcpServers }: ServerHomeProps) {
     }, [searchQuery, servers])
 
     return (
-        <Command
-            loop={true}
-            tabIndex={0}
-            shouldFilter={false}
-            defaultValue="empty"
-            className="tw-flex tw-flex-col tw-h-full tw-py-4 tw-bg-transparent tw-px-2 tw-mb-4 tw-overscroll-auto"
-            disablePointerSelection={true}
-        >
-            <header className="tw-flex tw-items-center tw-justify-between tw-mt-4 tw-px-4">
-                <div className="tw-flex tw-items-center tw-font-semibold tw-text-lg">
-                    <ServerIcon size={16} className="tw-mr-3" /> MCP Servers
-                </div>
-                <div className=" tw-inline-flex tw-gap-2">
-                    <Button
-                        variant="outline"
-                        className="tw-px-2"
-                        onClick={() =>
-                            getVSCodeAPI().postMessage({
-                                command: 'command',
-                                id: 'workbench.action.openSettingsJson',
-                                args: {
-                                    revealSetting: {
-                                        key: 'cody.mcpServers',
-                                    },
-                                },
-                            })
-                        }
-                        title="Configure settings in JSON"
-                    >
-                        <Settings size={16} /> View JSON
-                    </Button>
-                    <Button
-                        variant="outline"
-                        className="tw-px-2"
-                        onClick={() => {
-                            setServers([])
-                            setSelectedServer(null)
-                            getVSCodeAPI().postMessage({
-                                command: 'mcp',
-                                type: 'updateServer',
-                                name: '',
-                            })
-                        }}
-                        title="Refresh server list"
-                    >
-                        <RefreshCw size={16} /> Reload
-                    </Button>
-                </div>
-            </header>
-            {!mcpServers?.length ? (
-                <div className="tw-w-full tw-col-span-full tw-text-center tw-py-12 tw-border tw-rounded-lg tw-border-none">
-                    <Server className="tw-h-12 tw-w-12 tw-mx-auto tw-mb-4 tw-text-muted-foreground" />
-                    <h3 className="tw-text-md tw-font-medium">Waiting for server connections...</h3>
-                    <p className="tw-text-muted-foreground tw-mt-1">Add a new server to get started</p>
-                </div>
-            ) : (
-                <div>
-                    <div className="tw-flex tw-items-center tw-justify-between tw-px-2 tw-py-1">
-                        <CommandList className="tw-flex-1">
-                            <CommandInput
-                                value={searchQuery}
-                                onValueChange={setSearchQuery}
-                                placeholder="Search..."
-                                autoFocus={true}
-                                className="tw-m-[0.5rem] !tw-p-[0.5rem] tw-rounded tw-bg-input-background tw-text-input-foreground focus:tw-shadow-[0_0_0_0.125rem_var(--vscode-focusBorder)]"
-                            />
-                        </CommandList>
+        <div className="tw-flex tw-flex-col tw-justify-center tw-overflow-hidden tw-h-full tw-w-full">
+            <Command
+                loop={true}
+                tabIndex={0}
+                shouldFilter={false}
+                defaultValue="empty"
+                className="tw-flex tw-flex-col tw-py-4 tw-bg-transparent tw-px-2 tw-mb-4 tw-overscroll-auto"
+                disablePointerSelection={true}
+            >
+                <header className="tw-flex tw-items-center tw-justify-between tw-mt-4 tw-px-4">
+                    <div className="tw-flex tw-items-center tw-font-semibold tw-text-lg">
+                        <ServerIcon size={16} className="tw-mr-3" /> MCP Servers
                     </div>
-                    <CommandList className="tw-flex-1 tw-overflow-y-auto tw-m-2 tw-gap-6 !tw-bg-transparent focus:tw-bg-inherit">
-                        {filteredServers.map(server => (
-                            <CommandItem
-                                key={server.id}
-                                className="tw-text-left tw-truncate tw-w-full tw-rounded-md tw-text-sm tw-overflow-hidden tw-text-sidebar-foreground tw-align-baseline hover:tw-bg-transparent [&[aria-selected='true']]:tw-bg-transparent tw-my-2"
-                                onSelect={() => setSelectedServer(server)}
-                            >
-                                <div className="tw-truncate tw-w-full tw-flex tw-flex-col tw-gap-2">
-                                    <div className="tw-flex tw-items-center tw-justify-between tw-gap-2">
-                                        <div className="tw-flex tw-self-end tw-gap-2">
-                                            <PencilRulerIcon
-                                                className="tw-w-8 tw-h-8"
-                                                strokeWidth={1.25}
-                                                size={16}
-                                            />
-                                            <strong>{server.name}</strong>
-                                        </div>
-                                        {server.name === selectedServer?.name && (
-                                            <Button
-                                                variant="ghost"
-                                                size="sm"
-                                                className="tw-p-2 tw-z-10"
-                                                onClick={e => {
-                                                    e.stopPropagation()
-                                                    removeServer(server.name)
-                                                }}
-                                                title="Delete server"
-                                            >
-                                                <Minus size={16} />
-                                            </Button>
-                                        )}
-                                    </div>
-                                    <div className="tw-flex tw-align-top tw-justify-between tw-my-1 tw-flex-wrap">
-                                        {server.error && (
-                                            <div className="tw-mt-2 tw-mb-1 tw-w-full">
-                                                <p
-                                                    className="tw-text-xs tw-text-pink-300 tw-mt-1 tw-truncate"
-                                                    title={server.error}
-                                                >
-                                                    {server.error}
-                                                </p>
+                    <div className=" tw-inline-flex tw-gap-2">
+                        <Button
+                            variant="outline"
+                            className="tw-px-2"
+                            onClick={() =>
+                                getVSCodeAPI().postMessage({
+                                    command: 'command',
+                                    id: 'workbench.action.openSettingsJson',
+                                    args: {
+                                        revealSetting: {
+                                            key: 'cody.mcpServers',
+                                        },
+                                    },
+                                })
+                            }
+                            title="Configure settings in JSON"
+                        >
+                            <Settings size={16} /> View JSON
+                        </Button>
+                        <Button
+                            variant="outline"
+                            className="tw-px-2"
+                            onClick={() => {
+                                setServers([])
+                                setSelectedServer(null)
+                                getVSCodeAPI().postMessage({
+                                    command: 'mcp',
+                                    type: 'updateServer',
+                                    name: '',
+                                })
+                            }}
+                            title="Refresh server list"
+                        >
+                            <RefreshCw size={16} /> Reload
+                        </Button>
+                    </div>
+                </header>
+                {!mcpServers?.length ? (
+                    <div className="tw-w-full tw-col-span-full tw-text-center tw-py-12 tw-border tw-rounded-lg tw-border-none">
+                        <Server className="tw-h-12 tw-w-12 tw-mx-auto tw-mb-4 tw-text-muted-foreground" />
+                        <h3 className="tw-text-md tw-font-medium">Waiting for server connections...</h3>
+                        <p className="tw-text-muted-foreground tw-mt-1">
+                            Add a new server to get started
+                        </p>
+                    </div>
+                ) : (
+                    <div>
+                        <div className="tw-flex tw-items-center tw-justify-between tw-px-2 tw-py-1">
+                            <CommandList className="tw-flex-1">
+                                <CommandInput
+                                    value={searchQuery}
+                                    onValueChange={setSearchQuery}
+                                    placeholder="Search..."
+                                    autoFocus={true}
+                                    className="tw-m-[0.5rem] !tw-p-[0.5rem] tw-rounded tw-bg-input-background tw-text-input-foreground focus:tw-shadow-[0_0_0_0.125rem_var(--vscode-focusBorder)]"
+                                />
+                            </CommandList>
+                        </div>
+                        <CommandList className="tw-flex-1 tw-overflow-y-auto tw-m-2 tw-gap-6 !tw-bg-transparent focus:tw-bg-inherit">
+                            {filteredServers.map(server => (
+                                <CommandItem
+                                    key={server.id}
+                                    className="tw-text-left tw-truncate tw-w-full tw-rounded-md tw-text-sm tw-overflow-hidden tw-text-sidebar-foreground tw-align-baseline hover:tw-bg-transparent [&[aria-selected='true']]:tw-bg-transparent tw-my-2"
+                                    onSelect={() => setSelectedServer(server)}
+                                >
+                                    <div className="tw-truncate tw-w-full tw-flex tw-flex-col tw-gap-2">
+                                        <div className="tw-flex tw-items-center tw-justify-between tw-gap-2">
+                                            <div className="tw-flex tw-self-end tw-gap-2">
+                                                <PencilRulerIcon
+                                                    className="tw-w-8 tw-h-8"
+                                                    strokeWidth={1.25}
+                                                    size={16}
+                                                />
+                                                <strong>{server.name}</strong>
                                             </div>
-                                        )}
-                                        <div className="tw-mt-2">
-                                            <div className="tw-flex tw-flex-wrap tw-gap-4">
-                                                {server.tools?.map(tool => (
-                                                    <Badge
-                                                        key={`${server.name}-${tool.name}-tool`}
-                                                        variant={tool.disabled ? 'disabled' : 'outline'}
-                                                        className={`tw-truncate tw-max-w-[250px] tw-text-foreground tw-cursor-pointer tw-font-thin ${
-                                                            tool.disabled
-                                                                ? 'tw-opacity-50 tw-line-through'
-                                                                : ''
-                                                        }`}
-                                                        onClick={e => {
-                                                            e.stopPropagation()
-                                                            toggleTool(
-                                                                server.name,
-                                                                tool.name,
-                                                                tool.disabled !== true
-                                                            )
-                                                        }}
-                                                        title={`${tool.disabled ? '[Disabled] ' : ''} ${
-                                                            tool.description
-                                                        }`}
+                                            {server.name === selectedServer?.name && (
+                                                <Button
+                                                    variant="ghost"
+                                                    size="sm"
+                                                    className="tw-p-2 tw-z-10"
+                                                    onClick={e => {
+                                                        e.stopPropagation()
+                                                        removeServer(server.name)
+                                                    }}
+                                                    title="Delete server"
+                                                >
+                                                    <Minus size={16} />
+                                                </Button>
+                                            )}
+                                        </div>
+                                        <div className="tw-flex tw-align-top tw-justify-between tw-my-1 tw-flex-wrap">
+                                            {server.error && (
+                                                <div className="tw-mt-2 tw-mb-1 tw-w-full">
+                                                    <p
+                                                        className="tw-text-xs tw-text-pink-300 tw-mt-1 tw-truncate"
+                                                        title={server.error}
                                                     >
-                                                        {tool.name}
-                                                    </Badge>
-                                                ))}
-                                                {server?.tools === undefined && !server?.error && (
-                                                    <div className="tw-flex tw-flex-wrap tw-gap-2 tw-overflow-hidden tw-flex-1">
-                                                        {[1, 2, 3, 4].map(index => (
-                                                            <Badge
-                                                                key={`skeleton-${index}`}
-                                                                variant="outline"
-                                                                className={`tw-truncate tw-max-w-[90px] tw-min-w-[70px] ${
-                                                                    showSkeletonAnimation
-                                                                        ? 'tw-animate-pulse'
-                                                                        : ''
-                                                                }`}
-                                                            >
-                                                                <Skeleton
-                                                                    className={`tw-h-4 tw-w-full tw-bg-zinc-800 ${
+                                                        {server.error}
+                                                    </p>
+                                                </div>
+                                            )}
+                                            <div className="tw-mt-2">
+                                                <div className="tw-flex tw-flex-wrap tw-gap-4">
+                                                    {server.tools?.map(tool => (
+                                                        <Badge
+                                                            key={`${server.name}-${tool.name}-tool`}
+                                                            variant={
+                                                                tool.disabled ? 'disabled' : 'outline'
+                                                            }
+                                                            className={`tw-truncate tw-max-w-[250px] tw-text-foreground tw-cursor-pointer tw-font-thin ${
+                                                                tool.disabled
+                                                                    ? 'tw-opacity-50 tw-line-through'
+                                                                    : ''
+                                                            }`}
+                                                            onClick={e => {
+                                                                e.stopPropagation()
+                                                                toggleTool(
+                                                                    server.name,
+                                                                    tool.name,
+                                                                    tool.disabled !== true
+                                                                )
+                                                            }}
+                                                            title={`${
+                                                                tool.disabled ? '[Disabled] ' : ''
+                                                            } ${tool.description}`}
+                                                        >
+                                                            {tool.name}
+                                                        </Badge>
+                                                    ))}
+                                                    {server?.tools === undefined && !server?.error && (
+                                                        <div className="tw-flex tw-flex-wrap tw-gap-2 tw-overflow-hidden tw-flex-1">
+                                                            {[1, 2, 3, 4].map(index => (
+                                                                <Badge
+                                                                    key={`skeleton-${index}`}
+                                                                    variant="outline"
+                                                                    className={`tw-truncate tw-max-w-[90px] tw-min-w-[70px] ${
                                                                         showSkeletonAnimation
                                                                             ? 'tw-animate-pulse'
                                                                             : ''
                                                                     }`}
-                                                                />
-                                                            </Badge>
-                                                        ))}
-                                                    </div>
-                                                )}
+                                                                >
+                                                                    <Skeleton
+                                                                        className={`tw-h-4 tw-w-full tw-bg-zinc-800 ${
+                                                                            showSkeletonAnimation
+                                                                                ? 'tw-animate-pulse'
+                                                                                : ''
+                                                                        }`}
+                                                                    />
+                                                                </Badge>
+                                                            ))}
+                                                        </div>
+                                                    )}
+                                                </div>
                                             </div>
                                         </div>
                                     </div>
-                                </div>
-                            </CommandItem>
-                        ))}
-                        <div className="tw-flex tw-flex-col tw-justify-center tw-mt-4 tw-w-full">
-                            <AddServerView
-                                onAddServer={addServer}
-                                className="tw-my-4 tw-w-full tw-px-2"
-                                serverToEdit={selectedServer}
-                                setServerToEdit={setSelectedServer}
-                            />
-                        </div>
-                    </CommandList>
-                </div>
-            )}
-        </Command>
+                                </CommandItem>
+                            ))}
+                        </CommandList>
+                    </div>
+                )}
+            </Command>
+            <div className="tw-flex tw-flex-col tw-justify-center tw-mt-4 tw-w-full">
+                <AddServerView
+                    onAddServer={addServer}
+                    className="tw-my-4 tw-w-full tw-px-2"
+                    serverToEdit={selectedServer}
+                    setServerToEdit={setSelectedServer}
+                />
+            </div>
+        </div>
     )
 }
 

--- a/vscode/webviews/components/mcp/views/AddServerForm.tsx
+++ b/vscode/webviews/components/mcp/views/AddServerForm.tsx
@@ -82,16 +82,23 @@ export function AddServerForm({ onAddServer, _server }: AddServerFormProps) {
             <div className="tw-grid tw-gap-4 tw-py-4 tw-text-sm">
                 <div className="tw-grid tw-grid-cols-2 tw-gap-4">
                     <div className="tw-space-y-2">
-                        <Label htmlFor="name">Name</Label>
+                        <Label htmlFor="name" className={_server?.name && ' tw-cursor-not-allowed'}>
+                            Name
+                        </Label>
                         <input
                             type="text"
                             id="name"
                             value={formData.name.replace(' ', '-')}
                             name="name"
                             onChange={e => setFormData({ ...formData, name: e.target.value })}
-                            className="tw-block tw-py-2.5 tw-px-0 tw-w-full tw-text-sm tw-text-input-foreground tw-bg-transparent tw-border-0 tw-border-b-2 tw-border-gray-300 tw-appearance-none dark:tw-border-gray-600 dark:focus:tw-border-blue-500 focus:tw-outline-none focus:tw-ring-0 focus:tw-border-blue-600 peer"
+                            className={
+                                (_server?.name && 'tw-cursor-not-allowed tw-text-muted-foreground ') +
+                                'tw-block tw-py-2.5 tw-px-0 tw-w-full tw-text-sm tw-text-input-foreground tw-bg-transparent tw-border-0 tw-border-b-2 tw-border-gray-300 tw-appearance-none dark:tw-border-gray-600 dark:focus:tw-border-blue-500 focus:tw-outline-none focus:tw-ring-0 focus:tw-border-blue-600 peer'
+                            }
                             placeholder=" "
                             required
+                            disabled={Boolean(_server?.name)}
+                            readOnly={Boolean(_server?.name)}
                         />
                     </div>
                 </div>

--- a/vscode/webviews/components/mcp/views/AddServerForm.tsx
+++ b/vscode/webviews/components/mcp/views/AddServerForm.tsx
@@ -25,7 +25,7 @@ interface AddServerFormProps {
     className?: string
 }
 export function AddServerForm({ onAddServer, _server }: AddServerFormProps) {
-    const [formData, setFormData] = React.useState<ServerType>({ ...DEFAULT_CONFIG })
+    const [formData, setFormData] = React.useState<ServerType>({ ...DEFAULT_CONFIG, ..._server })
 
     useEffect(() => {
         setFormData({ ..._DEFAULT_CONFIG, ..._server })
@@ -78,7 +78,7 @@ export function AddServerForm({ onAddServer, _server }: AddServerFormProps) {
     }
 
     return (
-        <form onSubmit={handleSubmit}>
+        <form id={_server?.id || ''} onSubmit={handleSubmit}>
             <div className="tw-grid tw-gap-4 tw-py-4 tw-text-sm">
                 <div className="tw-grid tw-grid-cols-2 tw-gap-4">
                     <div className="tw-space-y-2">

--- a/vscode/webviews/components/mcp/views/AddServerForm.tsx
+++ b/vscode/webviews/components/mcp/views/AddServerForm.tsx
@@ -78,12 +78,12 @@ export function AddServerForm({ onAddServer, _server }: AddServerFormProps) {
     }
 
     return (
-        <form id={_server?.id || ''} onSubmit={handleSubmit}>
-            <div className="tw-grid tw-gap-4 tw-py-4 tw-text-sm">
+        <form id={_server?.id || ''} className="tw-w-full" onSubmit={handleSubmit}>
+            <div className="tw-grid tw-gap-4 tw-p-2 tw-text-sm">
                 <div className="tw-grid tw-grid-cols-2 tw-gap-4">
                     <div className="tw-space-y-2">
                         <Label htmlFor="name" className={_server?.name && ' tw-cursor-not-allowed'}>
-                            Name
+                            Name {_server?.name && '(Read only in edit mode)'}
                         </Label>
                         <input
                             type="text"
@@ -164,8 +164,13 @@ export function AddServerForm({ onAddServer, _server }: AddServerFormProps) {
                     ))}
                 </div>
             </div>
-            <div className="tw-px-2 tw-my-4">
-                <Button variant="default" className="tw-inline-flex tw-px-4 tw-w-auto" type="submit">
+            <div className="tw-px-2 tw-mt-2">
+                <Button
+                    variant="default"
+                    size="sm"
+                    className="tw-inline-flex tw-px-4 tw-w-full"
+                    type="submit"
+                >
                     <div className="tw-flex tw-items-center">
                         <SaveIcon size={16} className="tw-mr-3" /> Save
                     </div>

--- a/vscode/webviews/components/mcp/views/AddServerView.tsx
+++ b/vscode/webviews/components/mcp/views/AddServerView.tsx
@@ -31,7 +31,8 @@ export function AddServerView({ onAddServer, serverToEdit, setServerToEdit }: Ad
     }
 
     return (
-        <div className="tw-px-2 tw-my-4">
+        <div className="tw-w-full tw-p-4 tw-flex tw-flex-col tw-items-center tw-gap-2">
+            {open && <AddServerForm onAddServer={handleAddServer} _server={serverToEdit || undefined} />}
             <Button
                 variant="outline"
                 size="sm"
@@ -42,11 +43,6 @@ export function AddServerView({ onAddServer, serverToEdit, setServerToEdit }: Ad
                 {open ? <XIcon size={12} className="tw-mr-1" /> : <Plus size={12} className="tw-mr-1" />}
                 {open ? 'Cancel' : 'MCP Server'}
             </Button>
-            {open && (
-                <div className="tw-sm:max-w-[500px] tw-my-4">
-                    <AddServerForm onAddServer={handleAddServer} _server={serverToEdit || undefined} />
-                </div>
-            )}
         </div>
     )
 }

--- a/vscode/webviews/tabs/HistoryTab.tsx
+++ b/vscode/webviews/tabs/HistoryTab.tsx
@@ -38,7 +38,7 @@ export const HistoryTab: React.FC<HistoryTabProps> = ({
     const chats = useMemo(() => (userHistory ? Object.values(userHistory) : userHistory), [userHistory])
 
     return (
-        <div className="tw-flex tw-flex-col tw-justify-center tw-overflow-hidden tw-h-full tw-w-full">
+        <div className="tw-flex tw-flex-col tw-justify-center tw-overflow-hidden tw-h-full tw-w-full tw-m-4">
             {!chats ? (
                 <LoadingDots />
             ) : (


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-5829/remove-mcp-transporttype-from-settings

Improvements to MCP server management and tool state handling:

- Adds a "Reload" button to the MCP Servers view in the webview, allowing users to refresh the server list.
- Refactors MCP connection management for improved reliability and error handling.
- Implements persistent tool disabling across sessions by storing disabled tool states in the configuration.
- Enhances MCP server configuration updates and validation.

The following changes were made:

- Added a "Reload" button with a refresh icon to the `ServerHome` component in the webview.
- Modified `MCPConnectionManager` to handle connection status updates, error reporting, and transport events more robustly.
- Implemented `updateToolStateInConfig` in `MCPManager` to persist disabled tool states in the `cody.mcpServers` configuration.
- Refactored `MCPManager` to streamline server synchronization, connection management, and configuration updates.
- Added validation for server configurations.
- Improved logging and telemetry for MCP server operations.

These changes improve the reliability of MCP connections, and provide better control over tool usage.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

- Verify MCP servers are loaded from your user settings json file.
- Make changes to the setting json file and see the changes reflected in the UI and vice versa 
- Adding or deleting a server from UI should update the server list in both UI and settings json
- Clicking on a tool in UI should disable a tool, both in UI and settings json
- View JSON and Reload buttons work as expected

![image](https://github.com/user-attachments/assets/5d1e5455-c815-43b5-9cb5-070009db6189)

