### PR TITLE
Split edit code between flow/model and UI (QuickPick)

### DIFF
--- a/agent/src/AgentFixupControls.ts
+++ b/agent/src/AgentFixupControls.ts
@@ -1,5 +1,5 @@
 import type * as vscode from 'vscode'
-import type { QuickPickInput } from '../../vscode/src/edit/input/get-input'
+import type { EditInput } from '../../vscode/src/edit/input/get-input'
 import type { FixupFile } from '../../vscode/src/non-stop/FixupFile'
 import type { FixupTask, FixupTaskID } from '../../vscode/src/non-stop/FixupTask'
 import { FixupCodeLenses } from '../../vscode/src/non-stop/codelenses/provider'
@@ -36,7 +36,7 @@ export class AgentFixupControls extends FixupCodeLenses {
         }
     }
 
-    public retry(id: FixupTaskID, previousInput: QuickPickInput): Promise<FixupTask | undefined> {
+    public retry(id: FixupTaskID, previousInput: EditInput): Promise<FixupTask | undefined> {
         const task = this.fixups.taskForId(id)
         if (task) {
             return this.fixups.retry(task, 'code-lens', previousInput)

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -63,7 +63,7 @@ import type { CompletionItemID } from '../../vscode/src/completions/analytics-lo
 import { loadTscRetriever } from '../../vscode/src/completions/context/retrievers/tsc/load-tsc-retriever'
 import { supportedTscLanguages } from '../../vscode/src/completions/context/retrievers/tsc/supportedTscLanguages'
 import { type ExecuteEditArguments, executeEdit } from '../../vscode/src/edit/execute'
-import type { QuickPickInput } from '../../vscode/src/edit/input/get-input'
+import type { EditInput } from '../../vscode/src/edit/input/get-input'
 import { getModelOptionItems } from '../../vscode/src/edit/input/get-items/model'
 import { getEditSmartSelection } from '../../vscode/src/edit/utils/edit-selection'
 import type { ExtensionClient } from '../../vscode/src/extension-client'
@@ -1188,7 +1188,7 @@ export class Agent extends MessageHandler implements ExtensionClient {
                 true,
                 await checkIfEnterpriseUser()
             )
-            const previousInput: QuickPickInput = {
+            const previousInput: EditInput = {
                 instruction: instruction,
                 userContextFiles: [],
                 model: models.find(item => item.modelTitle === params.model)?.model ?? models[0].model,

--- a/vscode/src/edit/edit-manager.ts
+++ b/vscode/src/edit/edit-manager.ts
@@ -212,7 +212,6 @@ export class EditManager implements vscode.Disposable {
             document,
             range,
             expandedRange,
-            mode,
             model,
             configuration.rules ?? null,
             intent,

--- a/vscode/src/edit/edit-manager.ts
+++ b/vscode/src/edit/edit-manager.ts
@@ -217,6 +217,7 @@ export class EditManager implements vscode.Disposable {
             intent,
             canStream,
             source,
+            mode,
             telemetryMetadata
         )
     }

--- a/vscode/src/edit/input/edit-input-flow.ts
+++ b/vscode/src/edit/input/edit-input-flow.ts
@@ -1,0 +1,234 @@
+import {
+    type ContextItem,
+    type EditModel,
+    type MentionQuery,
+    type Model,
+    ModelUsage,
+    PromptString,
+    type Rule,
+    checkIfEnterpriseUser,
+    currentUserProductSubscription,
+    displayLineRange,
+    firstResultFromOperation,
+    firstValueFrom,
+    modelsService,
+} from '@sourcegraph/cody-shared'
+import * as vscode from 'vscode'
+
+import type { QuickPickItem } from 'vscode'
+import { getEditor } from '../../editor/active-editor'
+import { type TextChange, updateRangeMultipleChanges } from '../../non-stop/tracked-range'
+import { ruleService } from '../../rules/service'
+import { isGenerateIntent } from '../utils/edit-intent'
+import type { EditInput } from './get-input'
+import { CURSOR_RANGE_ITEM, EXPANDED_RANGE_ITEM, SELECTION_RANGE_ITEM } from './get-items/constants'
+import { getEditInputItems } from './get-items/edit'
+import { getModelInputItems, getModelOptionItems } from './get-items/model'
+import { getRangeInputItems } from './get-items/range'
+import { getRangeSymbolInputItems } from './get-items/range-symbols'
+import type { EditModelItem, EditRangeItem } from './get-items/types'
+import { type FixupMatchingContext, getMatchingContext } from './get-matching-context'
+import type { GetItemsResult } from './quick-pick'
+import { fetchDocumentSymbols, getLabelForContextItem, removeAfterLastAt } from './utils'
+
+export class EditInputFlow implements vscode.Disposable {
+    private document: vscode.TextDocument
+    private editInput: EditInput
+    private symbolsPromise: Promise<vscode.DocumentSymbol[]>
+    private activeRange: vscode.Range
+    private activeModel: EditModel
+    private activeModelItem: EditModelItem | undefined
+    private activeRangeItem: QuickPickItem
+    private activeModelContextWindow: number
+    private rulesToApply: Rule[] | null = null
+    private showModelSelector = false
+    private selectedContextItems = new Map<string, ContextItem>()
+    private contextItems = new Map<string, ContextItem>()
+    private textDocumentListener: vscode.Disposable | undefined
+    private modelOptions: Model[] = []
+    private isCodyPro = false
+    private isEnterpriseUser = false
+    private onRangeChangeCallback: ((newRange: vscode.Range, newTitle: string) => void) | undefined =
+        undefined
+
+    constructor(document: vscode.TextDocument, editInput: EditInput) {
+        this.document = document
+        this.editInput = editInput
+
+        const editor = getEditor().active
+        if (!editor) {
+            throw new Error('No active editor found for EditInputLogic initialization.')
+        }
+
+        this.activeRange = editInput.expandedRange || editInput.range
+        this.activeRangeItem =
+            editInput.intent === 'add'
+                ? CURSOR_RANGE_ITEM
+                : editInput.expandedRange
+                  ? EXPANDED_RANGE_ITEM
+                  : SELECTION_RANGE_ITEM
+        this.activeModel = editInput.model
+
+        for (const file of editInput.userContextFiles ?? []) {
+            this.selectedContextItems.set(getLabelForContextItem(file), file)
+        }
+
+        this.symbolsPromise = fetchDocumentSymbols(this.document)
+        this.activeModelContextWindow = this.getContextWindowForModel(this.activeModel)
+
+        this.textDocumentListener = vscode.workspace.onDidChangeTextDocument(event => {
+            if (event.document !== this.document) {
+                return
+            }
+
+            const changes = new Array<TextChange>(...event.contentChanges)
+            const updatedRange = updateRangeMultipleChanges(this.activeRange, changes)
+            if (!updatedRange.isEqual(this.activeRange)) {
+                this.updateActiveRange(updatedRange)
+            }
+        })
+    }
+
+    public async init(): Promise<void> {
+        const sub = await currentUserProductSubscription()
+        this.isEnterpriseUser = await checkIfEnterpriseUser()
+        this.isCodyPro = Boolean(sub && !sub.userCanUpgrade)
+
+        this.modelOptions = await firstResultFromOperation(modelsService.getModels(ModelUsage.Edit))
+        const modelItems = getModelOptionItems(this.modelOptions, this.isCodyPro, this.isEnterpriseUser)
+        this.activeModelItem = modelItems.find(item => item.model === this.editInput.model)
+        this.showModelSelector = this.modelOptions.length > 1
+
+        this.rulesToApply =
+            this.editInput.rules ??
+            (await firstValueFrom(ruleService.rulesForPaths([this.document.uri])))
+    }
+
+    public getEditInputItems(input: string): GetItemsResult {
+        return getEditInputItems(
+            input,
+            this.activeRangeItem,
+            this.activeModelItem,
+            this.showModelSelector,
+            this.rulesToApply
+        )
+    }
+
+    public getModelInputItems(): GetItemsResult {
+        return getModelInputItems(
+            this.modelOptions,
+            this.activeModel,
+            this.isCodyPro,
+            this.isEnterpriseUser
+        )
+    }
+
+    public getRangeSymbolInputItems(): Promise<GetItemsResult> {
+        return getRangeSymbolInputItems(this.activeRange.start, this.symbolsPromise)
+    }
+
+    public getRangeInputItems(): Promise<GetItemsResult> {
+        return getRangeInputItems(
+            this.document,
+            this.editInput,
+            this.activeRange,
+            this.activeModelContextWindow
+        )
+    }
+
+    private getContextWindowForModel(model: EditModel): number {
+        const latestContextWindow = modelsService.getContextWindowByID(model)
+        return latestContextWindow.input + (latestContextWindow.context?.user ?? 0)
+    }
+
+    public getActiveRange(): vscode.Range {
+        return this.activeRange
+    }
+
+    public getActiveTitle(): string {
+        const relativeFilePath = vscode.workspace.asRelativePath(this.document.uri.fsPath)
+        return `Edit ${relativeFilePath}:${displayLineRange(this.activeRange)} with Cody`
+    }
+
+    public setRangeListener(onRangeChangeCallback: (newRange: vscode.Range, newTitle: string) => void) {
+        this.onRangeChangeCallback = onRangeChangeCallback
+    }
+
+    public updateActiveRange(range: vscode.Range, rangeItem?: EditRangeItem): void {
+        this.activeRange = range
+        if (rangeItem) {
+            this.activeRangeItem = rangeItem
+        }
+        this.onRangeChangeCallback?.(this.activeRange, this.getActiveTitle())
+    }
+
+    public dispose(): void {
+        this.textDocumentListener?.dispose()
+        this.textDocumentListener = undefined
+    }
+
+    public async selectModel(
+        item: EditModelItem
+    ): Promise<{ requiresUpgrade: boolean; modelTitle?: string }> {
+        if (item.codyProOnly && !this.isCodyPro && !this.isEnterpriseUser) {
+            return { requiresUpgrade: true, modelTitle: item.modelTitle }
+        }
+
+        await modelsService.setSelectedModel(ModelUsage.Edit, item.model)
+        this.activeModelItem = item
+        this.activeModel = item.model
+        this.activeModelContextWindow = this.getContextWindowForModel(item.model)
+        return { requiresUpgrade: false }
+    }
+
+    public async getMatchingContextForQuery(
+        mentionQuery: MentionQuery
+    ): Promise<FixupMatchingContext[]> {
+        const matchingContext = await getMatchingContext(mentionQuery)
+        for (const { key, item } of matchingContext) {
+            this.contextItems.set(key, item)
+        }
+        return matchingContext
+    }
+
+    public isContextOverLimit(currentInstruction: string, size?: number): boolean {
+        let used = PromptString.unsafe_fromUserQuery(currentInstruction).length
+        for (const [k, v] of this.selectedContextItems) {
+            if (currentInstruction.includes(`@${k}`)) {
+                used += v.size ?? 0
+            } else {
+                this.selectedContextItems.delete(k)
+            }
+        }
+        const totalBudget = this.activeModelContextWindow
+        return size ? totalBudget - used < size : false
+    }
+
+    public addSelectedContextItem(key: string, instruction: string): string {
+        const contextItem = this.contextItems.get(key)
+        if (contextItem) {
+            this.selectedContextItems.set(key, contextItem)
+            return `${removeAfterLastAt(instruction)}@${key} `
+        }
+        return instruction
+    }
+
+    public finalizeInput(instructionValue: string): EditInput {
+        const instruction = PromptString.unsafe_fromUserQuery(instructionValue.trim())
+        const finalUserContextFiles = Array.from(this.selectedContextItems)
+            .filter(([key]) => instruction.toString().includes(`@${key}`))
+            .map(([, value]) => value)
+
+        const isGenerate = isGenerateIntent(this.document, this.activeRange)
+
+        return {
+            instruction: instruction.trim(),
+            userContextFiles: finalUserContextFiles,
+            model: this.activeModel,
+            range: this.activeRange,
+            intent: isGenerate ? 'add' : 'edit',
+            mode: isGenerate ? 'insert' : 'edit',
+            rules: this.rulesToApply,
+        }
+    }
+}

--- a/vscode/src/edit/input/get-input.ts
+++ b/vscode/src/edit/input/get-input.ts
@@ -5,16 +5,9 @@ import {
     FILE_CONTEXT_MENTION_PROVIDER,
     GENERAL_HELP_LABEL,
     LARGE_FILE_WARNING_LABEL,
-    ModelUsage,
-    PromptString,
+    type PromptString,
     type Rule,
     SYMBOL_CONTEXT_MENTION_PROVIDER,
-    checkIfEnterpriseUser,
-    currentUserProductSubscription,
-    displayLineRange,
-    firstResultFromOperation,
-    firstValueFrom,
-    modelsService,
     parseMentionQuery,
     scanForMentionTriggerInUserTextInput,
 } from '@sourcegraph/cody-shared'
@@ -25,23 +18,16 @@ import { EventSourceTelemetryMetadataMapping } from '@sourcegraph/cody-shared/sr
 import { ACCOUNT_UPGRADE_URL } from '../../chat/protocol'
 import { executeDocCommand, executeTestEditCommand } from '../../commands/execute'
 import { getEditor } from '../../editor/active-editor'
-import { type TextChange, updateRangeMultipleChanges } from '../../non-stop/tracked-range'
-import { ruleService } from '../../rules/service'
 import type { EditIntent, EditMode } from '../types'
-import { isGenerateIntent } from '../utils/edit-intent'
-import { CURSOR_RANGE_ITEM, EXPANDED_RANGE_ITEM, SELECTION_RANGE_ITEM } from './get-items/constants'
-import { DOCUMENT_ITEM, MODEL_ITEM, RANGE_ITEM, TEST_ITEM, getEditInputItems } from './get-items/edit'
-import { getModelInputItems, getModelOptionItems } from './get-items/model'
-import { getRangeInputItems } from './get-items/range'
-import { RANGE_SYMBOLS_ITEM, getRangeSymbolInputItems } from './get-items/range-symbols'
+import { EditInputFlow } from './edit-input-flow'
+import { DOCUMENT_ITEM, MODEL_ITEM, RANGE_ITEM, TEST_ITEM } from './get-items/edit'
+import { RANGE_SYMBOLS_ITEM } from './get-items/range-symbols'
 import type { EditModelItem, EditRangeItem } from './get-items/types'
-import { getMatchingContext } from './get-matching-context'
 import { createQuickPick } from './quick-pick'
-import { fetchDocumentSymbols, getLabelForContextItem, removeAfterLastAt } from './utils'
 
-export interface QuickPickInput {
+export interface EditInput {
     /** The user provided instruction */
-    instruction: PromptString
+    instruction?: PromptString
     /** Any user provided context, from @ or @# */
     userContextFiles: ContextItem[]
     /** The LLM that the user has selected */
@@ -55,20 +41,10 @@ export interface QuickPickInput {
      */
     intent: EditIntent
     /** The derived mode from the users' selected range */
-    mode: EditMode
-
+    mode?: EditMode
     /** Rules to apply. */
     rules: Rule[] | null
-}
-
-export interface EditInputInitialValues {
-    initialRange: vscode.Range
-    initialExpandedRange?: vscode.Range
-    initialModel: EditModel
-    initialIntent: EditIntent
-    initialInputValue?: PromptString
-    initialSelectedContextItems?: ContextItem[]
-    initialRules?: Rule[] | null
+    expandedRange?: vscode.Range
 }
 
 const PREVIEW_RANGE_DECORATION = vscode.window.createTextEditorDecorationType({
@@ -80,9 +56,9 @@ const PREVIEW_RANGE_DECORATION = vscode.window.createTextEditorDecorationType({
 
 export const getInput = async (
     document: vscode.TextDocument,
-    initialValues: EditInputInitialValues,
+    initialValues: EditInput,
     source: EventSource
-): Promise<QuickPickInput | null> => {
+): Promise<EditInput | null> => {
     const editor = getEditor().active
     if (!editor) {
         return null
@@ -95,206 +71,121 @@ export const getInput = async (
         privateMetadata: { source },
     })
 
-    const initialCursorPosition = editor.selection.active
-    let activeRange = initialValues.initialExpandedRange || initialValues.initialRange
-    let activeRangeItem =
-        initialValues.initialIntent === 'add'
-            ? CURSOR_RANGE_ITEM
-            : initialValues.initialExpandedRange
-              ? EXPANDED_RANGE_ITEM
-              : SELECTION_RANGE_ITEM
+    const editFlow = new EditInputFlow(document, initialValues)
+    await editFlow.init()
 
-    const sub = await currentUserProductSubscription()
-    const isEnterpriseUser = await checkIfEnterpriseUser()
-    const isCodyPro = Boolean(sub && !sub.userCanUpgrade)
-    const modelOptions = await firstResultFromOperation(modelsService.getModels(ModelUsage.Edit))
-    const modelItems = getModelOptionItems(modelOptions, isCodyPro, isEnterpriseUser)
-    const showModelSelector = modelOptions.length > 1
-
-    let activeModel = initialValues.initialModel
-    let activeModelItem = modelItems.find(item => item.model === initialValues.initialModel)
-
-    const getContextWindowOnModelChange = (model: EditModel) => {
-        const latestContextWindow = modelsService.getContextWindowByID(model)
-        return latestContextWindow.input + (latestContextWindow.context?.user ?? 0)
-    }
-    let activeModelContextWindow = getContextWindowOnModelChange(activeModel)
-
-    // ContextItems to store possible user-provided context
-    const contextItems = new Map<string, ContextItem>()
-    const selectedContextItems = new Map<string, ContextItem>()
-
-    // Initialize the selectedContextItems with any previous items
-    // This is primarily for edit retries, where a user may want to reuse their context
-    for (const file of initialValues.initialSelectedContextItems ?? []) {
-        selectedContextItems.set(getLabelForContextItem(file), file)
-    }
-
-    /**
-     * Set the title of the quick pick to include the file and range
-     * Update the title as the range changes
-     */
-    const relativeFilePath = vscode.workspace.asRelativePath(document.uri.fsPath)
-    let activeTitle: string
-    const updateActiveTitle = (newRange: vscode.Range) => {
-        activeTitle = `Edit ${relativeFilePath}:${displayLineRange(newRange)} with Cody`
-    }
-    updateActiveTitle(activeRange)
-
-    const rulesToApply: Rule[] | null = await firstValueFrom(ruleService.rulesForPaths([document.uri]))
-
-    /**
-     * Listens for text document changes and updates the range when changes occur.
-     * This allows the range to stay in sync if the user continues editing after
-     * requesting the refactoring.
-     */
-    const registerRangeListener = () => {
-        return vscode.workspace.onDidChangeTextDocument(event => {
-            if (event.document !== document) {
-                return
-            }
-
-            const changes = new Array<TextChange>(...event.contentChanges)
-            const updatedRange = updateRangeMultipleChanges(activeRange, changes)
-            if (!updatedRange.isEqual(activeRange)) {
-                activeRange = updatedRange
-                updateActiveTitle(activeRange)
-            }
-        })
-    }
-    let textDocumentListener = registerRangeListener()
-    const updateActiveRange = (range: vscode.Range) => {
-        // Clear any set decorations
-        editor.setDecorations(PREVIEW_RANGE_DECORATION, [])
-
-        // Pause listening to range changes to avoid a possible race condition
-        textDocumentListener.dispose()
-
-        editor.selection = new vscode.Selection(range.start, range.end)
-        activeRange = range
-
-        // Resume listening to range changes
-        textDocumentListener = registerRangeListener()
-        // Update the title to reflect the new range
-        updateActiveTitle(activeRange)
-    }
     const previewActiveRange = (range: vscode.Range) => {
         editor.setDecorations(PREVIEW_RANGE_DECORATION, [range])
         editor.revealRange(range, vscode.TextEditorRevealType.InCenterIfOutsideViewport)
     }
-    previewActiveRange(activeRange)
+    previewActiveRange(editFlow.getActiveRange())
 
-    // Start fetching symbols early, so they can be used immediately if an option is selected
-    const symbolsPromise = fetchDocumentSymbols(document)
+    return new Promise<EditInput | null>(resolve => {
+        const disposables: vscode.Disposable[] = []
+        disposables.push(editFlow)
 
-    return new Promise<QuickPickInput | null>(resolve => {
+        const updateTitle = (newTitle: string) => {
+            if (modelInput) modelInput.input.title = newTitle
+            if (rangeSymbolsInput) rangeSymbolsInput.input.title = newTitle
+            if (rangeInput) rangeInput.input.title = newTitle
+            if (editInput) editInput.input.title = newTitle
+        }
+
+        const rangeListenerCallback = (newRange: vscode.Range, newTitle: string) => {
+            editor.setDecorations(PREVIEW_RANGE_DECORATION, [])
+            editor.selection = new vscode.Selection(newRange.start, newRange.end)
+            updateTitle(newTitle)
+        }
+
+        async function handleRangeSelectionOnAccept(acceptedItem: EditRangeItem): Promise<void> {
+            const range =
+                acceptedItem.range instanceof vscode.Range
+                    ? acceptedItem.range
+                    : await acceptedItem.range()
+            editFlow.updateActiveRange(range, acceptedItem)
+        }
+
+        async function previewRangeOnActiveChange(
+            items: readonly vscode.QuickPickItem[]
+        ): Promise<void> {
+            const item = items[0] as EditRangeItem
+            if (item?.range) {
+                const range = item.range instanceof vscode.Range ? item.range : await item.range()
+                previewActiveRange(range)
+            }
+        }
+
+        editFlow.setRangeListener(rangeListenerCallback)
+
         const modelInput = createQuickPick({
-            title: activeTitle,
+            title: editFlow.getActiveTitle(),
             placeHolder: 'Select a model',
-            getItems: () => getModelInputItems(modelOptions, activeModel, isCodyPro, isEnterpriseUser),
+            getItems: () => editFlow.getModelInputItems(),
             buttons: [vscode.QuickInputButtons.Back],
             onDidHide: () => editor.setDecorations(PREVIEW_RANGE_DECORATION, []),
             onDidTriggerButton: () => editInput.render(editInput.input.value),
-            onDidAccept: async item => {
-                const acceptedItem = item as EditModelItem
+            onDidAccept: async selected => {
+                const acceptedItem = selected as EditModelItem
                 if (!acceptedItem) {
                     return
                 }
                 telemetryRecorder.recordEvent('cody.fixup.input.model', 'selected', {
-                    billingMetadata: {
-                        product: 'cody',
-                        category: 'billable',
-                    },
+                    billingMetadata: { product: 'cody', category: 'billable' },
                 })
 
-                if (acceptedItem.codyProOnly && !isCodyPro && !isEnterpriseUser) {
+                const modelSelectionResult = await editFlow.selectModel(acceptedItem)
+                if (modelSelectionResult.requiresUpgrade) {
                     const option = await vscode.window.showInformationMessage(
                         'Upgrade to Cody Pro',
                         {
                             modal: true,
-                            detail: `Upgrade to Cody Pro to use ${acceptedItem.modelTitle} for Edit`,
+                            detail: `Upgrade to Cody Pro to use ${modelSelectionResult.modelTitle} for Edit`,
                         },
                         'Upgrade',
                         'See Plans'
                     )
-
-                    // Both options go to the same URL
                     if (option) {
                         void vscode.env.openExternal(vscode.Uri.parse(ACCOUNT_UPGRADE_URL.toString()))
                     }
-
                     return
                 }
-
-                modelsService.setSelectedModel(ModelUsage.Edit, acceptedItem.model)
-                activeModelItem = acceptedItem
-                activeModel = acceptedItem.model
-                activeModelContextWindow = getContextWindowOnModelChange(acceptedItem.model)
-
                 editInput.render(editInput.input.value)
             },
         })
+        disposables.push(modelInput.input)
 
         const rangeSymbolsInput = createQuickPick({
-            title: activeTitle,
+            title: editFlow.getActiveTitle(),
             placeHolder: 'Select a symbol',
-            getItems: () =>
-                getRangeSymbolInputItems({ ...initialValues, initialCursorPosition }, symbolsPromise),
+            getItems: () => editFlow.getRangeSymbolInputItems(),
             buttons: [vscode.QuickInputButtons.Back],
             onDidTriggerButton: () => editInput.render(editInput.input.value),
             onDidHide: () => editor.setDecorations(PREVIEW_RANGE_DECORATION, []),
-            onDidChangeActive: async items => {
-                const item = items[0] as EditRangeItem
-                if (item) {
-                    const range = item.range instanceof vscode.Range ? item.range : await item.range()
-                    previewActiveRange(range)
-                }
-            },
-            onDidAccept: async item => {
-                const acceptedItem = item as EditRangeItem
+            onDidChangeActive: previewRangeOnActiveChange,
+            onDidAccept: async selected => {
+                const acceptedItem = selected as EditRangeItem
                 if (!acceptedItem) {
                     return
                 }
                 telemetryRecorder.recordEvent('cody.fixup.input.rangeSymbol', 'selected', {
-                    billingMetadata: {
-                        product: 'cody',
-                        category: 'billable',
-                    },
+                    billingMetadata: { product: 'cody', category: 'billable' },
                 })
-
-                activeRangeItem = acceptedItem
-                const range =
-                    acceptedItem.range instanceof vscode.Range
-                        ? acceptedItem.range
-                        : await acceptedItem.range()
-
-                updateActiveRange(range)
+                await handleRangeSelectionOnAccept(acceptedItem)
                 editInput.render(editInput.input.value)
             },
         })
+        disposables.push(rangeSymbolsInput.input)
 
         const rangeInput = createQuickPick({
-            title: activeTitle,
+            title: editFlow.getActiveTitle(),
             placeHolder: 'Select a range to edit',
-            getItems: () =>
-                getRangeInputItems(
-                    document,
-                    { ...initialValues, initialCursorPosition },
-                    activeRange,
-                    activeModelContextWindow
-                ),
+            getItems: () => editFlow.getRangeInputItems(),
             buttons: [vscode.QuickInputButtons.Back],
             onDidTriggerButton: () => editInput.render(editInput.input.value),
             onDidHide: () => editor.setDecorations(PREVIEW_RANGE_DECORATION, []),
-            onDidChangeActive: async items => {
-                const item = items[0] as EditRangeItem
-                if (item) {
-                    const range = item.range instanceof vscode.Range ? item.range : await item.range()
-                    previewActiveRange(range)
-                }
-            },
-            onDidAccept: async item => {
-                const acceptedItem = item as EditRangeItem
+            onDidChangeActive: previewRangeOnActiveChange,
+            onDidAccept: async selected => {
+                const acceptedItem = selected as EditRangeItem
                 if (!acceptedItem) {
                     return
                 }
@@ -305,35 +196,18 @@ export const getInput = async (
                 }
 
                 telemetryRecorder.recordEvent('cody.fixup.input.range', 'selected', {
-                    billingMetadata: {
-                        product: 'cody',
-                        category: 'billable',
-                    },
+                    billingMetadata: { product: 'cody', category: 'billable' },
                 })
-
-                activeRangeItem = acceptedItem
-                const range =
-                    acceptedItem.range instanceof vscode.Range
-                        ? acceptedItem.range
-                        : await acceptedItem.range()
-
-                updateActiveRange(range)
+                await handleRangeSelectionOnAccept(acceptedItem)
                 editInput.render(editInput.input.value)
             },
         })
+        disposables.push(rangeInput.input)
 
         const editInput = createQuickPick({
-            title: activeTitle,
+            title: editFlow.getActiveTitle(),
             placeHolder: 'Enter edit instructions (type @ to include code, ⏎ to submit)',
-            getItems: () => {
-                return getEditInputItems(
-                    editInput.input.value,
-                    activeRangeItem,
-                    activeModelItem,
-                    showModelSelector,
-                    rulesToApply
-                )
-            },
+            getItems: () => editFlow.getEditInputItems(editInput.input.value),
             onDidHide: () => editor.setDecorations(PREVIEW_RANGE_DECORATION, []),
             ...(source === 'menu'
                 ? {
@@ -349,10 +223,9 @@ export const getInput = async (
             onDidChangeValue: async value => {
                 const input = editInput.input
                 if (
-                    initialValues.initialInputValue !== undefined &&
-                    value.toString() === initialValues.initialInputValue.toString()
+                    initialValues.instruction !== undefined &&
+                    value.toString() === initialValues.instruction.toString()
                 ) {
-                    // Noop, this event is fired when an initial value is set
                     return
                 }
 
@@ -365,20 +238,12 @@ export const getInput = async (
                     : undefined
 
                 if (!mentionQuery) {
-                    // Nothing to match, re-render existing items
-                    input.items = getEditInputItems(
-                        input.value,
-                        activeRangeItem,
-                        activeModelItem,
-                        showModelSelector,
-                        rulesToApply
-                    ).items
+                    input.items = editFlow.getEditInputItems(input.value).items
                     return
                 }
 
-                const matchingContext = await getMatchingContext(mentionQuery)
+                const matchingContext = await editFlow.getMatchingContextForQuery(mentionQuery)
                 if (matchingContext.length === 0) {
-                    // Attempted to match but found nothing
                     input.items = [
                         {
                             alwaysShow: true,
@@ -395,35 +260,14 @@ export const getInput = async (
                     return
                 }
 
-                // Update stored context items so we can retrieve them later
-                for (const { key, item } of matchingContext) {
-                    contextItems.set(key, item)
-                }
-
-                /**
-                 * Checks if the total size of the selected context items exceeds the context budget.
-                 */
-                const isOverLimit = (size?: number): boolean => {
-                    const currentInput = input.value
-                    let used = currentInput.length
-                    for (const [k, v] of selectedContextItems) {
-                        if (currentInput.includes(`@${k}`)) {
-                            used += v.size ?? 0
-                        } else {
-                            selectedContextItems.delete(k)
-                        }
-                    }
-                    const totalBudget = activeModelContextWindow
-                    return size ? totalBudget - used < size : false
-                }
-
-                // Add human-friendly labels to the quick pick so the user can select them
                 input.items = [
                     ...matchingContext.map(({ key, shortLabel, item }) => ({
                         alwaysShow: true,
                         label: shortLabel || key,
                         description: shortLabel ? key : undefined,
-                        detail: isOverLimit(item.size) ? LARGE_FILE_WARNING_LABEL : undefined,
+                        detail: editFlow.isContextOverLimit(value, item.size)
+                            ? LARGE_FILE_WARNING_LABEL
+                            : undefined,
                     })),
                     {
                         kind: vscode.QuickPickItemKind.Separator,
@@ -442,9 +286,8 @@ export const getInput = async (
             },
             onDidAccept: () => {
                 const input = editInput.input
-                const instruction = PromptString.unsafe_fromUserQuery(input.value.trim())
+                const instructionValue = input.value.trim()
 
-                // Selected item flow, update the input and store it for submission
                 const selectedItem = input.selectedItems[0]
                 switch (selectedItem.label) {
                     case MODEL_ITEM.label:
@@ -455,61 +298,47 @@ export const getInput = async (
                         return
                     case DOCUMENT_ITEM.label:
                         input.hide()
-                        return executeDocCommand({ range: activeRange, source: 'menu' })
+                        return executeDocCommand({ range: editFlow.getActiveRange(), source: 'menu' })
                     case TEST_ITEM.label:
                         input.hide()
-                        return executeTestEditCommand({ range: activeRange, source: 'menu' })
+                        return executeTestEditCommand({
+                            range: editFlow.getActiveRange(),
+                            source: 'menu',
+                        })
                     case FILE_CONTEXT_MENTION_PROVIDER.queryLabel:
                     case FILE_CONTEXT_MENTION_PROVIDER.emptyLabel:
                     case SYMBOL_CONTEXT_MENTION_PROVIDER.queryLabel:
                     case SYMBOL_CONTEXT_MENTION_PROVIDER.emptyLabel:
                     case LARGE_FILE_WARNING_LABEL:
                     case GENERAL_HELP_LABEL:
-                        // Noop, the user has actioned an item that is non intended to be actionable.
                         return
                 }
 
-                // Empty input flow, do nothing
-                if (instruction.length === 0) {
-                    return
-                }
-
-                // User provided context flow, the `key` is provided as the `description` for symbol items, use this if available.
                 const key = selectedItem?.description || selectedItem?.label
-                if (selectedItem) {
-                    const contextItem = contextItems.get(key)
-                    if (contextItem) {
-                        // Replace fuzzy value with actual context in input
-                        input.value = `${removeAfterLastAt(instruction.toString())}@${key} `
-                        selectedContextItems.set(key, contextItem)
+                if (key) {
+                    const newInstruction = editFlow.addSelectedContextItem(key, input.value)
+                    if (newInstruction !== input.value) {
+                        input.value = newInstruction
                         return
                     }
                 }
 
-                // Submission flow, validate selected items and return final output
+                if (instructionValue.length === 0) {
+                    return
+                }
+
                 input.hide()
-                textDocumentListener.dispose()
-                const isGenerate = isGenerateIntent(document, activeRange)
-                return resolve({
-                    instruction: instruction.trim(),
-                    userContextFiles: Array.from(selectedContextItems)
-                        .filter(([key]) => instruction.toString().includes(`@${key}`))
-                        .map(([, value]) => value),
-                    model: activeModel,
-                    range: activeRange,
-                    intent: isGenerate ? 'add' : 'edit',
-                    mode: isGenerate ? 'insert' : 'edit',
-                    rules: rulesToApply,
-                })
+                const finalInput = editFlow.finalizeInput(instructionValue)
+                vscode.Disposable.from(...disposables).dispose()
+                return resolve(finalInput)
             },
         })
+        disposables.push(editInput.input)
 
-        const initialInput = initialValues.initialInputValue?.toString() || ''
-        editInput.render(initialInput)
+        const initialInputString = initialValues.instruction?.toString() || ''
+        editInput.render(initialInputString)
 
-        if (initialInput.length === 0) {
-            // If we have no initial input, we want to ensure we don't auto-select anything
-            // This helps ensure the input does not feel like a menu.
+        if (initialInputString.length === 0) {
             editInput.input.activeItems = []
         }
     })

--- a/vscode/src/edit/input/get-input.ts
+++ b/vscode/src/edit/input/get-input.ts
@@ -41,7 +41,7 @@ export interface EditInput {
      */
     intent: EditIntent
     /** The derived mode from the users' selected range */
-    mode?: EditMode
+    mode: EditMode
     /** Rules to apply. */
     rules: Rule[] | null
     expandedRange?: vscode.Range

--- a/vscode/src/edit/input/get-items/range-symbols.ts
+++ b/vscode/src/edit/input/get-items/range-symbols.ts
@@ -12,14 +12,8 @@ export const RANGE_SYMBOLS_ITEM: vscode.QuickPickItem = {
     alwaysShow: true,
 }
 
-interface RangeInputInitialValues {
-    initialCursorPosition: vscode.Position
-    initialRange: vscode.Range
-    initialExpandedRange?: vscode.Range
-}
-
 export const getRangeSymbolInputItems = async (
-    initialValues: RangeInputInitialValues,
+    cursorPosition: vscode.Position,
     symbolsPromise: Thenable<vscode.DocumentSymbol[]>
 ): Promise<GetItemsResult> => {
     const symbols = await symbolsPromise
@@ -38,8 +32,8 @@ export const getRangeSymbolInputItems = async (
      */
     const activeItem = symbolItems.reduce(
         (a, b) =>
-            getMinimumDistanceToRangeBoundary(initialValues.initialCursorPosition, a.range) <
-            getMinimumDistanceToRangeBoundary(initialValues.initialCursorPosition, b.range)
+            getMinimumDistanceToRangeBoundary(cursorPosition, a.range) <
+            getMinimumDistanceToRangeBoundary(cursorPosition, b.range)
                 ? a
                 : b,
         symbolItems[0]

--- a/vscode/src/edit/input/get-matching-context.ts
+++ b/vscode/src/edit/input/get-matching-context.ts
@@ -3,7 +3,7 @@ import type { ContextItem, MentionQuery } from '@sourcegraph/cody-shared'
 import { getChatContextItemsForMention } from '../../chat/context/chatContext'
 import { getLabelForContextItem } from './utils'
 
-interface FixupMatchingContext {
+export interface FixupMatchingContext {
     /* Unique identifier for the context, shown in the input value but not necessarily in the quick pick selector */
     key: string
     /* If present, will override the key shown in the quick pick selector */

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -57,7 +57,7 @@ export interface CreateTaskOptions {
     selectionRange: vscode.Range
     intent: EditIntent
     isStreamed: boolean
-    mode?: EditMode
+    mode: EditMode
     model: EditModel
     rules: Rule[] | null
     source?: EventSource
@@ -398,6 +398,7 @@ export class FixupController
                     model: task.model,
                     intent: task.intent,
                     rules: task.rules,
+                    mode: task.mode,
                 },
                 source
             ))
@@ -467,6 +468,7 @@ export class FixupController
         intent: EditIntent,
         canStream: boolean,
         source: EventSource,
+        mode: EditMode,
         telemetryMetadata?: FixupTelemetryMetadata,
         smartApplyMetadata?: SmartApplyAdditionalMetadata
     ): Promise<FixupTask | null> {
@@ -480,6 +482,7 @@ export class FixupController
                 instruction: preInstruction,
                 rules: rules,
                 userContextFiles: [],
+                mode: mode,
             },
             source
         )

--- a/vscode/src/non-stop/roles.ts
+++ b/vscode/src/non-stop/roles.ts
@@ -1,7 +1,7 @@
 import type * as vscode from 'vscode'
 
 import type { EventSource } from '@sourcegraph/cody-shared'
-import type { QuickPickInput } from '../edit/input/get-input'
+import type { EditInput } from '../edit/input/get-input'
 import type { FixupFile } from './FixupFile'
 import type { FixupTask, FixupTaskID } from './FixupTask'
 import type { CodyTaskState } from './state'
@@ -55,7 +55,7 @@ export interface FixupActor {
     retry(
         task: FixupTask,
         source: EventSource,
-        previousInput?: QuickPickInput
+        previousInput?: EditInput
     ): Promise<FixupTask | undefined>
 }
 


### PR DESCRIPTION
Initial work for https://linear.app/sourcegraph/issue/QA-668/core-method-not-implemented-error-display-when-using-edit-search

## Changes

Intention of this PR is mostly to prepare codebase for sub-sequent PRs which will unify the way in which VSC and other clients use the edit code. Currently `getInput` method which is at the core of UI logic is not called by clients at all, and instead edit code is hacked a bit in the agent. In the long run that can lead to various issues like this one: https://linear.app/sourcegraph/issue/QA-668/core-method-not-implemented-error-display-when-using-edit-search

One side effect of this PR is that I fixed title of the quickpic, which is updated if user changes selection type (e.g. from range to line).

## Test plan

Requires full edits QA.

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
