### PR TITLE
Refresh Cody window on display configuration change

### DIFF
--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/ui/web/WebUIProxy.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/ui/web/WebUIProxy.kt
@@ -310,6 +310,14 @@ internal class WebUIProxy(private val host: WebUIHost, private val browser: JBCe
       browser.loadURL("$MAIN_RESOURCE_URL?${value.hashCode()}")
     }
 
+  fun forceRepaint() {
+    // Ugly workaround for an JCEF/JetBrains bug where changing displays configuration
+    // causes rendering issues. We cannot use browser.cefBrowser.reload() because
+    // it wipes out component state when rendering it from scratch
+    browser.zoomLevel = 0.9
+    browser.zoomLevel = 1.0
+  }
+
   fun setOptions(value: DefiniteWebviewOptions) {
     host.setOptions(value)
   }


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/CODY-4220/cody-plugin-gets-stuck-in-jetbrains-pycharm-intelli-j

## Changes

JCEF implementation in IntelliJ is buggy, and depending on IntelliJ version it is buggy in different way:

* IJ 2023.3 - I was not able to reproduce any issues
* IJ 2024.2 - When connecting and disconnecting external displays I'm from time to time able to cause webview hang
* IJ 2025.1 - Moving IntelliJ window between displays causes webview rendering issues - white box is rendered over most of the UI and it does not refresh itself properly

I did quite a bit of debugging and so far I was able to establish that:

1. Looks like problem is caused by JetBrains or JCEF implementation is not handling display configuration changes properly. There are few places where is should be taken into account, and looking at the implementation it seems to be, but maybe not correctly. For example `JBCefOSRHandlerFactory::createScreenBoundsProvider` is one of the suspicious places:

```
  /**
   * Creates a screen bounds provider which takes into account the passed component.
   * Override the method in the headless mode to provide meaningful screen bounds.
   *
   * @see GraphicsEnvironment#isHeadless
   */
  default @NotNull Function<? super JComponent, ? extends Rectangle> createScreenBoundsProvider() {
    return component -> {
      if (component != null && !GraphicsEnvironment.isHeadless()) {
        try {
          return component.isShowing() ?
                 component.getGraphicsConfiguration().getDevice().getDefaultConfiguration().getBounds() :
                 GraphicsEnvironment.getLocalGraphicsEnvironment().getDefaultScreenDevice().getDefaultConfiguration().getBounds();
        }
        catch (Exception e) {
          Logger.getInstance(JBCefOSRHandlerFactory.class).error(e);
        }
      }

      return new Rectangle(0, 0, 0, 0);
    };
  }
```

2. Problem can be mitigated by triggering full browser window refresh. I found 4 ways to do that:
* `browser.cefBrowser.reload()` - that one seems to be always working, but causes reset of component state
* calling 'window.location.refresh()' through `browser.cefBrowser.executeJavaScript(...)` - I'm not convinced it always can fix cases of hangs; it also resets component state
* opening devtools seems to be causing correct repaint (although with some delay)

3. I tried several other approaches which turned out to be fruitless, including but not limited to:
* manual repainting or revalidating `browser.component` `browser.cefBrowser.uiComponent`
* various ways to trigger html reflow using `browser.cefBrowser.executeJavaScript(...)` 
* `browser.cefBrowser.notifyScreenInfoChanged()` (promising name but does noting useful for us); I also checked other methods from browser interface
* refreshing react App component through js API call (not doing anything, although interestingly changing view causes partial refresh, I'm not sure what is going on there)
* I checked various JCEF classes and internally there are some other methods which looks potentially useful but are inaccessible (e.g. `CefBrowser_N::invalidate()`)

4. Only currently rendered component is impacted. Opening new chat in a separate window works fine. Under the hood agent is fully functional, so problem is limited to internal JCEF implementation.

Workaround I implemented fixes the problem completely, but it is not perfect.
It works by listening to AWT repaint events using `Toolkit.getDefaultToolkit().addAWTEventListener(<my_listener>, AWTEvent.PAINT_EVENT_MASK)`, and if such event happens calling `browser.cefBrowser.reload()` explicitly. That repain events happens when:

1. user disconnect/reconnect new display
2. user moved IntelliJ window from one display to another
3. user resizes existing window

**Problem with that workaround** is that it always causes full component reload when one of those events happen.
It is pretty quick (not visually annoying) but cause component state to be reset. In particular, it clears Cody chat input box. That is not what user would expect, and may be annoying if someone moves/resizes IntelliJ window a lot. Unfortunately so far I was not able to differentiate between broken and valid webview state to limit times we call that reload.

That is not ideal situation, but I think change is still net positve.

**[UPDATE]**

I retested what happens when I rescale webview component using `browser.zoomLevel`, and it seems to be working perfectly fine and always refreshes the component as expected. This fixes issues both with IJ 2024 and 2025 and preserves component state!

## Test plan

**[IJ 2024.2]** 

1. Connect and disconnect external displays 
2. If you have more than one try to connect and disconnect them in different order
3. After few tries webview should hang [if tested without this fix]

It is worth noting that depending on a session sometimes I was able to reproduce it with 3-4 tries, and sometimes I was not able to do it at all. I do not know what could cause the difference.

**[IJ 2025.1]** 

1. Move IntelliJ window from one display to another
2. Cody tool window should be incorrectly rendered with most of the content being covered by a white boxes [if tested without this fix]

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
