### PR TITLE
fix(chat): prune local chat history to reduce storage usage

### DIFF
--- a/vscode/src/services/LocalStorageProvider.test.ts
+++ b/vscode/src/services/LocalStorageProvider.test.ts
@@ -21,13 +21,155 @@ describe('LocalStorageProvider', () => {
     })
 
     it('sets and gets chat history', async () => {
+        const currentTime = new Date().toISOString()
         await localStorage.setChatHistory(AUTH_STATUS_FIXTURE_AUTHED, {
-            chat: { a: { id: 'a', lastInteractionTimestamp: '123', interactions: [] } },
+            chat: { a: { id: 'a', lastInteractionTimestamp: currentTime, interactions: [] } },
         })
 
         const loadedHistory = localStorage.getChatHistory(AUTH_STATUS_FIXTURE_AUTHED)
         expect(loadedHistory).toEqual<UserLocalHistory>({
-            chat: { a: { id: 'a', lastInteractionTimestamp: '123', interactions: [] } },
+            chat: { a: { id: 'a', lastInteractionTimestamp: currentTime, interactions: [] } },
         })
+    })
+
+    describe('filterChatHistoryOlderThan', () => {
+        it('removes chat entries older than the specified date', () => {
+            const now = new Date()
+            const twoDaysAgo = new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000)
+            const tenDaysAgo = new Date(now.getTime() - 10 * 24 * 60 * 60 * 1000)
+            const fortyDaysAgo = new Date(now.getTime() - 40 * 24 * 60 * 60 * 1000)
+
+            const history: UserLocalHistory = {
+                chat: {
+                    recent: {
+                        id: 'recent',
+                        lastInteractionTimestamp: now.toISOString(),
+                        interactions: [],
+                    },
+                    twoDaysOld: {
+                        id: 'twoDaysOld',
+                        lastInteractionTimestamp: twoDaysAgo.toISOString(),
+                        interactions: [],
+                    },
+                    tenDaysOld: {
+                        id: 'tenDaysOld',
+                        lastInteractionTimestamp: tenDaysAgo.toISOString(),
+                        interactions: [],
+                    },
+                    fortyDaysOld: {
+                        id: 'fortyDaysOld',
+                        lastInteractionTimestamp: fortyDaysAgo.toISOString(),
+                        interactions: [],
+                    },
+                },
+            }
+
+            // Filter out chats older than 15 days
+            const fifteenDaysAgo = new Date(now.getTime() - 15 * 24 * 60 * 60 * 1000)
+            localStorage.filterChatHistoryOlderThan(fifteenDaysAgo, history)
+
+            // Should keep recent and twoDaysOld and tenDaysOld, but remove fortyDaysOld
+            expect(Object.keys(history.chat).length).toBe(3)
+            expect(history.chat.recent).toBeDefined()
+            expect(history.chat.twoDaysOld).toBeDefined()
+            expect(history.chat.tenDaysOld).toBeDefined()
+            expect(history.chat.fortyDaysOld).toBeUndefined()
+        })
+
+        it('keeps all chat entries if all are newer than the cutoff date', () => {
+            const now = new Date()
+            const fiveDaysAgo = new Date(now.getTime() - 5 * 24 * 60 * 60 * 1000)
+
+            const history: UserLocalHistory = {
+                chat: {
+                    recent1: {
+                        id: 'recent1',
+                        lastInteractionTimestamp: now.toISOString(),
+                        interactions: [],
+                    },
+                    recent2: {
+                        id: 'recent2',
+                        lastInteractionTimestamp: fiveDaysAgo.toISOString(),
+                        interactions: [],
+                    },
+                },
+            }
+
+            const initialCount = Object.keys(history.chat).length
+
+            // Filter out chats older than 10 days
+            const tenDaysAgo = new Date(now.getTime() - 10 * 24 * 60 * 60 * 1000)
+            localStorage.filterChatHistoryOlderThan(tenDaysAgo, history)
+
+            // Should keep all chats
+            expect(Object.keys(history.chat).length).toBe(initialCount)
+            expect(history.chat.recent1).toBeDefined()
+            expect(history.chat.recent2).toBeDefined()
+        })
+
+        it('removes all chat entries if all are older than the cutoff date', () => {
+            const now = new Date()
+            const twentyDaysAgo = new Date(now.getTime() - 20 * 24 * 60 * 60 * 1000)
+            const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000)
+
+            const history: UserLocalHistory = {
+                chat: {
+                    old1: {
+                        id: 'old1',
+                        lastInteractionTimestamp: twentyDaysAgo.toISOString(),
+                        interactions: [],
+                    },
+                    old2: {
+                        id: 'old2',
+                        lastInteractionTimestamp: thirtyDaysAgo.toISOString(),
+                        interactions: [],
+                    },
+                },
+            }
+
+            // Filter out chats older than 10 days
+            const tenDaysAgo = new Date(now.getTime() - 10 * 24 * 60 * 60 * 1000)
+            localStorage.filterChatHistoryOlderThan(tenDaysAgo, history)
+
+            // Should remove all chats
+            expect(Object.keys(history.chat).length).toBe(0)
+        })
+    })
+
+    it('automatically filters old chat entries when saving chat history', async () => {
+        const now = new Date()
+
+        // Create a chat history with both recent and old entries
+        const recentChat = {
+            id: 'recent',
+            lastInteractionTimestamp: now.toISOString(),
+            interactions: [],
+        }
+
+        // Create entry older than 30 days (the cutoff in setChatHistory)
+        const oldDate = new Date(now.getTime() - 31 * 24 * 60 * 60 * 1000)
+        const oldChat = {
+            id: 'old',
+            lastInteractionTimestamp: oldDate.toISOString(),
+            interactions: [],
+        }
+
+        const history: UserLocalHistory = {
+            chat: {
+                recent: recentChat,
+                old: oldChat,
+            },
+        }
+
+        // Save the chat history
+        await localStorage.setChatHistory(AUTH_STATUS_FIXTURE_AUTHED, history)
+
+        // Retrieve the chat history
+        const loadedHistory = localStorage.getChatHistory(AUTH_STATUS_FIXTURE_AUTHED)
+
+        // The old chat should be filtered out
+        expect(Object.keys(loadedHistory.chat).length).toBe(1)
+        expect(loadedHistory.chat.recent).toBeDefined()
+        expect(loadedHistory.chat.old).toBeUndefined()
     })
 })

