### PR TITLE
Do not use blocking operations in write actions

### DIFF
--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/edit/lenses/actions/EditShowDiffAction.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/edit/lenses/actions/EditShowDiffAction.kt
@@ -9,8 +9,8 @@ import com.sourcegraph.common.ShowDocumentDiffAction
 class EditShowDiffAction :
     LensEditAction({ project, event, editor, taskId ->
       CodyAgentService.withAgent(project) { agent ->
+        val editTask = agent.server.editTask_getTaskDetails(taskId).get()
         WriteCommandAction.runWriteCommandAction<Unit>(project) {
-          val editTask = agent.server.editTask_getTaskDetails(taskId).get()
           if (editTask != null) {
             val documentAfter = editor.document
             val documentBefore = EditorFactory.getInstance().createDocument(documentAfter.text)


### PR DESCRIPTION
Fixes issue reported by Sentry in a diff action:

```
Crashed in non-app: jdk.internal.misc.Unsafe in park
com.sourcegraph.cody.edit.lenses.actions.EditShowDiffAction in _init_$lambda$2$lambda$1$lambda$0 at line 13
com.sourcegraph.cody.edit.lenses.actions.EditShowDiffAction$$Lambda/0x00000001037c8e00 in compute
Called from: com.intellij.openapi.command.WriteCommandAction in lambda$runWriteCommandAction$5
```

We should not have blocking code in a IntelliJ write actions.

## Test plan

N/A

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
