### PR TITLE
Do not throw exceptions from unimplemented protocol methods

### DIFF
--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentClient.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentClient.kt
@@ -178,7 +178,7 @@ class CodyAgentClient(private val project: Project, private val webview: NativeW
   }
 
   override fun window_focusSidebar(params: Null?) {
-    TODO("Not yet implemented")
+    // TODO: Implement this.
   }
 
   override fun authStatus_didUpdate(params: ProtocolAuthStatus) {


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/QA-666

## Changes

`TODO(..)` in kotlin throws `NotImplemented` exception, we should not use it in unimplemented protocol methods

## Test plan

1. Open JetBrains and log out
2. Log in - it should be successful 

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
