### PR TITLE
Fix missing JCEF panel

### DIFF
--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
@@ -37,16 +37,17 @@ class CodyToolWindowContent(val project: Project) {
 
   @RequiresEdt
   fun refreshPanelsVisibility() {
+    if (isCurrentRuntimeMissingJcef()) {
+      showView(MissingJcefPanel())
+      return
+    }
+
     val errorOnProxyCreation = WebUIService.getInstance(project).proxyCreationException.get()
     if (errorOnProxyCreation == null) {
       webview?.proxy?.component?.let { showView(it) }
     } else {
-      if (isCurrentRuntimeMissingJcef()) {
-        showView(MissingJcefPanel())
-      } else {
-        showView(ErrorPanel())
-        logger.error(errorOnProxyCreation)
-      }
+      showView(ErrorPanel())
+      logger.error(errorOnProxyCreation)
     }
   }
 


### PR DESCRIPTION

<img width="433" alt="image" src="https://github.com/user-attachments/assets/26dfcf20-aceb-4d92-a003-895deb4dea88" />

The logic was there but there was a bug.

## Test plan
1. Run the plugin with a runtime without JCEF.
2. Ensure that the related notification appears & that the panel appears in Cody tool window.

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
