### PR TITLE
fix(smart-apply): custom model now checks for token limit

### DIFF
--- a/vscode/src/edit/output/response-transformer.test.ts
+++ b/vscode/src/edit/output/response-transformer.test.ts
@@ -78,7 +78,7 @@ describe('Smart Apply Response Extraction', () => {
     })
 
     it('should not add newline for smartApply with empty selection range', () => {
-        const text = `<${SMART_APPLY_CUSTOM_PROMPT_TOPICS.FINAL_CODE}>const x = 1;</${SMART_APPLY_CUSTOM_PROMPT_TOPICS.FINAL_CODE}>`
+        const text = 'const x = 1;'
         const task = {
             ...createTask('smartApply', SMART_APPLY_MODEL_IDENTIFIERS.FireworksQwenCodeDefault),
             mode: 'insert',
@@ -90,21 +90,6 @@ describe('Smart Apply Response Extraction', () => {
         const result = responseTransformer(text, task, false)
         expect(result).toBe('const x = 1;')
         expect(result.endsWith('\n')).toBe(false)
-    })
-
-    it('should add newline for smartApply without empty selection range', () => {
-        const text = `<${SMART_APPLY_CUSTOM_PROMPT_TOPICS.FINAL_CODE}>const x = 1;</${SMART_APPLY_CUSTOM_PROMPT_TOPICS.FINAL_CODE}>`
-        const task = {
-            ...createTask('smartApply', SMART_APPLY_MODEL_IDENTIFIERS.FireworksQwenCodeDefault),
-            mode: 'insert',
-            selectionRange: { isEmpty: false },
-            original: 'existing content',
-            fixupFile: { uri: {} as any },
-        } as any
-
-        const result = responseTransformer(text, task, false)
-        expect(result).toBe('const x = 1;\n')
-        expect(result.endsWith('\n')).toBe(true)
     })
 
     it('should preserve newlines based on original text', () => {

--- a/vscode/src/edit/output/response-transformer.test.ts
+++ b/vscode/src/edit/output/response-transformer.test.ts
@@ -16,7 +16,12 @@ describe('Smart Apply Response Extraction', () => {
         const text = `<${SMART_APPLY_CUSTOM_PROMPT_TOPICS.FINAL_CODE}>const x = 1;</${SMART_APPLY_CUSTOM_PROMPT_TOPICS.FINAL_CODE}>`
         const task = createTask('smartApply', SMART_APPLY_MODEL_IDENTIFIERS.FireworksQwenCodeDefault)
 
-        const result = responseTransformer(text, task, true)
+        // When isMessageInProgress is true, the original text is returned without processing
+        const resultInProgress = responseTransformer(text, task, true)
+        expect(resultInProgress).toBe(text)
+
+        // When isMessageInProgress is false, the text is processed
+        const result = responseTransformer(text, task, false)
         expect(result).toBe('const x = 1;')
     })
 
@@ -48,7 +53,12 @@ describe('Smart Apply Response Extraction', () => {
         const text = `<${SMART_APPLY_CUSTOM_PROMPT_TOPICS.FINAL_CODE}>outer <${SMART_APPLY_CUSTOM_PROMPT_TOPICS.FINAL_CODE}>inner</${SMART_APPLY_CUSTOM_PROMPT_TOPICS.FINAL_CODE}> content</${SMART_APPLY_CUSTOM_PROMPT_TOPICS.FINAL_CODE}>`
         const task = createTask('smartApply', SMART_APPLY_MODEL_IDENTIFIERS.FireworksQwenCodeDefault)
 
-        const result = responseTransformer(text, task, true)
+        // When isMessageInProgress is true, the original text is returned without processing
+        const resultInProgress = responseTransformer(text, task, true)
+        expect(resultInProgress).toBe(text)
+
+        // When isMessageInProgress is false, the text is processed
+        const result = responseTransformer(text, task, false)
         expect(result).toBe(
             `outer <${SMART_APPLY_CUSTOM_PROMPT_TOPICS.FINAL_CODE}>inner</${SMART_APPLY_CUSTOM_PROMPT_TOPICS.FINAL_CODE}> content`
         )
@@ -58,7 +68,12 @@ describe('Smart Apply Response Extraction', () => {
         const text = `<${SMART_APPLY_CUSTOM_PROMPT_TOPICS.FINAL_CODE}></${SMART_APPLY_CUSTOM_PROMPT_TOPICS.FINAL_CODE}>`
         const task = createTask('smartApply', SMART_APPLY_MODEL_IDENTIFIERS.FireworksQwenCodeDefault)
 
-        const result = responseTransformer(text, task, true)
+        // When isMessageInProgress is true, the original text is returned without processing
+        const resultInProgress = responseTransformer(text, task, true)
+        expect(resultInProgress).toBe(text)
+
+        // When isMessageInProgress is false, the text is processed
+        const result = responseTransformer(text, task, false)
         expect(result).toBe('')
     })
 
@@ -90,6 +105,50 @@ describe('Smart Apply Response Extraction', () => {
         const result = responseTransformer(text, task, false)
         expect(result).toBe('const x = 1;\n')
         expect(result.endsWith('\n')).toBe(true)
+    })
+
+    it('should preserve newlines based on original text', () => {
+        const text = `<${SMART_APPLY_CUSTOM_PROMPT_TOPICS.FINAL_CODE}>\nconst x = 1;\n</${SMART_APPLY_CUSTOM_PROMPT_TOPICS.FINAL_CODE}>`
+
+        // Test 1: Original has no newlines, result should have no newlines
+        const task1 = {
+            ...createTask('smartApply', SMART_APPLY_MODEL_IDENTIFIERS.FireworksQwenCodeDefault),
+            original: 'const y = 2;',
+        } as any
+        const result1 = responseTransformer(text, task1, false)
+        expect(result1).toBe('const x = 1;')
+        expect(result1.startsWith('\n')).toBe(false)
+        expect(result1.endsWith('\n')).toBe(false)
+
+        // Test 2: Original has starting newline, result should have starting newline
+        const task2 = {
+            ...createTask('smartApply', SMART_APPLY_MODEL_IDENTIFIERS.FireworksQwenCodeDefault),
+            original: '\nconst y = 2;',
+        } as any
+        const result2 = responseTransformer(text, task2, false)
+        expect(result2).toBe('\nconst x = 1;')
+        expect(result2.startsWith('\n')).toBe(true)
+        expect(result2.endsWith('\n')).toBe(false)
+
+        // Test 3: Original has ending newline, result should have ending newline
+        const task3 = {
+            ...createTask('smartApply', SMART_APPLY_MODEL_IDENTIFIERS.FireworksQwenCodeDefault),
+            original: 'const y = 2;\n',
+        } as any
+        const result3 = responseTransformer(text, task3, false)
+        expect(result3).toBe('const x = 1;\n')
+        expect(result3.startsWith('\n')).toBe(false)
+        expect(result3.endsWith('\n')).toBe(true)
+
+        // Test 4: Original has both newlines, result should have both newlines
+        const task4 = {
+            ...createTask('smartApply', SMART_APPLY_MODEL_IDENTIFIERS.FireworksQwenCodeDefault),
+            original: '\nconst y = 2;\n',
+        } as any
+        const result4 = responseTransformer(text, task4, false)
+        expect(result4).toBe('\nconst x = 1;\n')
+        expect(result4.startsWith('\n')).toBe(true)
+        expect(result4.endsWith('\n')).toBe(true)
     })
 })
 

--- a/vscode/src/edit/output/response-transformer.ts
+++ b/vscode/src/edit/output/response-transformer.ts
@@ -38,11 +38,13 @@ const MARKDOWN_CODE_BLOCK_REGEX = new RegExp(
 const LEADING_SPACES_AND_NEW_LINES = /^\s*\n/
 const LEADING_SPACES = /^[ ]+/
 
+const SMART_APPLY_MODEL_SET = new Set(Object.values(SMART_APPLY_MODEL_IDENTIFIERS))
+
 /**
  * Checks if the task is using a smart apply custom model
  */
 function taskUsesSmartApplyCustomModel(task: FixupTask): boolean {
-    return Object.values(SMART_APPLY_MODEL_IDENTIFIERS).includes(task.model)
+    return SMART_APPLY_MODEL_SET.has(task.model)
 }
 
 /**
@@ -97,13 +99,11 @@ function trimLLMNewlines(text: string, original: string): string {
     let result = text
 
     // Handle starting newline
-    if (result.startsWith('\n') && !original.startsWith('\n')) {
-        result = result.replace(/^\n/, '')
+    if (result.match(/^\r?\n/) && !original.match(/^\r?\n/)) {
+        result = result.replace(/^\r?\n/, '')
     }
-
-    // Handle ending newline
-    if (result.endsWith('\n') && !original.endsWith('\n')) {
-        result = result.replace(/\n$/, '')
+    if (result.match(/\r?\n$/) && !original.match(/\r?\n$/)) {
+        result = result.replace(/\r?\n$/, '')
     }
 
     return result

--- a/vscode/src/edit/output/response-transformer.ts
+++ b/vscode/src/edit/output/response-transformer.ts
@@ -107,6 +107,13 @@ export function responseTransformer(
     task: FixupTask,
     isMessageInProgress: boolean
 ): string {
+    if (
+        task.intent === 'smartApply' &&
+        Object.values(SMART_APPLY_MODEL_IDENTIFIERS).includes(task.model) &&
+        isMessageInProgress
+    ) {
+        return text
+    }
     const updatedText = extractSmartApplyCustomModelResponse(text, task)
 
     // if we use the new Qwen based smart apply which performs an entire-file
@@ -115,7 +122,7 @@ export function responseTransformer(
         task.intent === 'smartApply' &&
         Object.values(SMART_APPLY_MODEL_IDENTIFIERS).includes(task.model)
     ) {
-        return updatedText.replace(LEADING_SPACES_AND_NEW_LINES, '')
+        return task.original.endsWith('\n') ? updatedText : updatedText.trimEnd()
     }
     const strippedText = stripText(updatedText, task)
 

--- a/vscode/src/edit/output/response-transformer.ts
+++ b/vscode/src/edit/output/response-transformer.ts
@@ -131,7 +131,7 @@ export function responseTransformer(
 ): string {
     // Skip processing for in-progress messages from smart apply custom models
     if (taskUsesSmartApplyCustomModel(task)) {
-        if (isMessageInProgress) {
+        if (isMessageInProgress || task.mode === 'insert') {
             return text
         }
 

--- a/vscode/src/edit/output/response-transformer.ts
+++ b/vscode/src/edit/output/response-transformer.ts
@@ -108,6 +108,15 @@ export function responseTransformer(
     isMessageInProgress: boolean
 ): string {
     const updatedText = extractSmartApplyCustomModelResponse(text, task)
+
+    // if we use the new Qwen based smart apply which performs an entire-file
+    // replace it's enough for us to just remove the start and end newline
+    if (
+        task.intent === 'smartApply' &&
+        Object.values(SMART_APPLY_MODEL_IDENTIFIERS).includes(task.model)
+    ) {
+        return updatedText.replace(LEADING_SPACES_AND_NEW_LINES, '')
+    }
     const strippedText = stripText(updatedText, task)
 
     // Trim leading spaces

--- a/vscode/src/edit/prompt/smart-apply/selection/custom-model.ts
+++ b/vscode/src/edit/prompt/smart-apply/selection/custom-model.ts
@@ -58,10 +58,6 @@ export class CustomModelSelectionProvider implements SmartApplySelectionProvider
         chatClient,
         contextWindow,
     }: SelectionPromptProviderArgs): Promise<string> {
-        if (this.shouldAlwaysUseEntireFile) {
-            return 'ENTIRE_FILE'
-        }
-
         const documentRange = new vscode.Range(0, 0, document.lineCount - 1, 0)
         const documentText = PromptString.fromDocumentText(document, documentRange)
         const tokenCount = await TokenCounterUtils.countPromptString(documentText)
@@ -69,9 +65,10 @@ export class CustomModelSelectionProvider implements SmartApplySelectionProvider
         if (tokenCount > contextWindow.input) {
             throw new Error("The amount of text in this document exceeds Cody's current capacity.")
         }
-        if (tokenCount < FULL_FILE_REWRITE_TOKEN_TOKEN_LIMIT) {
+        if (tokenCount < FULL_FILE_REWRITE_TOKEN_TOKEN_LIMIT || this.shouldAlwaysUseEntireFile) {
             return 'ENTIRE_FILE'
         }
+
         const { prefix, messages } = await this.getPrompt(
             instruction,
             replacement,


### PR DESCRIPTION
This pr makes a couple of changes to the smart apply behavior of the new custom model such as:
* Added logic to validate token counts against context window limits in `CustomModelSelectionProvider`. If the token count exceeds the limit, an error is thrown.
*  Added the `trimLLMNewlines` function to preserve or remove newlines based on the original text, ensuring consistent formatting in transformed responses. 
  I think that if the original file didn't have a starting and ending newline our smart apply task shouldn't insert them either,
  as we should stay as close as possible to what you see is what you get.
* Updated `responseTransformer` to skip processing for in-progress messages and `insert` mode tasks.
  If we just insert the text we don't need it to be cleaned up, it's basically a copy paste job

## Test plan
- Try to call smart apply on a file that has over 12000 tokens
- Try to delete file content and hit apply and notice that it inserts the content as seen in the chat window
