### PR TITLE
fix(autoedit): Disable hot streak experimental model in agent

### DIFF
--- a/vscode/src/autoedits/autoedits-config.ts
+++ b/vscode/src/autoedits/autoedits-config.ts
@@ -11,6 +11,7 @@ import {
 
 import { RetrieverIdentifier } from '../completions/context/utils'
 import { getConfiguration } from '../configuration'
+import { isRunningInsideAgent } from '../jsonrpc/isRunningInsideAgent'
 import { isHotStreakEnabledInSettings } from './hot-streak/utils'
 
 interface BaseAutoeditsProviderConfig {
@@ -81,6 +82,10 @@ featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.CodyAutoEditHotStreak).subs
  * Determines if hot streak mode should be enabled based on feature flag and settings.
  */
 export function isHotStreakEnabled(): boolean {
+    if (isRunningInsideAgent()) {
+        return false
+    }
+
     return hotStreakEnabled || isHotStreakEnabledInSettings()
 }
 


### PR DESCRIPTION
## Description

Hot streak logic was disabled in Agent... but this helper was used for the model layer and meant we were using a different model and rewrite window in Agent / other clients

## Test plan

Manual testing needed on the JB side after merge

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
