### PR TITLE
Add settings for custom node process args and env variables

### DIFF
--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgent.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgent.kt
@@ -16,6 +16,7 @@ import com.sourcegraph.cody.error.SentryService
 import com.sourcegraph.cody.ui.web.WebUIServiceWebviewProvider
 import com.sourcegraph.cody.vscode.CancellationToken
 import com.sourcegraph.config.ConfigUtil
+import com.sourcegraph.config.ConfigUtil.getConfigurationEntries
 import java.io.*
 import java.net.Socket
 import java.net.URI
@@ -118,7 +119,7 @@ private constructor(
         token: String?,
     ): CompletableFuture<CodyAgent> {
       try {
-        val conn = startAgentProcess()
+        val conn = startAgentProcess(project)
         val client = CodyAgentClient(project, WebUIServiceWebviewProvider(project))
         val launcher = startAgentLauncher(conn, client)
         val server = launcher.remoteProxy
@@ -158,7 +159,47 @@ private constructor(
       }
     }
 
-    private fun startAgentProcess(): AgentConnection {
+    // spotless:off
+    /**
+     * Retrieves custom process arguments and environment variables from configuration.
+     *
+     * These settings can be configured in the code_settings.json file under:
+     * - cody.advanced.agent.process.node.args: List of additional command-line arguments for the agent process
+     * - cody.advanced.agent.process.node.env: Map of environment variables to set for the agent process
+     *
+     * Example configuration:
+     * {
+     *   "cody.advanced.agent.process.node": {
+     *      "args": ["--max-old-space-size=4096", "--trace-warnings"],
+     *      "env": {
+     *        "NODE_OPTIONS": "--max-http-header-size=16384"
+     *      }
+     *    }
+     *  }
+     */
+    // spotless:on
+    private fun getProcessNodeConfig(project: Project?): Pair<List<String>, Map<String, String>> {
+      if (project == null) return Pair(emptyList(), emptyMap())
+
+      try {
+        val customArgs =
+            getConfigurationEntries(project, "cody.advanced.agent.process.node.args").flatMap {
+              it.second as? List<String> ?: emptyList()
+            }
+        val customEnv =
+            getConfigurationEntries(project, "cody.advanced.agent.process.node.env").associate {
+                (key, value) ->
+              key to value.toString()
+            }
+
+        return Pair(customArgs, customEnv)
+      } catch (e: Exception) {
+        logger.warn("Failed to parse custom process configuration", e)
+        return Pair(emptyList(), emptyMap())
+      }
+    }
+
+    private fun startAgentProcess(project: Project? = null): AgentConnection {
       if (ConfigUtil.shouldConnectToDebugAgent()) {
         return connectToDebugAgent()
       }
@@ -175,15 +216,32 @@ private constructor(
             Debuggability.Debuggable -> listOf("--enable-source-maps", "--inspect")
             Debuggability.DebuggableWaitForAttach -> listOf("--enable-source-maps", "--inspect-brk")
           }
+
+      val (nodeArgs, nodeEnv) = getProcessNodeConfig(project)
+
+      if (nodeArgs.isNotEmpty()) {
+        logger.info("Using custom agent process args: ${nodeArgs.joinToString(" ")}")
+      }
+      if (nodeEnv.isNotEmpty()) {
+        logger.info(
+            "Using custom agent process environment variables: ${nodeEnv.keys.joinToString(", ")}")
+      }
+
       val command: List<String> =
           listOf(
                   listOf(binaryPath),
+                  nodeArgs,
                   debuggerArgs,
                   listOf(script.toFile().absolutePath),
                   jsonRpcArgs)
               .flatten()
 
       val processBuilder = ProcessBuilder(command)
+
+      if (nodeEnv.isNotEmpty()) {
+        processBuilder.environment().putAll(nodeEnv)
+      }
+
       if (java.lang.Boolean.getBoolean("cody.accept-non-trusted-certificates-automatically") ||
           ConfigUtil.getShouldAcceptNonTrustedCertificatesAutomatically()) {
         processBuilder.environment()["CODY_NODE_TLS_REJECT_UNAUTHORIZED"] = "0"

--- a/jetbrains/src/main/kotlin/com/sourcegraph/config/ConfigUtil.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/config/ConfigUtil.kt
@@ -162,7 +162,17 @@ object ConfigUtil {
   }
 
   @JvmStatic
-  fun getCustomConfiguration(project: Project, customConfigContent: String?): String {
+  fun getConfigurationEntries(project: Project, key: String): List<Pair<String, Any>> {
+    val config = ConfigFactory.parseString(getCustomConfiguration(project)).resolve()
+    return config.entrySet().mapNotNull { configEntry ->
+      val parts = com.typesafe.config.ConfigUtil.splitPath(configEntry.key)
+      if (parts.joinToString(".").startsWith(key)) parts.last() to configEntry.value.unwrapped()
+      else null
+    }
+  }
+
+  @JvmStatic
+  fun getCustomConfiguration(project: Project, customConfigContent: String? = null): String {
     // Needed by Edit commands to trigger smart-selection; without it things break.
     // So it isn't optional in JetBrains clients, which do not offer language-neutral solutions
     // to this problem; instead we hardwire it to use the indentation-based provider.


### PR DESCRIPTION
## Changes

Allows us to change node process settings using cody settings - will be useful while debugging user issues with the process.

## Test plan

Add additional node configuration in `cody_settings.json`:

```
{
   "cody" : {
        "advanced.agent.process.node": {
         "args": ["--max-old-space-size=4096", "--trace-warnings"],
            "env": {
                "NODE_OPTIONS": "--max-http-header-size=16384",
                "NODE_DEBUG": "http*"
             }
        }
  }
}
```

and observe a lot of noise in the idea.log :)
Don't forget to remove it afterwards.