### PR TITLE
[Backport M104] fix(chat): Update the storage warning banner message (#8056)

### DIFF
--- a/vscode/webviews/chat/StorageWarningBanner.tsx
+++ b/vscode/webviews/chat/StorageWarningBanner.tsx
@@ -39,11 +39,12 @@ export const StorageWarningBanner = ({ extensionAPI, vscodeAPI }: StorageWarning
             </div>
             <div className={styles.body}>
                 <header>
-                    <h1 className="tw-text-blue-500">Storage is Full</h1>
+                    <h1 className="tw-text-blue-500">Large Chat History Detected</h1>
                     <p className="tw-text-gray-500">
-                        Low local storage space detected. Chat performance may be slow. To fix this,
-                        export your chat history to save a copy, then clear your chat history to free up
-                        space.
+                        Your large chat history is being loaded into memory, which may slow down Cody's
+                        performance. To improve performance, select the options below to export your chat
+                        history to save a backup, then clear it to free up memory. You can also go to the
+                        history page to perform these actions.
                     </p>
                 </header>
                 <div className={`${styles.actions} tw-flex tw-gap-3 tw-flex-wrap`}>


### PR DESCRIPTION
Update the storage warning banner message to avoid [confusion](https://discord.com/channels/969688426372825169/969688427232641136/1383142818234630305) about 'storage'.

## Test plan
Text update
<!-- Required. See
https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

---------


(cherry picked from commit dcfe95d3b943863ee662965cd8ebaf19ff08c42d)


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
