### PR TITLE
feat(chat): Show both file and selection mentions in Cody Web chat

### DIFF
--- a/lib/prompt-editor/src/mentions/mentionMenu/useMentionMenuData.ts
+++ b/lib/prompt-editor/src/mentions/mentionMenu/useMentionMenuData.ts
@@ -106,21 +106,22 @@ export function useMentionMenuData(
                     item.description?.toString().toLowerCase().includes(queryLower)
                   : true
           )
-
     const additionalItems =
         value?.items
             ?.filter(
                 // If an item is shown as initial context, don't show it twice.
+                // For file items, we consider them the same only if they have the same range status
                 item =>
                     !filteredInitialContextItems.some(
                         initialItem =>
                             initialItem.uri.toString() === item.uri.toString() &&
-                            initialItem.type === item.type
+                            initialItem.type === item.type &&
+                            // For file types, consider range status to differentiate between file and selection
+                            (initialItem.type !== 'file' || !!initialItem.range === !!item.range)
                     )
             )
             .slice(0, limit)
             .map(item => prepareUserContextItem(item, remainingTokenBudget)) ?? []
-
     return useMemo(
         () =>
             ({

--- a/web/lib/components/CodyWebChat.tsx
+++ b/web/lib/components/CodyWebChat.tsx
@@ -315,22 +315,35 @@ const CodyWebPanel: FC<CodyWebPanelProps> = props => {
                 } as ContextItemOpenCtx)
             } else {
                 // Common file mention with possible file range positions
+                // Always add the current file item
                 initialContext.push({
                     type: 'file',
                     isIgnored: false,
-                    title: initialContextData?.fileRange ? 'Current Selection' : 'Current File',
-                    range: initialContextData?.fileRange
-                        ? {
-                              start: { line: initialContextData.fileRange.startLine, character: 0 },
-                              end: { line: initialContextData.fileRange.endLine + 1, character: 0 },
-                          }
-                        : undefined,
+                    title: 'Current File',
                     repoName: repository.name,
                     remoteRepositoryName: repository.name,
                     uri: URI.file(`${repository.name}/${fileURL}`),
                     source: ContextItemSource.Initial,
                     icon: 'file',
                 })
+
+                // Add the current selection item if there's a range
+                if (initialContextData?.fileRange) {
+                    initialContext.push({
+                        type: 'file',
+                        isIgnored: false,
+                        title: 'Current Selection',
+                        range: {
+                            start: { line: initialContextData.fileRange.startLine, character: 0 },
+                            end: { line: initialContextData.fileRange.endLine + 1, character: 0 },
+                        },
+                        repoName: repository.name,
+                        remoteRepositoryName: repository.name,
+                        uri: URI.file(`${repository.name}/${fileURL}`),
+                        source: ContextItemSource.Initial,
+                        icon: 'list-selection',
+                    })
+                }
             }
         }
 


### PR DESCRIPTION
This commit modifies the mention menu to display both the file and selection mentions in the chat interface.

Previously, if a file was already present in the initial context, the selection (file with range) from the mention menu would be filtered out due to URI-based deduplication. This change ensures that both the file and selection are displayed as separate options in the mention menu, providing users with more granular control over the context they include in their chat prompts.

## Test plan
- Select a file range within Cody Web
- Check if @ mention displays `Current file` not just `Current selection`