### PR TITLE
Fix History tab styling across IDE themes

### DIFF
--- a/vscode/webviews/tabs/HistoryTab.tsx
+++ b/vscode/webviews/tabs/HistoryTab.tsx
@@ -261,8 +261,7 @@ export const HistoryTabWithData: React.FC<HistoryTabProps & { chats: Lightweight
             {IDE !== CodyIDE.Web && (
                 <header className="tw-inline-flex tw-px-4 tw-gap-4">
                     <Button
-                        variant="secondary"
-                        className="tw-bg-popover tw-border tw-border-border !tw-justify-between"
+                        className="tw-bg-popover tw-border tw-border-border !tw-justify-between tw-text-sidebar-foreground"
                         onClick={onExportClick}
                     >
                         <div className="tw-flex tw-items-center">
@@ -270,8 +269,7 @@ export const HistoryTabWithData: React.FC<HistoryTabProps & { chats: Lightweight
                         </div>
                     </Button>
                     <Button
-                        variant="secondary"
-                        className="tw-bg-popover tw-border tw-border-border !tw-justify-between"
+                        className="tw-bg-popover tw-border tw-border-border !tw-justify-between tw-text-sidebar-foreground"
                         onClick={() => setIsDeleteAllActive(true)}
                     >
                         <div className="tw-flex tw-items-center">
@@ -282,7 +280,7 @@ export const HistoryTabWithData: React.FC<HistoryTabProps & { chats: Lightweight
             )}
             {isDeleteAllActive && (
                 <div
-                    className="tw-my-4 tw-p-4 tw-mx-[0.5rem] tw-border tw-border-red-300 tw-rounded-lg tw-bg-muted-transparent dark:tw-text-red-400 dark:tw-border-red-800"
+                    className="tw-my-4 tw-p-4 tw-mx-[0.5rem] tw-border tw-bg-muted-transparent tw-border-red-800 tw-rounded-lg"
                     role="alert"
                 >
                     <div className="tw-flex tw-items-center">
@@ -293,11 +291,11 @@ export const HistoryTabWithData: React.FC<HistoryTabProps & { chats: Lightweight
                     <div className="tw-mt-2 tw-mb-4 tw-text-sm tw-text-muted-foreground">
                         You will not be able to recover them once deleted.
                     </div>
-                    <div className="tw-flex">
+                    <div className="tw-flex tw-gap-2">
                         <Button
                             size="sm"
                             aria-label="Delete all chats"
-                            className="tw-text-white tw-bg-red-800 hover:tw-bg-red-900 focus:tw-ring-4 focus:tw-outline-none focus:tw-ring-red-200 tw-font-medium tw-rounded-lg tw-text-xs tw-px-3 tw-py-1.5 tw-me-2 tw-text-center tw-inline-flex tw-items-center dark:tw-bg-red-600 dark:hover:tw-bg-red-700 dark:focus:tw-ring-red-800"
+                            className="tw-bg-popover tw-border tw-border-border tw-text-white tw-bg-red-800 hover:tw-bg-red-900 focus:tw-ring-4"
                             onClick={e => {
                                 onDeleteButtonClick(e, 'clear-all-no-confirm')
                                 setIsDeleteAllActive(false)
@@ -307,7 +305,7 @@ export const HistoryTabWithData: React.FC<HistoryTabProps & { chats: Lightweight
                         </Button>
                         <Button
                             size="sm"
-                            className="tw-text-red-800 tw-bg-transparent tw-border tw-border-red-800 hover:tw-bg-red-900 hover:tw-text-white focus:tw-ring-4 focus:tw-outline-none focus:tw-ring-red-200 tw-font-medium tw-rounded-lg tw-text-xs tw-px-3 tw-py-1.5 tw-text-center dark:hover:tw-bg-red-600 dark:tw-border-red-600 dark:tw-text-red-400 dark:hover:tw-text-white dark:focus:tw-ring-red-800"
+                            className="tw-bg-popover tw-border tw-border-border tw-text-sidebar-foreground"
                             onClick={() => setIsDeleteAllActive(false)}
                             aria-label="Cancel"
                         >


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/QA-622/jb-specificwindows-specific-cancel-button-doesnt-match-the-theme-of

## Changes

Various fixes for readability of the History tab.

On first 3 screenshots from VSC you can see old look on the left and new look on the right:
![Pasted Graphic](https://github.com/user-attachments/assets/c10c7c02-b2fe-4d02-bfbb-e2b25feb86c5)
![Pasted Graphic 1](https://github.com/user-attachments/assets/7d7ec124-8d18-40a1-83aa-3d64495c490c)
![Pasted Graphic 2](https://github.com/user-attachments/assets/da81b989-4ca7-4f26-bb2f-6fc7994a26bd)

On the next 3 screenshots you can see new look in the IntelliJ across various themes:

![Are you sure you want to delete all of your chats](https://github.com/user-attachments/assets/119842eb-d036-47e6-8b5d-03ca0926c7f0)
![Are you sure you want to delete all of your chats](https://github.com/user-attachments/assets/671ae8df-b3f6-496b-ac10-463957ed73e4)
![Are you sure you want to delete all of your chats](https://github.com/user-attachments/assets/ec89c6f2-4a5d-494a-b9d4-514720bb3b09)



## Test plan

1. Open VSC and IntelliJ and change themes
2. Make sure `Export`, `Delete all`, `Delete all chats` and `Cancel` buttons, together with other UI elements looks good and are redable.

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
