### PR TITLE
Remove billing metadata from `customTitle` event

### DIFF
--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -1567,10 +1567,6 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                     titleLength: title.length,
                     inputLength: inputText.length,
                 },
-                billingMetadata: {
-                    product: 'cody',
-                    category: 'billable',
-                },
             })
         })
     }


### PR DESCRIPTION
Eliminate unnecessary billing metadata from the `cody.chat.customTitle:generated` event

## Test plan
CI