### PR TITLE
feat(chat): add `cody.chat.agenticContext` configuration option

### DIFF
--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -129,6 +129,7 @@ interface RawClientConfiguration {
 
     // Deep Cody
     agenticContextExperimentalOptions?: AgenticContextConfiguration
+    agenticChat: boolean
 
     //#region Autocomplete
     autocomplete: boolean

--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -129,7 +129,7 @@ interface RawClientConfiguration {
 
     // Deep Cody
     agenticContextExperimentalOptions?: AgenticContextConfiguration
-    agenticContext: boolean
+    chatAgenticContext: boolean
 
     //#region Autocomplete
     autocomplete: boolean

--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -129,7 +129,7 @@ interface RawClientConfiguration {
 
     // Deep Cody
     agenticContextExperimentalOptions?: AgenticContextConfiguration
-    agenticChat: boolean
+    agenticContext: boolean
 
     //#region Autocomplete
     autocomplete: boolean

--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -155,7 +155,7 @@ export enum FeatureFlag {
     /**
      * Allow Deep Cody to use MCP tools during context fetching steps.
      */
-    AgenticChatWithMCP = 'agentic-chat-mcp-enabled',
+    AgenticChatWithMCP = 'agentic-context-mcp-enabled',
 
     /**
      * Disable agentic context for chat - Deep Cody disabled

--- a/lib/shared/src/models/client.ts
+++ b/lib/shared/src/models/client.ts
@@ -1,22 +1,5 @@
-import type { ServerModel } from './model'
-import type { ModelTag } from './tags'
-
 export const DeepCodyAgentID = 'deep-cody'
+// Deprecated
 export const DeepCodyModelRef = 'sourcegraph::2023-06-01::deep-cody'
-
+// Deprecated
 export const ToolCodyModelName = 'tool-cody'
-
-export const DEEP_CODY_MODEL: ServerModel = {
-    // This modelRef does not exist in the backend and is used to identify the model in the client.
-    modelRef: DeepCodyModelRef,
-    displayName: 'Agentic chat',
-    modelName: DeepCodyAgentID,
-    capabilities: ['chat'],
-    category: 'accuracy',
-    status: 'experimental' as ModelTag.Experimental,
-    tier: 'pro' as ModelTag.Pro,
-    contextWindow: {
-        maxInputTokens: 45000,
-        maxOutputTokens: 4000,
-    },
-}

--- a/lib/shared/src/models/sync.test.ts
+++ b/lib/shared/src/models/sync.test.ts
@@ -386,7 +386,7 @@ describe('syncModels', () => {
         }
     )
 
-    it('set Agentic Chat as default chat model when feature flag is enabled', async () => {
+    it('Agentic Chat does not show up in the model dropdown even if the old feature flag is enabled', async () => {
         const serverSonnet: ServerModel = {
             modelRef: 'anthropic::unknown::claude-3-5-sonnet',
             displayName: 'Sonnet',
@@ -454,7 +454,7 @@ describe('syncModels', () => {
         vi.spyOn(modelsService, 'modelsChanges', 'get').mockReturnValue(Observable.of(result))
 
         // Check if Deep Cody model is no longer in the models list.
-        expect(result.primaryModels.some(model => model.id.includes('deep-cody'))).toBe(true)
+        expect(result.primaryModels.some(model => model.id.includes('deep-cody'))).toBe(false)
 
         // preference should not be affected and remains unchanged as this is handled in a later step.
         expect(result.preferences.selected.chat).toBe(undefined)

--- a/lib/shared/src/models/sync.ts
+++ b/lib/shared/src/models/sync.ts
@@ -29,7 +29,6 @@ import type { UserProductSubscription } from '../sourcegraph-api/userProductSubs
 import { telemetryRecorder } from '../telemetry-v2/singleton'
 import { CHAT_INPUT_TOKEN_BUDGET } from '../token/constants'
 import { isError } from '../utils'
-import { DEEP_CODY_MODEL } from './client'
 import { type Model, type ServerModel, createModel, createModelFromServerModel } from './model'
 import type {
     DefaultsAndUserPreferencesForEndpoint,
@@ -191,8 +190,7 @@ export function syncModels({
                                         featureFlagProvider.evaluatedFeatureFlag(
                                             FeatureFlag.FallbackToFlash,
                                             true /** force refresh */
-                                        ),
-                                        featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.DeepCody)
+                                        )
                                     ).pipe(
                                         switchMap(
                                             ([
@@ -200,7 +198,6 @@ export function syncModels({
                                                 defaultToHaiku,
                                                 enhancedContextWindowFlag,
                                                 fallbackToFlashFlag,
-                                                hasAgenticChatFlag,
                                             ]) => {
                                                 if (serverModelsConfig) {
                                                     // Remove deprecated models from the list, filter out waitlisted models for Enterprise.
@@ -435,23 +432,6 @@ export function syncModels({
                                                     }
                                                     return model
                                                 })
-
-                                                // Handle agentic chat features
-                                                const isAgenticChatEnabled =
-                                                    hasAgenticChatFlag ||
-                                                    (isDotComUser && !isCodyFreeUser)
-                                                const hasDeepCody = data.primaryModels.some(m =>
-                                                    m.id.includes('deep-cody')
-                                                )
-
-                                                if (isAgenticChatEnabled && !hasDeepCody) {
-                                                    data.primaryModels.push(
-                                                        createModelFromServerModel(
-                                                            DEEP_CODY_MODEL,
-                                                            false // Should not affect the context window set for Agentic chat
-                                                        )
-                                                    )
-                                                }
 
                                                 return Observable.of(data)
                                             }

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1167,6 +1167,13 @@
           "markdownDeprecationMessage": "**Deprecated** Enable Agents like Deep Cody to autonomously execute shell commands in your environment for context. Enable with caution as mistakes are possible.",
           "deprecationMessage": "Deprecated. Now configurable via UI."
         },
+        "cody.agentic.chat": {
+          "order": 13,
+          "title": "Cody Agentic Chat",
+          "type": "boolean",
+          "markdownDescription": "Enable agentic chat functionality for enhanced AI assistant capabilities.",
+          "default": true
+        },
         "cody.agentic.context.experimentalOptions": {
           "type": "object",
           "properties": {

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1167,7 +1167,7 @@
           "markdownDeprecationMessage": "**Deprecated** Enable Agents like Deep Cody to autonomously execute shell commands in your environment for context. Enable with caution as mistakes are possible.",
           "deprecationMessage": "Deprecated. Now configurable via UI."
         },
-        "cody.agentic.context": {
+        "cody.chat.agenticContext": {
           "order": 13,
           "title": "Agentic context for chat",
           "type": "boolean",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1167,7 +1167,7 @@
           "markdownDeprecationMessage": "**Deprecated** Enable Agents like Deep Cody to autonomously execute shell commands in your environment for context. Enable with caution as mistakes are possible.",
           "deprecationMessage": "Deprecated. Now configurable via UI."
         },
-        "cody.agentic.chat": {
+        "cody.agentic.context": {
           "order": 13,
           "title": "Agentic context for chat",
           "type": "boolean",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1129,7 +1129,7 @@
         },
         "cody.mcpServers": {
           "type": "object",
-          "markdownDescription": "Configuration for MCP servers to use with agentic chat.",
+          "markdownDescription": "Configuration for MCP servers to use with agentic chat. Enterprise instance with feature flag enabled required.",
           "default": {}
         },
         "cody.internal.unstable": {
@@ -1169,9 +1169,9 @@
         },
         "cody.agentic.chat": {
           "order": 13,
-          "title": "Cody Agentic Chat",
+          "title": "Agentic context for chat",
           "type": "boolean",
-          "markdownDescription": "Enable agentic chat functionality for enhanced AI assistant capabilities.",
+          "markdownDescription": "Enable agentic context for chat.",
           "default": true
         },
         "cody.agentic.context.experimentalOptions": {

--- a/vscode/src/chat/agentic/ToolboxManager.test.ts
+++ b/vscode/src/chat/agentic/ToolboxManager.test.ts
@@ -1,6 +1,8 @@
 import { type Model, ModelTag } from '@sourcegraph/cody-shared'
 import { DeepCodyAgentID } from '@sourcegraph/cody-shared/src/models/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { DeepCodyAgent } from './DeepCody'
+import { getDeepCodyModel, toolboxManager } from './ToolboxManager'
 
 // Set up mocks with vi.mocked approach
 vi.mock('vscode', () => ({ env: { shell: undefined } }))
@@ -32,6 +34,8 @@ vi.mock('@sourcegraph/cody-shared', () => ({
         Speed: 'speed',
     },
     pendingOperation: Symbol('pendingOperation'),
+
+    resolvedConfig: { pipe: vi.fn().mockReturnThis(), next: vi.fn(), subscribe: vi.fn() },
 }))
 
 vi.mock('./DeepCody', () => ({
@@ -39,10 +43,6 @@ vi.mock('./DeepCody', () => ({
         model: undefined,
     },
 }))
-
-// Import after setting up mocks
-import { DeepCodyAgent } from './DeepCody'
-import { getDeepCodyModel, toolboxManager } from './ToolboxManager'
 
 // Mocks are defined at the top of the file
 

--- a/vscode/src/chat/agentic/ToolboxManager.test.ts
+++ b/vscode/src/chat/agentic/ToolboxManager.test.ts
@@ -136,7 +136,6 @@ describe('ToolboxManager', () => {
                 name: 'should return settings with agent when enabled and not rate limited',
                 setup: () => {
                     vi.spyOn(toolboxManager as any, 'isEnabled', 'get').mockReturnValue(true)
-                    vi.spyOn(toolboxManager as any, 'isAgenticModelOnly', 'get').mockReturnValue(false)
                     vi.spyOn(toolboxManager as any, 'getFeatureError').mockReturnValue(undefined)
                 },
                 expected: {
@@ -151,7 +150,6 @@ describe('ToolboxManager', () => {
                 name: 'should return settings with shell error when shell not supported',
                 setup: () => {
                     vi.spyOn(toolboxManager as any, 'isEnabled', 'get').mockReturnValue(true)
-                    vi.spyOn(toolboxManager as any, 'isAgenticModelOnly', 'get').mockReturnValue(false)
                     vi.spyOn(toolboxManager as any, 'getFeatureError').mockReturnValue(
                         'Not supported by the instance.'
                     )

--- a/vscode/src/chat/agentic/ToolboxManager.ts
+++ b/vscode/src/chat/agentic/ToolboxManager.ts
@@ -119,7 +119,7 @@ class ToolboxManager {
                     !models ||
                     isCodyTesting ||
                     isDisabledOnInstance ||
-                    !config.configuration?.agenticChat
+                    !config.configuration?.agenticContext
                 ) {
                     DeepCodyAgent.model = undefined
                     this.isEnabled = false

--- a/vscode/src/chat/agentic/ToolboxManager.ts
+++ b/vscode/src/chat/agentic/ToolboxManager.ts
@@ -119,7 +119,7 @@ class ToolboxManager {
                     !models ||
                     isCodyTesting ||
                     isDisabledOnInstance ||
-                    !config.configuration?.agenticContext
+                    config.configuration?.agenticContext === false
                 ) {
                     DeepCodyAgent.model = undefined
                     this.isEnabled = false

--- a/vscode/src/chat/agentic/ToolboxManager.ts
+++ b/vscode/src/chat/agentic/ToolboxManager.ts
@@ -111,7 +111,7 @@ class ToolboxManager {
                     !models ||
                     isCodyTesting ||
                     isDisabledOnInstance ||
-                    config.configuration?.agenticContext === false
+                    config.configuration?.chatAgenticContext === false
                 ) {
                     DeepCodyAgent.model = undefined
                     this.isEnabled = false

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -801,7 +801,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                     text: inputText,
                     editorState,
                     intent: manuallySelectedIntent,
-                    agent: toolboxManager.isAgenticChatEnabled(model) ? DeepCodyAgent.id : undefined,
+                    agent: toolboxManager.isAgenticChatEnabled() ? DeepCodyAgent.id : undefined,
                 })
 
                 this.setCustomChatTitle(requestID, inputText, signal)

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -656,7 +656,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
 
     private async getConfigForWebview(): Promise<ConfigurationSubsetForWebview & LocalEnv> {
         const { configuration, auth } = await currentResolvedConfig()
-        const [experimentalPromptEditorEnabled, internalAgenticChatEnabled] = await Promise.all([
+        const [experimentalPromptEditorEnabled, internalAgentModeEnabled] = await Promise.all([
             firstValueFrom(
                 featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.CodyExperimentalPromptEditor)
             ),
@@ -664,7 +664,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                 featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.NextAgenticChatInternal)
             ),
         ])
-        const experimentalAgenticChatEnabled = internalAgenticChatEnabled && isS2(auth.serverEndpoint)
+        const experimentalAgenticChatEnabled = internalAgentModeEnabled && isS2(auth.serverEndpoint)
         const sidebarViewOnly = this.extensionClient.capabilities?.webviewNativeConfig?.view === 'single'
         const isEditorViewType = this.webviewPanelOrView?.viewType === 'cody.editorPanel'
         const webviewType = isEditorViewType && !sidebarViewOnly ? 'editor' : 'sidebar'

--- a/vscode/src/chat/chat-view/handlers/registry.ts
+++ b/vscode/src/chat/chat-view/handlers/registry.ts
@@ -42,7 +42,7 @@ export function getAgent(model: string, intent: ChatMessage['intent'], tools: Ag
     // Use agentic chat (Deep Cody) handler if enabled.
     // Skip in agent testing mode to avoid non-deterministic results causing
     // recordings to fail consistently.
-    if (!isCodyTesting && toolboxManager.isAgenticChatEnabled(model)) {
+    if (!isCodyTesting && toolboxManager.isAgenticChatEnabled()) {
         return new DeepCodyHandler(contextRetriever, editor, chatClient)
     }
 

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -136,6 +136,8 @@ describe('getConfiguration', () => {
                         return false
                     case 'cody.agentic.context.experimentalOptions':
                         return { shell: { allow: ['git'] } }
+                    case 'cody.agentic.chat':
+                        return false
                     case 'cody.auth.externalProviders':
                         return []
                     case 'cody.rules.enabled':
@@ -169,6 +171,7 @@ describe('getConfiguration', () => {
             },
             commandCodeLenses: true,
             agenticContextExperimentalOptions: { shell: { allow: ['git'] } },
+            agenticChat: false,
             experimentalSupercompletions: false,
             experimentalAutoEditEnabled: false,
             experimentalAutoEditConfigOverride: undefined,

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -171,7 +171,7 @@ describe('getConfiguration', () => {
             },
             commandCodeLenses: true,
             agenticContextExperimentalOptions: { shell: { allow: ['git'] } },
-            agenticChat: false,
+            agenticContext: false,
             experimentalSupercompletions: false,
             experimentalAutoEditEnabled: false,
             experimentalAutoEditConfigOverride: undefined,

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -136,7 +136,7 @@ describe('getConfiguration', () => {
                         return false
                     case 'cody.agentic.context.experimentalOptions':
                         return { shell: { allow: ['git'] } }
-                    case 'cody.agentic.context':
+                    case 'cody.chat.agenticContext':
                         return false
                     case 'cody.auth.externalProviders':
                         return []
@@ -171,7 +171,7 @@ describe('getConfiguration', () => {
             },
             commandCodeLenses: true,
             agenticContextExperimentalOptions: { shell: { allow: ['git'] } },
-            agenticContext: false,
+            chatAgenticContext: false,
             experimentalSupercompletions: false,
             experimentalAutoEditEnabled: false,
             experimentalAutoEditConfigOverride: undefined,

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -136,7 +136,7 @@ describe('getConfiguration', () => {
                         return false
                     case 'cody.agentic.context.experimentalOptions':
                         return { shell: { allow: ['git'] } }
-                    case 'cody.agentic.chat':
+                    case 'cody.agentic.context':
                         return false
                     case 'cody.auth.externalProviders':
                         return []

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -121,7 +121,7 @@ export function getConfiguration(
          */
         agenticContextExperimentalOptions: config.get(CONFIG_KEY.agenticContextExperimentalOptions, {}),
 
-        agenticContext: config.get(CONFIG_KEY.agenticContext, true),
+        chatAgenticContext: config.get(CONFIG_KEY.chatAgenticContext, true),
 
         authExternalProviders: config.get(CONFIG_KEY.authExternalProviders, []),
 

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -121,6 +121,8 @@ export function getConfiguration(
          */
         agenticContextExperimentalOptions: config.get(CONFIG_KEY.agenticContextExperimentalOptions, {}),
 
+        agenticChat: config.get(CONFIG_KEY.agenticChat, true),
+
         authExternalProviders: config.get(CONFIG_KEY.authExternalProviders, []),
 
         /**

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -121,7 +121,7 @@ export function getConfiguration(
          */
         agenticContextExperimentalOptions: config.get(CONFIG_KEY.agenticContextExperimentalOptions, {}),
 
-        agenticChat: config.get(CONFIG_KEY.agenticChat, true),
+        agenticContext: config.get(CONFIG_KEY.agenticContext, true),
 
         authExternalProviders: config.get(CONFIG_KEY.authExternalProviders, []),
 

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -938,6 +938,7 @@ export const DEFAULT_VSCODE_SETTINGS = {
     internalDebugContext: false,
     internalDebugState: false,
     agenticContextExperimentalOptions: {},
+    agenticChat: true,
     autocompleteAdvancedProvider: 'default',
     autocompleteAdvancedModel: null,
     autocompleteCompleteSuggestWidgetSelection: true,

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -938,7 +938,7 @@ export const DEFAULT_VSCODE_SETTINGS = {
     internalDebugContext: false,
     internalDebugState: false,
     agenticContextExperimentalOptions: {},
-    agenticContext: true,
+    chatAgenticContext: true,
     autocompleteAdvancedProvider: 'default',
     autocompleteAdvancedModel: null,
     autocompleteCompleteSuggestWidgetSelection: true,

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -938,7 +938,7 @@ export const DEFAULT_VSCODE_SETTINGS = {
     internalDebugContext: false,
     internalDebugState: false,
     agenticContextExperimentalOptions: {},
-    agenticChat: true,
+    agenticContext: true,
     autocompleteAdvancedProvider: 'default',
     autocompleteAdvancedModel: null,
     autocompleteCompleteSuggestWidgetSelection: true,


### PR DESCRIPTION
Add a new configuration option, `cody.chat.agenticContext`, to enable or disable agentic chat functionality, enabled by default. Also removing Agentic Context from model dropdown.

- Is added to the `RawClientConfiguration` interface in `lib/shared/src/configuration.ts`.
- Is exposed as a configurable option in VS Code settings via `vscode/package.json`.
- Defaults to `true` in `vscode/package.json`, `vscode/src/configuration.ts`, and `vscode/src/testutils/mocks.ts`.
- Can be overridden in VS Code settings.
- Is used to determine whether to enable the Deep Cody agent in `vscode/src/chat/agentic/ToolboxManager.ts`.
- Removes the feature flag check for `DeepCody` and replaces it with the `cody.agentic.context` config.
- Removes the addition of the `DEEP_CODY_MODEL` based on feature flags and dotcom status in `lib/shared/src/models/sync.ts`.

This change allows users to control whether they want to use agentic chat features, providing more flexibility and control over Cody's behavior.

Update: replace agentic chat with `cody.chat.agenticContext`:

```
update mcp feature flag to be `agentic-context-mcp-enabled`
:pray:
1

[13:39](https://sourcegraph.slack.com/archives/D089QB2V67J/p1748032779237669)
agentic-context-disabled to disable agentic context on instance level
:pray:
1

[13:39](https://sourcegraph.slack.com/archives/D089QB2V67J/p1748032787795379)
cody.agentic.chat for user level setting
```

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->


Agentic chat removed from model dropdown.
Agentic chat enabled for all models by default.
You can disable the default agentic chat behavior with `cody.agentic.context` to false
