### PR TITLE
fix(chat): track code paste event

### DIFF
--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -325,7 +325,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                 await handleCodeFromInsertAtCursor(message.text)
                 break
             case 'copy':
-                await handleCopiedCode(message.text, message.eventType === 'Button')
+                await handleCopiedCode(message.text, message.eventType)
                 break
             case 'smartApplyPrefetch':
             case 'smartApplySubmit':

--- a/vscode/src/services/utils/codeblock-action-tracker.ts
+++ b/vscode/src/services/utils/codeblock-action-tracker.ts
@@ -69,7 +69,7 @@ function setLastStoredCode({
 }): void {
     // All non-copy events are considered as insertions since we don't need to listen for paste events
     const source = 'chat'
-    insertInProgress = !eventName.includes('copy')
+    insertInProgress = !eventName.toLowerCase().includes('copy')
     const { lineCount, charCount } = countCode(code)
     const codeCount = { code, lineCount, charCount, eventName, source }
 
@@ -269,10 +269,10 @@ export async function handleCodeFromSaveToNewFile(text: string, editor: VSCodeEd
 /**
  * Handles copying code and detecting a paste event.
  */
-export async function handleCopiedCode(text: string, isButtonClickEvent: boolean): Promise<void> {
+export async function handleCopiedCode(text: string, eventType: string): Promise<void> {
     // If it's a Button event, then the text is already passed in from the whole code block
-    const copiedCode = isButtonClickEvent ? text : await vscode.env.clipboard.readText()
-    const eventName = isButtonClickEvent ? 'copyButton' : 'keyDown.Copy'
+    const copiedCode = text ?? (await vscode.env.clipboard.readText())
+    const eventName = eventType.toLowerCase().includes('button') ? 'copyButton' : 'keyDown.Copy'
     // Set for tracking
     if (copiedCode) {
         setLastStoredCode({ code: copiedCode, eventName })


### PR DESCRIPTION
The changes include:

-   In `ChatController.ts`, the `handleCopiedCode` function now passes the `message.eventType` directly instead of checking for `'Button'`.
-   In `codeblock-action-tracker.ts`, the logic for determining if a copy event is in progress has been updated to use `eventName.toLowerCase().includes('copy')` for case-insensitive matching.
-   The `handleCopiedCode` function in `codeblock-action-tracker.ts` now uses the `eventType` to determine if the copy event originated from a button click. If `eventType` includes 'button', the event is considered a 'copyButton' event; otherwise, it's a 'keyDown.Copy' event. The `copiedCode` is now retrieved from the `text` parameter if available, falling back to the clipboard if `text` is null or undefined.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Check output channel when copying and pasting code from code block in webview to editor:

```
█ telemetry-v2 recordEvent: cody.keyDown.Copy/clicked: {
  "parameters": {
    "version": 0,
    "metadata": [
      {
        "key": "source",
        "value": 1
      },
      {
        "key": "lineCount",
        "value": 14
      },
      {
        "key": "charCount",
        "value": 533
      },
      {
        "key": "tier",
        "value": 2
      }
    ],
    "privateMetadata": {
      "source": "chat",
      "op": "copy"
    },
    "billingMetadata": {
      "product": "cody",
      "category": "core"
    }
  },
  "timestamp": "2025-05-14T01:18:38.993Z"
}
█ telemetry-v2 recordEvent: cody.keyDown/paste: {
  "parameters": {
    "version": 0,
    "metadata": [
      {
        "key": "lineCount",
        "value": 14
      },
      {
        "key": "charCount",
        "value": 533
      },
      {
        "key": "source",
        "value": 1
      },
      {
        "key": "tier",
        "value": 2
      }
    ],
    "privateMetadata": {
      "source": "chat",
      "op": "paste"
    },
    "billingMetadata": {
      "product": "cody",
      "category": "core"
    }
  },
  "timestamp": "2025-05-14T01:19:01.870Z"
}
```
