### PR TITLE
Fix JetBrains uri parsing issues

### DIFF
--- a/jetbrains/src/main/kotlin/com/sourcegraph/utils/CodyEditorUtil.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/utils/CodyEditorUtil.kt
@@ -179,12 +179,12 @@ object CodyEditorUtil {
   }
 
   fun findFileOrScratch(project: Project, uriString: String): VirtualFile? {
-    val uri = CodyFileUri.parse(uriString, project.basePath)
+    val uri = CodyFileUri.parse(uriString)
     if (uri.isUntitled()) {
       return ScratchRootType.getInstance()
           .findFile(project, uri.toString(), ScratchFileService.Option.existing_only)
     } else {
-      val path = uri.toAbsolutePath()
+      val path = uri.toAbsolutePath(project.basePath)
       return VirtualFileManager.getInstance().refreshAndFindFileByNioPath(path)
     }
   }
@@ -195,7 +195,7 @@ object CodyEditorUtil {
       content: String? = null,
       overwrite: Boolean = false
   ): VirtualFile? {
-    val path = CodyFileUri.parse(uriString, project.basePath).toAbsolutePath()
+    val path = CodyFileUri.parse(uriString).toAbsolutePath(project.basePath)
     if (overwrite || path.notExists()) {
       path.parent.createDirectories()
       path.deleteIfExists()

--- a/jetbrains/src/test/kotlin/com/sourcegraph/common/CodyFileUriTest.kt
+++ b/jetbrains/src/test/kotlin/com/sourcegraph/common/CodyFileUriTest.kt
@@ -10,7 +10,7 @@ class CodyFileUriTest(private val uri: String, private val expectedUri: String) 
 
   @Test
   fun `can parse uri from agent`() {
-    val result = CodyFileUri.parse(uri, null)
+    val result = CodyFileUri.parse(uri)
 
     assertEquals(expectedUri, result.toString())
   }
@@ -26,6 +26,9 @@ class CodyFileUriTest(private val uri: String, private val expectedUri: String) 
           arrayOf(
               "C:\\dev\\JetbrainsTestsProjects\\kotlin\\TestProject\\Validate.kt",
               "file:///C:/dev/JetbrainsTestsProjects/kotlin/TestProject/Validate.kt"),
+          arrayOf(
+              "C:\\dev\\Jetbrains%20Tests%20Projects\\kotlin\\TestProject\\Validate.kt",
+              "file:///C:/dev/Jetbrains%20Tests%20Projects/kotlin/TestProject/Validate.kt"),
           arrayOf(
               "file:///c%3A/dev/JetbrainsTestsProjects/kotlin/TestProject/src/Main.kt",
               "file:///c:/dev/JetbrainsTestsProjects/kotlin/TestProject/src/Main.kt"),


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/QA-700/jb-onlywindows-only-cody-gets-crashed-when-user-tries-to-save-searched

## Changes

Before my changes the test I added was failing with:

```
Caused by: java.net.URISyntaxException: Illegal character in path at index 22: 
file:///C:/Users/Rajat Nagoria/PycharmProjects/pythonProject2/Untitled\

Illegal character in path at index 24: file:///C:/dev/Jetbrains Tests Projects/kotlin/TestProject/Validate.kt
java.net.URISyntaxException: Illegal character in path at index 24: file:///C:/dev/Jetbrains Tests Projects/kotlin/TestProject/Validate.kt
	at java.base/java.net.URI$Parser.fail(URI.java:2976)
	at java.base/java.net.URI$Parser.checkChars(URI.java:3147)
	at java.base/java.net.URI$Parser.parseHierarchical(URI.java:3229)
```

It was cause by usage of `URLDecoder.decode` which e.g. converts `%20` to spaces, which are illegal in the URI.
We should not use it at all in this specific place. I fixed that and added few other tweaks.

## Test plan

Unit test covering problematic scenario was added.

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
