### PR TITLE
fix(chat): chat transcript scrolling

### DIFF
--- a/vscode/webviews/index.css
+++ b/vscode/webviews/index.css
@@ -1,12 +1,12 @@
-@import '@vscode/codicons/dist/codicon';
-@import url(./utils/highlight.css);
-@import url(./components/shadcn/shadcn.css);
-@import url(./themes/index.css);
+@import url("@vscode/codicons/dist/codicon");
+@import url("./utils/highlight.css");
+@import url("./components/shadcn/shadcn.css");
+@import url("./themes/index.css");
 
 @font-face {
     font-family: cody-icons;
     font-display: block;
-    src: url('../resources/cody-icons.woff') format('woff');
+    src: url("../resources/cody-icons.woff") format("woff");
 }
 
 :root {
@@ -22,6 +22,7 @@
     font-family: var(--vscode-font-family);
     color: var(--vscode-sideBar-foreground);
     background-color: var(--vscode-sideBar-background);
+
     /* Override VS Code Webview Toolkit elements */
     --border-width: none;
 }
@@ -58,3 +59,13 @@ a:hover {
     font-weight: bold;
 }
 
+/* Hide scrollbar for Chrome, Safari and Opera */
+[data-scrollable]::-webkit-scrollbar {
+    display: none;
+}
+
+/* Hide scrollbar for IE, Edge and Firefox */
+[data-scrollable] {
+    -ms-overflow-style: none; /* IE and Edge */
+    scrollbar-width: none; /* Firefox */
+}


### PR DESCRIPTION
Improvements to the chat transcript scrolling behavior for the chat webviews.

- Implements logic to prevent auto-scrolling when the user has manually scrolled away from the bottom of the transcript. This ensures that the user's position is maintained when they are reviewing previous messages.
- The auto-scroll behavior is reset when a new message is finished streaming.
- Hides the scrollbar in the chat transcript.

These changes provides more control over the chat transcript and preventing disruptive auto-scrolling which was the previous behavior.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Ask Cody a question and verifyed:
- autoscroll as message is streaming
- you can break autoscroll if you scroll while the message is streaming
- scroll to bottom shows up if you're not at the bottom