### PR TITLE
Show empty chat history message if deleting all messages during filtering

### DIFF
--- a/vscode/webviews/tabs/HistoryTab.tsx
+++ b/vscode/webviews/tabs/HistoryTab.tsx
@@ -218,7 +218,7 @@ export const HistoryTabWithData: React.FC<HistoryTabProps & { chats: Lightweight
         }
     }, [hasMoreItems, filteredChats.length, isLoading])
 
-    if (!filteredChats.length && !searchText) {
+    if (!nonEmptyChats.length) {
         return (
             <div className="tw-flex tw-flex-col tw-items-center tw-p-6">
                 <HistoryIcon size={20} strokeWidth={1.25} className="tw-mb-5 tw-text-muted-foreground" />


### PR DESCRIPTION
## Changes

This PR fixes a bug where "You have no chat history"  message is not shown when user deletes last remaining history while filtering the messages.

## Test plan

1. Log in to Cody using any account type.
2. Have multiple conversations with Cody to create chat history entries.
3. Navigate to the "History" tab in the Cody panel.
4. Use the search box to filter existing history entries.
5. Click on the "Delete All" button to clear all chat history.
6. Observe the content of the history tab after deletion - "You have no chat history" message should appear

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
