### PR TITLE
fix(jetbrains): remove unset SKIP_CODE_SEARCH_BUILD env var

### DIFF
--- a/jetbrains/scripts/verify-release.sh
+++ b/jetbrains/scripts/verify-release.sh
@@ -6,7 +6,6 @@ echo "= Running automated tests before publishing release ="
 echo "====================================================="
 set -x
 unset CODY_DIR
-unset SKIP_CODE_SEARCH_BUILD
 
 ./gradlew clean || ./gradlew clean # Run it twice because Gradle clean is brittle
 ./gradlew buildPlugin


### PR DESCRIPTION
Removes the code to unset the `SKIP_CODE_SEARCH_BUILD` environment variable from the `verify-release.sh` script.  This code is causing the release script to fail locally even when `SKIP_CODE_SEARCH_BUILD`  sets to true. The GITHUB_TOKEN should be set in the CI only and should not required release captain to set it locally for security reason


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

run the `./scripts/push-git-tag-for-next-release.sh --patch --nightly` script after setting `SKIP_CODE_SEARCH_BUILD` to true. The script should not fail.
