### PR TITLE
refactor(chat): add more info to show in history tab

### DIFF
--- a/lib/shared/src/chat/transcript/lightweight-history.ts
+++ b/lib/shared/src/chat/transcript/lightweight-history.ts
@@ -1,4 +1,5 @@
 import type { SerializedChatTranscript } from '.'
+import type { ChatMessage } from './messages'
 
 /**
  * Enum representing the type of chat history.
@@ -26,6 +27,12 @@ export interface LightweightChatTranscript {
 
     /** The first human message text (used as fallback title) */
     firstHumanMessageText?: string
+
+    /** The model used for the chat */
+    model?: string
+
+    /** The mode of the chat */
+    mode?: ChatMessage['intent']
 }
 
 /**
@@ -46,11 +53,16 @@ export function toLightweightChatTranscript(
     const firstHumanMessage = transcript.interactions.find(
         i => !!transcript.chatTitle || !!i.humanMessage?.editorState
     )?.humanMessage
+    const lastAssistantMessage = transcript.interactions.findLast(
+        i => !!i.assistantMessage?.model
+    )?.assistantMessage
 
     return {
         id: transcript.id,
         chatTitle: transcript.chatTitle || firstHumanMessage?.text,
         lastInteractionTimestamp: transcript.lastInteractionTimestamp,
         firstHumanMessageText: firstHumanMessage?.text,
+        model: lastAssistantMessage?.model,
+        mode: lastAssistantMessage?.intent ?? 'chat',
     }
 }

--- a/vscode/src/chat/chat-view/tools/MCPManager.ts
+++ b/vscode/src/chat/chat-view/tools/MCPManager.ts
@@ -238,7 +238,7 @@ export class MCPManager {
             }
             // Add the connection
             const parsedConfig = result.data
-            await this.connectionManager.addConnection(name, config, parsedConfig?.disabled)
+            await this.connectionManager.addConnection(name, parsedConfig, parsedConfig?.disabled)
         } catch (error) {
             logDebug('MCPManager', `Error adding connection for ${name}`, { verbose: { error } })
         }

--- a/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/ModeSelectorButton.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/ModeSelectorButton.tsx
@@ -19,7 +19,7 @@ export enum IntentEnum {
 }
 
 // Mapping between ChatMessage intent and IntentEnum for faster lookups
-export const INTENT_MAPPING: Record<string, IntentEnum> = {
+export const INTENT_MAPPING: Record<NonNullable<ChatMessage['intent']>, IntentEnum> = {
     agentic: IntentEnum.Agentic,
     chat: IntentEnum.Chat,
     search: IntentEnum.Search,
@@ -135,7 +135,7 @@ export const ModeSelectorField: React.FunctionComponent<{
             return
         }
 
-        if (INTENT_MAPPING[_intent || IntentEnum.Chat] !== currentSelectedIntent) {
+        if (INTENT_MAPPING[_intent || 'chat'] !== currentSelectedIntent) {
             setCurrentSelectedIntent(INTENT_MAPPING[_intent || 'chat'] || IntentEnum.Chat)
         }
 

--- a/vscode/webviews/tabs/HistoryTab.tsx
+++ b/vscode/webviews/tabs/HistoryTab.tsx
@@ -7,6 +7,10 @@ import { DownloadIcon, HistoryIcon, MessageSquarePlusIcon, Trash2Icon, TrashIcon
 import type React from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { WebviewType } from '../../src/chat/protocol'
+import {
+    INTENT_MAPPING,
+    IntentEnum,
+} from '../chat/cells/messageCell/human/editor/toolbar/ModeSelectorButton'
 import { LoadingDots } from '../chat/components/LoadingDots'
 import { downloadChatHistory } from '../chat/downloadChatHistory'
 import { Button } from '../components/shadcn/ui/button'
@@ -325,13 +329,14 @@ export const HistoryTabWithData: React.FC<HistoryTabProps & { chats: Lightweight
             <CommandList className="tw-flex-1 tw-overflow-y-auto tw-m-2">
                 {displayedChats.map((chat: LightweightChatTranscript) => {
                     const id = chat.lastInteractionTimestamp
-                    const chatTitle = chat.chatTitle
                     const lastMessage = chat.firstHumanMessageText
+                    const chatTitle = chat.chatTitle || lastMessage
                     // Show the last interaction timestamp in a human-readable format
                     const timestamp = new Date(chat.lastInteractionTimestamp)
                         .toLocaleString()
                         .replace('T', ', ')
                         .replace('Z', '')
+                    const mode = INTENT_MAPPING[chat.mode || 'chat']
 
                     return (
                         <CommandItem
@@ -343,9 +348,12 @@ export const HistoryTabWithData: React.FC<HistoryTabProps & { chats: Lightweight
                                     chatID: id,
                                 })
                             }
+                            title={chat.model}
                         >
                             <div className="tw-truncate tw-w-full tw-flex tw-flex-col tw-gap-2">
-                                <div>{chatTitle || lastMessage}</div>
+                                <div>
+                                    {mode !== IntentEnum.Chat ? `[${mode}] ${chatTitle}` : chatTitle}
+                                </div>
                                 <div className="tw-text-left tw-text-muted-foreground">{timestamp}</div>
                             </div>
                             <Button


### PR DESCRIPTION
Enhances the history tab by displaying the chat mode (e.g., "Agentic", "Search") and the model used for each chat on hover.

The changes include:

- Adding `model` and `mode` fields to the `LightweightChatTranscript` interface to store the model and intent of the chat.
- Updating the `toLightweightChatTranscript` function to extract the model and intent from the transcript.
- Modifying the `HistoryTabWithData` component to display the chat mode and model in the history list.
- Updating the `INTENT_MAPPING` to include a fallback to 'chat' to avoid undefined values.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Minor UI update. Everything works as before. Last chat model used will show up on hover when available.
Non-chat mode will have mode title appended to title name.