### PR TITLE
Fix smart apply tooltips in jetbrains

### DIFF
--- a/vscode/test/e2e/chat-messages.test.ts
+++ b/vscode/test/e2e/chat-messages.test.ts
@@ -30,7 +30,7 @@ test('chat assistant response code buttons', async ({ page, nap, sidebar }, test
     await expect(assistantRow).toContainText('Hello! Here is a code snippet:')
     await expect(assistantRow).toContainText('def fib(n):')
 
-    const copyButton = assistantRow.getByTitle('Copy Code')
+    const copyButton = assistantRow.getByRole('button', { name: 'Copy' })
     const smartApplyButton = assistantRow.getByRole('button', { name: 'Apply' })
     const actionsDropdown = assistantRow.getByRole('button', { name: 'More Actions' })
     expect(await copyButton.count()).toBe(1)

--- a/vscode/webviews/chat/ChatMessageContent/EditButtons.tsx
+++ b/vscode/webviews/chat/ChatMessageContent/EditButtons.tsx
@@ -347,19 +347,22 @@ function createActionsDropdown(preText: string): React.ReactElement {
         event.stopPropagation()
     }, [])
 
+    const tooltip = 'More Actions…'
+
     return (
         <Tooltip>
             <TooltipTrigger asChild>
                 <button
                     type="button"
                     className={styles.button}
+                    aria-label={tooltip}
                     data-vscode-context={JSON.stringify(vscodeContext)}
                     onClick={handleClick}
                 >
                     {EllipsisIcon}
                 </button>
             </TooltipTrigger>
-            <TooltipContent>More Actions…</TooltipContent>
+            <TooltipContent>{tooltip}</TooltipContent>
         </Tooltip>
     )
 }

--- a/vscode/webviews/chat/ChatMessageContent/EditButtons.tsx
+++ b/vscode/webviews/chat/ChatMessageContent/EditButtons.tsx
@@ -2,6 +2,7 @@ import clsx from 'clsx'
 import type React from 'react'
 import { useCallback, useState } from 'react'
 import { CodyTaskState } from '../../../src/non-stop/state'
+import { Tooltip, TooltipContent, TooltipTrigger } from '../../components/shadcn/ui/tooltip'
 import {
     CheckCodeBlockIcon,
     CloseIcon,
@@ -54,10 +55,15 @@ export const CopyButton = ({
     }, [onCopy, text, label, customIcon])
 
     return (
-        <button type="button" className={className} onClick={handleClick} title={title}>
-            <div className={styles.iconContainer}>{icon}</div>
-            {showLabel && <span className="tw-hidden xs:tw-block">{currentLabel}</span>}
-        </button>
+        <Tooltip>
+            <TooltipTrigger asChild>
+                <button type="button" className={className} onClick={handleClick}>
+                    <div className={styles.iconContainer}>{icon}</div>
+                    {showLabel && <span className="tw-hidden xs:tw-block">{currentLabel}</span>}
+                </button>
+            </TooltipTrigger>
+            <TooltipContent>{title}</TooltipContent>
+        </Tooltip>
     )
 }
 
@@ -190,15 +196,19 @@ function createInsertButton(
     insertButtonOnSubmit?: CodeBlockActionsProps['insertButtonOnSubmit']
 ): React.ReactElement {
     return (
-        <button
-            type="button"
-            title="Insert Code at Cursor"
-            className={styles.button}
-            onClick={() => insertButtonOnSubmit?.(preText, false)}
-        >
-            <div className={styles.iconContainer}>{InsertCodeBlockIcon}</div>
-            <span className="tw-hidden xs:tw-block">Insert</span>
-        </button>
+        <Tooltip>
+            <TooltipTrigger asChild>
+                <button
+                    type="button"
+                    className={styles.button}
+                    onClick={() => insertButtonOnSubmit?.(preText, false)}
+                >
+                    <div className={styles.iconContainer}>{InsertCodeBlockIcon}</div>
+                    <span className="tw-hidden xs:tw-block">Insert</span>
+                </button>
+            </TooltipTrigger>
+            <TooltipContent>Insert Code at Cursor</TooltipContent>
+        </Tooltip>
     )
 }
 
@@ -207,15 +217,19 @@ function createSaveButton(
     insertButtonOnSubmit?: CodeBlockActionsProps['insertButtonOnSubmit']
 ): React.ReactElement {
     return (
-        <button
-            type="button"
-            title="Save Code to New File..."
-            className={styles.button}
-            onClick={() => insertButtonOnSubmit?.(preText, true)}
-        >
-            <div className={styles.iconContainer}>{SaveCodeBlockIcon}</div>
-            <span className="tw-hidden xs:tw-block">Save</span>
-        </button>
+        <Tooltip>
+            <TooltipTrigger asChild>
+                <button
+                    type="button"
+                    className={styles.button}
+                    onClick={() => insertButtonOnSubmit?.(preText, true)}
+                >
+                    <div className={styles.iconContainer}>{SaveCodeBlockIcon}</div>
+                    <span className="tw-hidden xs:tw-block">Save</span>
+                </button>
+            </TooltipTrigger>
+            <TooltipContent>Save Code to New File…</TooltipContent>
+        </Tooltip>
     )
 }
 
