### PR TITLE
Update Cody Web version and fix build

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/cody-web",
-  "version": "0.32.6",
+  "version": "0.32.8",
   "description": "Cody standalone web app",
   "license": "Apache-2.0",
   "repository": {

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -65,6 +65,13 @@ export default defineProjectWithDefaults(__dirname, {
             { find: /^(node:)?events$/, replacement: resolve(__dirname, 'node_modules/events') },
             { find: /^(node:)?util$/, replacement: resolve(__dirname, 'node_modules/util') },
             { find: /^(node:)?buffer$/, replacement: resolve(__dirname, 'node_modules/buffer') },
+            {
+                find: /^(node:)?process$/,
+                replacement: resolve(
+                    __dirname,
+                    '../node_modules/.pnpm/process@0.11.10/node_modules/process'
+                ),
+            },
             { find: /^fs-extra$/, replacement: resolve(__dirname, 'lib/agent/shims/fs-extra.ts') },
             { find: /^open$/, replacement: resolve(__dirname, 'lib/agent/shims/open.ts') },
             {


### PR DESCRIPTION
Fixes cody web build failing due to `node:process` and updates the package version.
## Test plan
- `cd web`
- `pnpm dev`
- test new chat and other core actions