--- a/vscode/src/services/LocalStorageProvider.ts
+++ b/vscode/src/services/LocalStorageProvider.ts
@@ -182,6 +182,11 @@ class LocalStorage implements LocalStorageForModelPreferences {
         history: UserLocalHistory
     ): Promise<void> {
         try {
+            // Filter out chats older than a month
+            const oneMonthAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)
+
+            this.filterChatHistoryOlderThan(oneMonthAgo, history)
+
             const key = getKeyForAuthStatus(authStatus)
             let fullHistory = this.storage.get<AccountKeyedChatHistory | null>(
                 this.KEY_LOCAL_HISTORY,
@@ -228,6 +233,22 @@ class LocalStorage implements LocalStorageForModelPreferences {
                 console.error(error)
             }
         }
+    }
+
+    public filterChatHistoryOlderThan(days: Date, history: UserLocalHistory): void {
+        const filteredChat = Object.entries(history.chat)
+            .filter(
+                ([_, chat]) => new Date(chat.lastInteractionTimestamp) >= new Date(days.toISOString())
+            )
+            .reduce(
+                (obj, [id, chat]) => {
+                    obj[id] = chat
+                    return obj
+                },
+                {} as Record<string, any>
+            )
+
+        history.chat = filteredChat
     }
 
     public async isAutoEditBetaEnrolled(): Promise<boolean> {


### PR DESCRIPTION
This PR introduces a mechanism to automatically filter out chat history entries older than 30 days when saving chat history to local storage. This helps to reduce storage usage and improve performance by preventing the accumulation of excessive chat data.

- Added a `filterChatHistoryOlderThan` method to `LocalStorageProvider` to filter chat entries based on their `lastInteractionTimestamp`.
- Modified `setChatHistory` to automatically call `filterChatHistoryOlderThan` before saving the history.
- Added unit tests to verify the filtering logic and the automatic filtering during saving.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

- do not run "saveSession" when user submitted a question, invoke only after we get a response to avoid all the operations we run on local storage
- Ask Cody a question and verified the chat history show up after the response is completed
- chat history still works as expected (except now month-old chat history is removed)