### PR TITLE
fix(chat): center empty history tab

### DIFF
--- a/vscode/webviews/tabs/HistoryTab.tsx
+++ b/vscode/webviews/tabs/HistoryTab.tsx
@@ -2,6 +2,7 @@
 
 import { CodyIDE, type WebviewToExtensionAPI } from '@sourcegraph/cody-shared'
 import type { LightweightChatTranscript } from '@sourcegraph/cody-shared/src/chat/transcript'
+import clsx from 'clsx'
 import { DownloadIcon, HistoryIcon, MessageSquarePlusIcon, Trash2Icon, TrashIcon } from 'lucide-react'
 import type React from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -38,7 +39,14 @@ export const HistoryTab: React.FC<HistoryTabProps> = ({
     const chats = useMemo(() => (userHistory ? Object.values(userHistory) : userHistory), [userHistory])
 
     return (
-        <div className="tw-flex tw-flex-col tw-justify-center tw-overflow-hidden tw-h-full tw-w-full tw-m-4">
+        <div
+            className={clsx(
+                'tw-flex tw-flex-col tw-justify-center tw-overflow-hidden tw-h-full tw-w-full tw-m-4',
+                {
+                    'tw-items-center': !chats,
+                }
+            )}
+        >
             {!chats ? (
                 <LoadingDots />
             ) : (


### PR DESCRIPTION
Ccenters the content of the history tab when there are no chat histories available.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Run storybook `pnpm -C vscode run storybook` and visit http://localhost:6007/?path=/story/cody-app--simple

After: loading dots moved to the center

![image](https://github.com/user-attachments/assets/267742ed-3ee9-44d8-9ea2-f85ba9da5a83)

Before: loading dots on the side

![image](https://github.com/user-attachments/assets/78ac2b9b-aa1e-4f66-9db0-602801f1d671)
