### PR TITLE
feat(context): Enable local context for all users

### DIFF
--- a/vscode/src/chat/initialContext.ts
+++ b/vscode/src/chat/initialContext.ts
@@ -234,24 +234,21 @@ export function getCorpusContextItemsForEditorState(): Observable<
         abortableOperation(async ([authStatus, remoteReposForAllWorkspaceFolders], signal) => {
             const items: ContextItem[] = []
 
-            // Local context is not available to enterprise users
-            if (!authStatus.isEnterpriseUser) {
-                // TODO(sqs): Support multi-root. Right now, this only supports the 1st workspace root.
-                const workspaceFolder = vscode.workspace.workspaceFolders?.at(0)
+            // TODO(sqs): Support multi-root. Right now, this only supports the 1st workspace root.
+            const workspaceFolder = vscode.workspace.workspaceFolders?.at(0)
 
-                if (workspaceFolder) {
-                    items.push({
-                        type: 'tree',
-                        uri: workspaceFolder.uri,
-                        title: 'Current Repository',
-                        name: workspaceFolder.name,
-                        description: workspaceFolder.name,
-                        isWorkspaceRoot: true,
-                        content: null,
-                        source: ContextItemSource.Initial,
-                        icon: 'folder',
-                    } satisfies ContextItemTree)
-                }
+            if (workspaceFolder) {
+                items.push({
+                    type: 'tree',
+                    uri: workspaceFolder.uri,
+                    title: 'Current Repository',
+                    name: workspaceFolder.name,
+                    description: workspaceFolder.name,
+                    isWorkspaceRoot: true,
+                    content: null,
+                    source: ContextItemSource.Initial,
+                    icon: 'folder',
+                } satisfies ContextItemTree)
             }
 
             // TODO(sqs): Make this consistent between self-serve (no remote search) and enterprise (has

--- a/vscode/src/local-context/symf.ts
+++ b/vscode/src/local-context/symf.ts
@@ -18,10 +18,8 @@ import {
     displayPath,
     isAbortError,
     isDefined,
-    isDotCom,
     isFileURI,
     isWindows,
-    isWorkspaceInstance,
     subscriptionDisposable,
     telemetryRecorder,
     uriBasename,
@@ -93,9 +91,9 @@ export class SymfRunner implements vscode.Disposable {
                 authStatus.subscribe(authStatus => {
                     // symf is now available for dotcom and Enterprise Starter users
                     // see https://linear.app/sourcegraph/issue/CODY-5017/enable-symf-for-enterprise-starter-and-make-it-easy-for-users-to
-                    const symfEnabledForLocalContext =
-                        isDotCom(authStatus) || isWorkspaceInstance(authStatus)
-                    if (!isInitialized && authStatus.authenticated && symfEnabledForLocalContext) {
+                    // symf is now available  also for enterprise users
+                    // https://linear.app/sourcegraph/issue/CODY-6021/bring-back-symf-for-enterprise-users
+                    if (!isInitialized && authStatus.authenticated) {
                         // Only initialize symf after the user has authenticated
                         isInitialized = true
                         this.disposables.push(initializeSymfIndexManagement(this))


### PR DESCRIPTION
This commit enables local context (Symf) for all users, including Enterprise users.

The previous restriction that limited local context to DotCom and Enterprise Starter users has been removed. This change ensures that all authenticated users can benefit from local context features.

Something to be aware of, not having the project into enterprise instance will display current codebase (not available)
![Loom Screenshot 2025-06-06 at 05 49 57](https://github.com/user-attachments/assets/a8824bd4-1b94-4040-a930-3f72afb18be6)



## Test plan
- Check that symf is enabled for enterprise user