@@ -243,25 +257,34 @@ function createApplyButton(
     }
 
     return (
-        <button
-            type="button"
-            className={styles.button}
-            onClick={onClick}
-            title="Apply in Editor"
-            disabled={disabled}
-        >
-            <div className={styles.iconContainer}>{icon}</div>
-            <span className="tw-hidden xs:tw-block">{label}</span>
-        </button>
+        <Tooltip>
+            <TooltipTrigger asChild>
+                <button type="button" className={styles.button} onClick={onClick} disabled={disabled}>
+                    <div className={styles.iconContainer}>{icon}</div>
+                    <span className="tw-hidden xs:tw-block">{label}</span>
+                </button>
+            </TooltipTrigger>
+            <TooltipContent>Apply in Editor</TooltipContent>
+        </Tooltip>
     )
 }
 
 function createExecuteButton(onExecute: () => void): React.ReactElement {
     return (
-        <button type="button" className={styles.button} onClick={onExecute} title="Execute in Terminal">
-            <div className={clsx(styles.iconContainer, 'tw-align-middle codicon codicon-terminal')} />
-            <span className="tw-hidden xs:tw-block">Execute</span>
-        </button>
+        <Tooltip>
+            <TooltipTrigger asChild>
+                <button type="button" className={styles.button} onClick={onExecute}>
+                    <div
+                        className={clsx(
+                            styles.iconContainer,
+                            'tw-align-middle codicon codicon-terminal'
+                        )}
+                    />
+                    <span className="tw-hidden xs:tw-block">Execute</span>
+                </button>
+            </TooltipTrigger>
+            <TooltipContent>Execute in Terminal</TooltipContent>
+        </Tooltip>
     )
 }
 
@@ -270,15 +293,15 @@ function createAcceptButton(
     smartApply: CodeBlockActionsProps['smartApply']
 ): React.ReactElement {
     return (
-        <button
-            type="button"
-            className={styles.button}
-            onClick={() => smartApply.onAccept(id)}
-            title="Accept"
-        >
-            <div className={styles.iconContainer}>{TickIcon}</div>
-            <span className="tw-hidden xs:tw-block">Accept</span>
-        </button>
+        <Tooltip>
+            <TooltipTrigger asChild>
+                <button type="button" className={styles.button} onClick={() => smartApply.onAccept(id)}>
+                    <div className={styles.iconContainer}>{TickIcon}</div>
+                    <span className="tw-hidden xs:tw-block">Accept</span>
+                </button>
+            </TooltipTrigger>
+            <TooltipContent>Accept</TooltipContent>
+        </Tooltip>
     )
 }
 
@@ -287,15 +310,15 @@ function createRejectButton(
     smartApply: CodeBlockActionsProps['smartApply']
 ): React.ReactElement {
     return (
-        <button
-            type="button"
-            className={styles.button}
-            onClick={() => smartApply.onReject(id)}
-            title="Reject"
-        >
-            <div className={styles.iconContainer}>{CloseIcon}</div>
-            <span className="tw-hidden xs:tw-block">Reject</span>
-        </button>
+        <Tooltip>
+            <TooltipTrigger asChild>
+                <button type="button" className={styles.button} onClick={() => smartApply.onReject(id)}>
+                    <div className={styles.iconContainer}>{CloseIcon}</div>
+                    <span className="tw-hidden xs:tw-block">Reject</span>
+                </button>
+            </TooltipTrigger>
+            <TooltipContent>Reject</TooltipContent>
+        </Tooltip>
     )
 }
 
@@ -325,14 +348,18 @@ function createActionsDropdown(preText: string): React.ReactElement {
     }, [])
 
     return (
-        <button
-            type="button"
-            title="More Actions..."
-            className={styles.button}
-            data-vscode-context={JSON.stringify(vscodeContext)}
-            onClick={handleClick}
-        >
-            {EllipsisIcon}
-        </button>
+        <Tooltip>
+            <TooltipTrigger asChild>
+                <button
+                    type="button"
+                    className={styles.button}
+                    data-vscode-context={JSON.stringify(vscodeContext)}
+                    onClick={handleClick}
+                >
+                    {EllipsisIcon}
+                </button>
+            </TooltipTrigger>
+            <TooltipContent>More Actions…</TooltipContent>
+        </Tooltip>
     )
 }


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/QA-572/jb-no-tool-tip-is-shown-for-apply-icon-on-mouse-hover

## Changes

JCEF implementation in JetBrains does not support native tooltips provided by `title`.
If we want to show them we should use dedicated React tooltip component.

## Test plan

1. Do chat action which will provide code change suggestion.
2. Hover mouse over smart apply buttons like `Apply` and veify that tooltip is showing up.

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
