### PR TITLE
feat(cody): migrate feature flags evaluation to new batch api

### DIFF
--- a/agent/src/cli/command-bench/strategy-chat-context.ts
+++ b/agent/src/cli/command-bench/strategy-chat-context.ts
@@ -1,5 +1,6 @@
 import path from 'node:path'
 import { PromptString, graphqlClient, isError } from '@sourcegraph/cody-shared'
+import { FeatureFlag } from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
 import { SourcegraphNodeCompletionsClient } from '../../../../vscode/src/completions/nodeClient'
 import { rewriteKeywordQuery } from '../../../../vscode/src/local-context/rewrite-keyword-query'
 import { version } from '../../../package.json'
@@ -42,7 +43,9 @@ export async function evaluateChatContextStrategy(options: CodyBenchOptions): Pr
     if (isError(userInfo)) {
         throw userInfo
     }
-    const evaluatedFeatureFlags = await graphqlClient.getEvaluatedFeatureFlags()
+    const evaluatedFeatureFlags = await graphqlClient.getEvaluatedFeatureFlags(
+        Object.values(FeatureFlag)
+    )
     if (isError(evaluatedFeatureFlags)) {
         throw evaluatedFeatureFlags
     }

--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -228,7 +228,7 @@ export class FeatureFlagProviderImpl implements FeatureFlagProvider {
             promiseFactoryToObservable(signal =>
                 process.env.DISABLE_FEATURE_FLAGS
                     ? Promise.resolve({})
-                    : graphqlClient.getEvaluatedFeatureFlags(signal)
+                    : graphqlClient.getEvaluatedFeatureFlags(Object.values(FeatureFlag), signal)
             ).pipe(
                 map(resultOrError => {
                     if (isError(resultOrError)) {

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -1006,7 +1006,11 @@ export class SourcegraphGraphQLAPIClient {
         first,
         after,
         query,
-    }: { first: number; after?: string; query?: string }): Promise<RepoListResponse | Error> {
+    }: {
+        first: number
+        after?: string
+        query?: string
+    }): Promise<RepoListResponse | Error> {
         return this.fetchSourcegraphAPI<APIResponse<RepoListResponse>>(REPOSITORY_LIST_QUERY, {
             first,
             after: after || null,
@@ -1547,14 +1551,16 @@ export class SourcegraphGraphQLAPIClient {
                 },
                 signal
             ).then(response => {
-                return extractDataOrError(response, data =>
-                    data.evaluatedFeatureFlags.reduce(
-                        (acc: Record<string, boolean>, { name, value }) => {
-                            acc[name] = value
-                            return acc
-                        },
-                        {}
-                    )
+                return extractDataOrError(
+                    response,
+                    data =>
+                        data.evaluatedFeatureFlags?.reduce(
+                            (acc: Record<string, boolean>, { name, value }) => {
+                                acc[name] = value
+                                return acc
+                            },
+                            {}
+                        ) || {}
                 )
             })
         }
@@ -1564,11 +1570,16 @@ export class SourcegraphGraphQLAPIClient {
             {},
             signal
         ).then(response => {
-            return extractDataOrError(response, data =>
-                data.evaluatedFeatureFlags.reduce((acc: Record<string, boolean>, { name, value }) => {
-                    acc[name] = value
-                    return acc
-                }, {})
+            return extractDataOrError(
+                response,
+                data =>
+                    data.evaluatedFeatureFlags?.reduce(
+                        (acc: Record<string, boolean>, { name, value }) => {
+                            acc[name] = value
+                            return acc
+                        },
+                        {}
+                    ) || {}
             )
         })
     }

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -596,6 +596,10 @@ interface EvaluatedFeatureFlagsResponse {
     evaluatedFeatureFlags: EvaluatedFeatureFlag[]
 }
 
+interface EvaluatedFeatureFlagsResponse {
+    evaluateFeatureFlags: EvaluatedFeatureFlag[]
+}
+
 interface EvaluateFeatureFlagResponse {
     evaluateFeatureFlag: boolean
 }
@@ -1553,7 +1557,7 @@ export class SourcegraphGraphQLAPIClient {
                 return extractDataOrError(
                     response,
                     data =>
-                        data.evaluatedFeatureFlags?.reduce(
+                        data.evaluateFeatureFlags?.reduce(
                             (acc: Record<string, boolean>, { name, value }) => {
                                 acc[name] = value
                                 return acc

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -1529,10 +1529,9 @@ export class SourcegraphGraphQLAPIClient {
     /**
      *
      * https://github.com/sourcegraph/sourcegraph/pull/3513 introduced a new GraphQL query evaluateFeatureFlags
-     * flagNames allow multiple flags to be evaluaed.
-     * This reduces the number of requests a client needs to make.
+     * @param flagNames allows multiple flags to be evaluated.
      *
-     * Deprecated: evaluatedFeatureFlags
+     * Deprecated API: evaluatedFeatureFlags
      */
     public async getEvaluatedFeatureFlags(
         flagNames: string[],

--- a/lib/shared/src/sourcegraph-api/graphql/queries.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/queries.ts
@@ -534,6 +534,9 @@ export const EVALUATE_FEATURE_FLAG_QUERY = `
     }
 `
 
+// Replacing GET_FEATURE_FLAGS_QUERY with EVALUATE_FEATURE_FLAGS_QUERY, starting from sg v6.2
+// GET_FEATURE_FLAGS_QUERY(deprecated) lists all the feature flags on the instance. 
+// EVALUATE_FEATURE_FLAGS_QUERY checks what the value should be given the user's and organization's overrides.
 export const EVALUATE_FEATURE_FLAGS_QUERY = `
     query EvaluateFeatureFlags($flagNames: [String!]!) {
         evaluateFeatureFlags(flagNames: $flagNames) {

--- a/lib/shared/src/sourcegraph-api/graphql/queries.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/queries.ts
@@ -535,7 +535,7 @@ export const EVALUATE_FEATURE_FLAG_QUERY = `
 `
 
 // Replacing GET_FEATURE_FLAGS_QUERY with EVALUATE_FEATURE_FLAGS_QUERY, starting from sg v6.2
-// GET_FEATURE_FLAGS_QUERY(deprecated) lists all the feature flags on the instance. 
+// GET_FEATURE_FLAGS_QUERY(deprecated) lists all the feature flags on the instance.
 // EVALUATE_FEATURE_FLAGS_QUERY checks what the value should be given the user's and organization's overrides.
 export const EVALUATE_FEATURE_FLAGS_QUERY = `
     query EvaluateFeatureFlags($flagNames: [String!]!) {

--- a/lib/shared/src/sourcegraph-api/graphql/queries.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/queries.ts
@@ -534,6 +534,15 @@ export const EVALUATE_FEATURE_FLAG_QUERY = `
     }
 `
 
+export const EVALUATE_FEATURE_FLAGS_QUERY = `
+    query EvaluateFeatureFlags($flagNames: [String!]!) {
+        evaluateFeatureFlags(flagNames: $flagNames) {
+            name
+            value
+        }
+    }
+`
+
 export const PACKAGE_LIST_QUERY = `
     query Packages($kind: PackageRepoReferenceKind!, $name: String!, $first: Int!, $after: String) {
         packageRepoReferences(kind: $kind, name: $name, first: $first, after: $after) {


### PR DESCRIPTION
CLOSING https://linear.app/sourcegraph/issue/SRCH-1673/cody-evaluatefeatureflags
migrate feature flags evaluation to new batch api on the sg repo https://github.com/sourcegraph/sourcegraph/pull/3513


`lib/shared/src/sourcegraph-api/graphql/client.ts`
- use `EVALUATE_FEATURE_FLAGS_QUERY` (evaluateFeatureFlags in queries.ts) instead of `GET_FEATURE_FLAGS_QUERY` (evaluatedFeatureFlags in queries.ts)
- add server version check for backwards compatibility

## Test plan
Backwards compatibility - Tested against dotcom and test 
- [x] old server vs new client, use the old API
- [x] new server vs old client (main) — right now it works, once we deprecate the old api, the user needs to upgrade the client
- [x] new server vs new client, use the new API

for each case tested
- [x] two flags
- [x] override or toggle the value, reload the window, test again
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
