### PR TITLE
Fix missing LLM icon in Edit Code's dropdown

### DIFF
--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/protocol_extensions/ModelUtil.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/protocol_extensions/ModelUtil.kt
@@ -5,12 +5,12 @@ import com.sourcegraph.cody.agent.protocol_generated.Model
 import javax.swing.Icon
 
 fun Model.getIcon(): Icon? =
-    when (provider) {
-      "Anthropic" -> Icons.LLM.Anthropic
-      "OpenAI" -> Icons.LLM.OpenAI
-      "Mistral" -> Icons.LLM.Mistral
-      "Google" -> Icons.LLM.Google
-      "Ollama" -> Icons.LLM.Ollama
+    when (provider?.lowercase()) {
+      "anthropic" -> Icons.LLM.Anthropic
+      "openai" -> Icons.LLM.OpenAI
+      "mistral" -> Icons.LLM.Mistral
+      "google" -> Icons.LLM.Google
+      "ollama" -> Icons.LLM.Ollama
       else -> null
     }
 


### PR DESCRIPTION
The icons disappeared long time ago (before the repo's merge). This PR brings them back.

## Demo
<img width="387" alt="image" src="https://github.com/user-attachments/assets/7884dbb1-a2d9-48f1-9569-00e82595610f" />


## Test plan
1. Edit Code...
2. Ensure that the icons are visible

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
