### PR TITLE
Replace native file picker with polyfill implementation

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -630,6 +630,9 @@ importers:
       axios:
         specifier: ^1.3.6
         version: 1.3.6
+      browser-fs-access:
+        specifier: ^0.37.0
+        version: 0.37.0
       canvaskit-wasm:
         specifier: ^0.39.1
         version: 0.39.1
@@ -8493,6 +8496,10 @@ packages:
   /browser-assert@1.2.1:
     resolution: {integrity: sha512-nfulgvOR6S4gt9UKCeGJOuSGBPGiFT6oQ/2UBnvTY/5aQ1PnksW72fhZkM30DzoRRv2WpwZf1vHHEr3mtuXIWQ==}
     dev: true
+
+  /browser-fs-access@0.37.0:
+    resolution: {integrity: sha512-MKpvZrKtv6pBJ2ACd+VwfS9XauBKTMVZg2UBibypuK1gfiXM7euZjbdKmvRsyxeQRhfzNVQrzCSVGXs19/LP8Q==}
+    dev: false
 
   /browser-stdout@1.3.1:
     resolution: {integrity: sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==}

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1373,6 +1373,7 @@
     "agent-base": "^7.1.1",
     "async-mutex": "^0.4.0",
     "axios": "^1.3.6",
+    "browser-fs-access": "^0.37.0",
     "canvaskit-wasm": "^0.39.1",
     "class-variance-authority": "^0.7.0",
     "classnames": "^2.5.1",

--- a/vscode/webviews/chat/downloadChatHistory.ts
+++ b/vscode/webviews/chat/downloadChatHistory.ts
@@ -4,6 +4,7 @@ import {
     firstResultFromOperation,
 } from '@sourcegraph/cody-shared'
 import { ChatHistoryType } from '@sourcegraph/cody-shared/src/chat/transcript'
+import { fileSave } from 'browser-fs-access'
 
 /**
  * Use native browser download dialog to download chat history as a JSON file.
@@ -20,11 +21,10 @@ export async function downloadChatHistory(
     }
     const json = JSON.stringify(chatHistory, null, 2)
     const blob = new Blob([json], { type: 'application/json' })
-    const url = URL.createObjectURL(blob)
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, -5) // Format: YYYY-MM-DDTHH-mm
-    const a = document.createElement('a') // a temporary anchor element
-    a.href = url
-    a.download = `cody-chat-history-${timestamp}.json`
-    a.target = '_blank'
-    a.click()
+
+    await fileSave(blob, {
+        fileName: `cody-chat-history-${timestamp}.json`,
+        extensions: ['.json'],
+    })
 }


### PR DESCRIPTION
## Changes

For reasons which are close to impossible to debug, JCEF version used in IntelliJ 2025.1 have problems with handling our native file picker implementation:

```
    const a = document.createElement('a') // a temporary anchor element
    a.href = url
    a.download = `cody-chat-history-${timestamp}.json`
    a.target = '_blank'
    a.click()
```

I replaced it with pollyfil `browser-fs-access` implementation which according to my testing works fine everywhere.

## Test plan

Try to export chat history in:
1. Intellij 2023.3
2. Intellij 2025.1
3. VSC
4. Web
