### PR TITLE
fix(chat): show toolbar even when only one model is available

### DIFF
--- a/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/Toolbar.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/Toolbar.tsx
@@ -119,10 +119,6 @@ export const Toolbar: FunctionComponent<{
         return () => window.removeEventListener('keydown', handleKeyboardShortcuts)
     }, [])
 
-    if (models?.length < 2) {
-        return null
-    }
-
     return (
         <menu
             role="toolbar"
@@ -159,15 +155,17 @@ export const Toolbar: FunctionComponent<{
                     isCodyProUser={userInfo?.isCodyProUser}
                     manuallySelectIntent={setLastManuallySelectedIntent}
                 />
-                <ModelSelectFieldToolbarItem
-                    models={models}
-                    userInfo={userInfo}
-                    focusEditor={focusEditor}
-                    modelSelectorRef={modelSelectorRef}
-                    className="tw-mr-1"
-                    extensionAPI={extensionAPI}
-                    intent={intent}
-                />
+                {models?.length >= 2 && (
+                    <ModelSelectFieldToolbarItem
+                        models={models}
+                        userInfo={userInfo}
+                        focusEditor={focusEditor}
+                        modelSelectorRef={modelSelectorRef}
+                        className="tw-mr-1"
+                        extensionAPI={extensionAPI}
+                        intent={intent}
+                    />
+                )}
             </div>
             <div className="tw-flex-1 tw-flex tw-justify-end">
                 <SubmitButton onClick={onSubmitClick} state={submitState} />


### PR DESCRIPTION
## Changes

Previously, the entire toolbar would not render if there were fewer than 2 models available. This change ensures the toolbar is always displayed, with only the model selector being conditionally rendered when multiple models are available.

## Test plan

1. Test with a configuration that has only one model available
   - Verify the toolbar with submit button and intent selector still appears
2. Test with multiple models available
   - Verify the model selector appears alongside other toolbar elements


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
