### PR TITLE
revert(chat): enable agentic chat based on feature flag and model

### DIFF
--- a/lib/shared/src/models/client.ts
+++ b/lib/shared/src/models/client.ts
@@ -1,2 +1,22 @@
+import type { ServerModel } from './model'
+import type { ModelTag } from './tags'
+
 export const DeepCodyAgentID = 'deep-cody'
+export const DeepCodyModelRef = 'sourcegraph::2023-06-01::deep-cody'
+
 export const ToolCodyModelName = 'tool-cody'
+
+export const DEEP_CODY_MODEL: ServerModel = {
+    // This modelRef does not exist in the backend and is used to identify the model in the client.
+    modelRef: DeepCodyModelRef,
+    displayName: 'Agentic chat',
+    modelName: DeepCodyAgentID,
+    capabilities: ['chat'],
+    category: 'accuracy',
+    status: 'experimental' as ModelTag.Experimental,
+    tier: 'pro' as ModelTag.Pro,
+    contextWindow: {
+        maxInputTokens: 45000,
+        maxOutputTokens: 4000,
+    },
+}

--- a/lib/shared/src/models/sync.test.ts
+++ b/lib/shared/src/models/sync.test.ts
@@ -386,7 +386,7 @@ describe('syncModels', () => {
         }
     )
 
-    it('not to set Agentic Chat as default chat model when feature flag is enabled', async () => {
+    it('set Agentic Chat as default chat model when feature flag is enabled', async () => {
         const serverSonnet: ServerModel = {
             modelRef: 'anthropic::unknown::claude-3-5-sonnet',
             displayName: 'Sonnet',
@@ -454,7 +454,7 @@ describe('syncModels', () => {
         vi.spyOn(modelsService, 'modelsChanges', 'get').mockReturnValue(Observable.of(result))
 
         // Check if Deep Cody model is no longer in the models list.
-        expect(result.primaryModels.some(model => model.id.includes('deep-cody'))).toBe(false)
+        expect(result.primaryModels.some(model => model.id.includes('deep-cody'))).toBe(true)
 
         // preference should not be affected and remains unchanged as this is handled in a later step.
         expect(result.preferences.selected.chat).toBe(undefined)

--- a/lib/shared/src/models/sync.ts
+++ b/lib/shared/src/models/sync.ts
@@ -445,7 +445,7 @@ export function syncModels({
                                                 )
 
                                                 if (isAgenticChatEnabled && !hasDeepCody) {
-                                                    data.primaryModels.unshift(
+                                                    data.primaryModels.push(
                                                         createModelFromServerModel(
                                                             DEEP_CODY_MODEL,
                                                             false // Should not affect the context window set for Agentic chat

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -801,7 +801,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                     text: inputText,
                     editorState,
                     intent: manuallySelectedIntent,
-                    agent: toolboxManager.isAgenticChatEnabled() ? DeepCodyAgent.id : undefined,
+                    agent: toolboxManager.isAgenticChatEnabled(model) ? DeepCodyAgent.id : undefined,
                 })
 
                 this.setCustomChatTitle(requestID, inputText, signal)

--- a/vscode/src/chat/chat-view/handlers/DeepCodyHandler.ts
+++ b/vscode/src/chat/chat-view/handlers/DeepCodyHandler.ts
@@ -1,6 +1,5 @@
 import type { ContextItem, ProcessingStep, SerializedPromptEditorState } from '@sourcegraph/cody-shared'
 import { DeepCodyAgent } from '../../agentic/DeepCody'
-import { toolboxManager } from '../../agentic/ToolboxManager'
 import type { ChatBuilder } from '../ChatBuilder'
 import type { HumanInput } from '../context'
 import { ChatHandler } from './ChatHandler'
@@ -32,11 +31,7 @@ export class DeepCodyHandler extends ChatHandler implements AgentHandler {
             skipQueryRewriteForDeepCody
         )
         // Early return if basic conditions aren't met.
-        if (
-            !toolboxManager.isAgenticChatEnabled() ||
-            baseContextResult.error ||
-            baseContextResult.abort
-        ) {
+        if (baseContextResult.error || baseContextResult.abort) {
             return baseContextResult
         }
 

--- a/vscode/src/chat/chat-view/handlers/registry.ts
+++ b/vscode/src/chat/chat-view/handlers/registry.ts
@@ -42,7 +42,7 @@ export function getAgent(model: string, intent: ChatMessage['intent'], tools: Ag
     // Use agentic chat (Deep Cody) handler if enabled.
     // Skip in agent testing mode to avoid non-deterministic results causing
     // recordings to fail consistently.
-    if (!isCodyTesting && toolboxManager.isAgenticChatEnabled()) {
+    if (!isCodyTesting && toolboxManager.isAgenticChatEnabled(model)) {
         return new DeepCodyHandler(contextRetriever, editor, chatClient)
     }
 


### PR DESCRIPTION
This commit reverts the  changes made in https://github.com/sourcegraph/cody/pull/7761

- Updates the `isAgenticChatEnabled` method in `ToolboxManager` to check for a feature flag (`FeatureFlag.DeepCody`) and the specific model being used (`DeepCodyModelRef`). This ensures that agentic chat is only enabled when the feature flag is enabled and the selected model is the Deep Cody model.
- Modifies the `syncModels` function to add the Deep Cody model to the list of available models if the `DeepCody` feature flag is enabled and the model is not already present.
- Updates `ChatController` and `registry` to pass the model to `isAgenticChatEnabled` to ensure the agent is only used with the correct model.
- Removes unnecessary check for `toolboxManager.isAgenticChatEnabled()` in `DeepCodyHandler` as the check is now done earlier.
- Adds `DEEP_CODY_MODEL` and `DeepCodyModelRef` to `lib/shared/src/models/client.ts`

These changes ensure that agentic chat is only enabled for users who have the feature flag enabled and are using the Deep Cody model. This allows us to control the rollout of agentic chat and ensure that it is only used by users who are intended to use it.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

- Verify that agentic chat is only enabled when the `DeepCody` feature flag is enabled and the Deep Cody model is selected.
- Verify that agentic chat is disabled when the `DeepCody` feature flag is disabled or a different model is selected.
- Verify that the Deep Cody model is added to the list of available models when the `DeepCody` feature flag is enabled and the model is not already present.


Verify agentic chat shows up in model dropdown:

![image](https://github.com/user-attachments/assets/1655f1ad-84a4-4f24-954c-82d3fe4ad928)


Ask agentic chat: "How do we display speaker transcript in the UI in this codebase"

![image](https://github.com/user-attachments/assets/1cfdd366-b50a-4fa4-9bf7-a2798fb5528c)


Ask the same question to Claude 3.7 Sonent and confirmed no agentic context was added:

![image](https://github.com/user-attachments/assets/9944154a-65e6-4492-afae-f0fe8e5ebead)
