### PR TITLE
Disable symf in JetBrains integration tests

### DIFF
--- a/jetbrains/src/integrationTest/kotlin/com/sourcegraph/cody/autocomplete/AutocompleteEditTest.kt
+++ b/jetbrains/src/integrationTest/kotlin/com/sourcegraph/cody/autocomplete/AutocompleteEditTest.kt
@@ -19,19 +19,13 @@ import org.junit.runner.RunWith
 class AutocompleteEditTest : BaseAutocompleteTest() {
 
   companion object {
-    private val codySettingsContent =
-        """{
-          |  "cody.suggestions.mode": "auto-edit"
-          |}
-          |"""
-            .trimMargin()
 
     private val fixture =
         BaseIntegrationTextFixture(
             recordingName = "autocompleteEdit",
             credentials = TestingCredentials.enterprise,
             CodyAgentService.clientCapabilities,
-            codySettingsContent)
+            mapOf("cody.suggestions.mode" to "auto-edit"))
 
     @JvmStatic
     @BeforeClass

--- a/jetbrains/src/integrationTest/kotlin/com/sourcegraph/cody/util/BaseIntegrationTextFixture.kt
+++ b/jetbrains/src/integrationTest/kotlin/com/sourcegraph/cody/util/BaseIntegrationTextFixture.kt
@@ -35,7 +35,7 @@ open class BaseIntegrationTextFixture(
     private val recordingName: String,
     private val credentials: TestingCredentials,
     private val capabilities: ClientCapabilities,
-    codySettingsContent: String = "{\n  \n}"
+    additionalCodySettings: Map<String, String> = emptyMap()
 ) {
   companion object {
     const val ASYNC_WAIT_TIMEOUT_SECONDS = 20L
@@ -60,6 +60,12 @@ open class BaseIntegrationTextFixture(
     myFixture.setUp()
     project = myFixture.project
     Disposer.register(myFixture.testRootDisposable) { shutdown() }
+
+    val allCodySettings =
+        additionalCodySettings + mapOf("cody.experimental.symf.enabled" to "false")
+    val codySettingsContent =
+        """{ ${allCodySettings.map { "${it.key} = ${it.value}"  }.joinToString("\n")} }"""
+            .trimIndent()
 
     CodyEditorUtil.createFileOrUseExisting(
         project, ConfigUtil.getSettingsFile(project).toUri().toString(), codySettingsContent)


### PR DESCRIPTION
## Changes

This PR fixes problems with tests trying to download symf atrifacts and failing on polly.js recordings being missing.

```
[  30268]   WARN - #com.sourcegraph.cody.agent.CodyAgent - Errored ➞ GET https://release-assets.githubusercontent.com/github-production-release-asset/704249692/79d7b86e-09f4-476a-8f20-f20d2fd3a5d8?sp=r&sv=2018-11-09&sr=b&spr=https&se=2025-06-13T09%3A24%3A22Z&skoid=96c2d410-5711-43a1-aedd-ab1947aa7ab0&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skt=2025-06-13T09%3A14%3A38Z&ske=2025-06-13T10%3A14%3A39Z&sks=b&skv=2018-11-09&sig=xL6ueS5IqEz04PzCc1Ist4qSJYK3CkPoR0Es06m8dCU%3D&jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmVsZWFzZS1hc3NldHMuZ2l0aHVidXNlcmNvbnRlbnQuY29tIiwia2V5Ijoia2V5MSIsImV4cCI6MTc0OTgwNjY2MiwibmJmIjoxNzQ5ODA2MzYyLCJwYXRoIjoicmVsZWFzZWFzc2V0cHJvZHVjdGlvbi5ibG9iLmNvcmUud2luZG93cy5uZXQifQ.A-upNsHMCntSFeb9sz1M1b5bSPrue4v9NTTLFLsLTSk&response-content-disposition=attachment%3B%20filename%3Dsymf-x86_64-linux-musl.zip&response-content-type=application%2Foctet-stream _PollyError: [Polly] [adapter:node-http] Recording for the following request is not found and `recordIfMissing` is `false`.
[  30268]   WARN - #com.sourcegraph.cody.agent.CodyAgent - {
[  30268]   WARN - #com.sourcegraph.cody.agent.CodyAgent -   "url": "https://release-assets.githubusercontent.com/github-production-release-asset/704249692/79d7b86e-09f4-476a-8f20-f20d2fd3a5d8?sp=r&sv=2018-11-09&sr=b&spr=https&se=2025-06-13T09%3A24%3A22Z&skoid=96c2d410-5711-43a1-aedd-ab1947aa7ab0&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skt=2025-06-13T09%3A14%3A38Z&ske=2025-06-13T10%3A14%3A39Z&sks=b&skv=2018-11-09&sig=xL6ueS5IqEz04PzCc1Ist4qSJYK3CkPoR0Es06m8dCU%3D&jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmVsZWFzZS1hc3NldHMuZ2l0aHVidXNlcmNvbnRlbnQuY29tIiwia2V5Ijoia2V5MSIsImV4cCI6MTc0OTgwNjY2MiwibmJmIjoxNzQ5ODA2MzYyLCJwYXRoIjoicmVsZWFzZWFzc2V0cHJvZHVjdGlvbi5ibG9iLmNvcmUud2luZG93cy5uZXQifQ.A-upNsHMCntSFeb9sz1M1b5bSPrue4v9NTTLFLsLTSk&response-content-disposition=attachment%3B%20filename%3Dsymf-x86_64-linux-musl.zip&response-content-type=application%2Foctet-stream",
```

## Test plan

N/A, fix for the infra

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
