### PR TITLE
Update `untilBuild` to `252.*`

### DIFF
--- a/jetbrains/build.gradle.kts
+++ b/jetbrains/build.gradle.kts
@@ -31,7 +31,7 @@ val isForceCodeSearchBuild = properties("forceCodeSearchBuild") == "true"
 // Update gradle.properties pluginSinceBuild, pluginUntilBuild
 // to match the min, max versions in this list.
 val versionsOfInterest =
-    listOf("2023.2", "2023.3", "2024.1", "2024.2.4", "251.14649.49-EAP-SNAPSHOT").sorted()
+    listOf("2023.2", "2023.3", "2024.1", "2024.2.4", "2025.1.1.1", "252.18003.27-EAP-SNAPSHOT").sorted()
 val versionsToValidate =
     when (project.properties["validation"]?.toString()) {
       "lite" -> listOf(versionsOfInterest.first(), versionsOfInterest.last())

--- a/jetbrains/build.gradle.kts
+++ b/jetbrains/build.gradle.kts
@@ -31,7 +31,8 @@ val isForceCodeSearchBuild = properties("forceCodeSearchBuild") == "true"
 // Update gradle.properties pluginSinceBuild, pluginUntilBuild
 // to match the min, max versions in this list.
 val versionsOfInterest =
-    listOf("2023.2", "2023.3", "2024.1", "2024.2.4", "2025.1.1.1", "252.18003.27-EAP-SNAPSHOT").sorted()
+    listOf("2023.2", "2023.3", "2024.1", "2024.2.4", "2025.1.1.1", "252.18003.27-EAP-SNAPSHOT")
+        .sorted()
 val versionsToValidate =
     when (project.properties["validation"]?.toString()) {
       "lite" -> listOf(versionsOfInterest.first(), versionsOfInterest.last())

--- a/jetbrains/gradle.properties
+++ b/jetbrains/gradle.properties
@@ -7,7 +7,7 @@ pluginVersion=9.9-localbuild
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild=232
-pluginUntilBuild=251.*
+pluginUntilBuild=252.*
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType=IC
 platformVersion=2023.2


### PR DESCRIPTION
`252.18003.27-EAP-SNAPSHOT` has been released. Let's prepare the plugin for `252.*`.

## Test plan
- plugin verifier did not report anything critical (no new errors)
- manually tested chat and autocomplete in the eap version - no issues 

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
