### PR TITLE
Add handling for read-only models list in jetbrains edit window

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/Chat_ModelsResult.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/Chat_ModelsResult.kt
@@ -2,6 +2,7 @@
 package com.sourcegraph.cody.agent.protocol_generated;
 
 data class Chat_ModelsResult(
+  val readOnly: Boolean,
   val models: List<ModelAvailabilityStatus>,
 )
 

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -6,6 +6,7 @@ import {
     type AccountKeyedChatHistory,
     type ChatHistoryKey,
     type ClientCapabilities,
+    ClientConfigSingleton,
     type CodyCommand,
     CodyIDE,
     ModelUsage,
@@ -15,6 +16,7 @@ import {
     firstNonPendingAuthStatus,
     firstResultFromOperation,
     getAuthHeaders,
+    isDotCom,
     resolvedConfig,
     telemetryRecorder,
     waitUntilComplete,
@@ -1293,7 +1295,9 @@ export class Agent extends MessageHandler implements ExtensionClient {
         })
 
         this.registerAuthenticatedRequest('chat/models', async ({ modelUsage }) => {
+            const clientConfig = await ClientConfigSingleton.getInstance().getConfig()
             return {
+                readOnly: !(isDotCom(currentAuthStatus()) || clientConfig?.modelsAPIEnabled),
                 models: await modelsService.getModelsAvailabilityStatus(modelUsage),
             }
         })

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -59,7 +59,7 @@ export type ClientRequests = {
     // Primary is used only in cody web client
     'chat/delete': [{ chatId: string }, ChatExportResult[]]
 
-    'chat/models': [{ modelUsage: ModelUsage }, { models: ModelAvailabilityStatus[] }]
+    'chat/models': [{ modelUsage: ModelUsage }, { readOnly: boolean; models: ModelAvailabilityStatus[] }]
     'chat/export': [null | { fullHistory: boolean }, ChatExportResult[]]
 
     // history is Map of {endpoint}-{username} to chat transcripts by date


### PR DESCRIPTION
## Changes

This PR brings back functionality to disable models list selection if account is enterprise and `clientConfig?.modelsAPIEnabled` is `false`. This was broken several months ago and no one noticed:

https://github.com/sourcegraph/cody/pull/6182/files#diff-96fcfc91b38ef7dec1c22931edfd74464efb663547e49be8718ecea3171113b8

I recently removed our code for handling it (since it was not working anyway and was overly complicated) and now bringing back simpler version of it.

## Test plan

Hard to test without being able to change server flags, but I changed server response in debugger and verified it works.

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
