### PR TITLE
fix(chat): resolve DeepCody terminal tool capability awareness issue

### DIFF
--- a/vscode/src/chat/chat-view/handlers/DeepCodyHandler.ts
+++ b/vscode/src/chat/chat-view/handlers/DeepCodyHandler.ts
@@ -1,8 +1,9 @@
-import { env } from 'node:process'
 import {
     type AgentToolboxSettings,
     type ContextItem,
+    ContextItemSource,
     FeatureFlag,
+    type Message,
     type Model,
     ModelTag,
     type ProcessingStep,
@@ -14,16 +15,19 @@ import {
     isDotCom,
     modelsService,
     pendingOperation,
+    ps,
     resolvedConfig,
     startWith,
     userProductSubscription,
 } from '@sourcegraph/cody-shared'
 import { DeepCodyAgentID } from '@sourcegraph/cody-shared/src/models/client'
 import { type Observable, Subject, map } from 'observable-fns'
+import * as vscode from 'vscode'
 import { DeepCodyAgent } from '../../agentic/DeepCody'
 import type { ChatBuilder } from '../ChatBuilder'
 import { isCodyTesting } from '../chat-helpers'
 import type { HumanInput } from '../context'
+import type { DefaultPrompter, PromptInfo } from '../prompt'
 import { ChatHandler } from './ChatHandler'
 import type { AgentHandler, AgentHandlerDelegate } from './interfaces'
 
@@ -81,6 +85,30 @@ export class DeepCodyHandler extends ChatHandler implements AgentHandler {
         )
 
         return { contextItems: await agent.getContext(requestID, signal, baseContext) }
+    }
+
+    override async buildPrompt(
+        prompter: DefaultPrompter,
+        chatBuilder: ChatBuilder,
+        abortSignal: AbortSignal,
+        codyApiVersion: number
+    ): Promise<PromptInfo> {
+        const result = await super.buildPrompt(prompter, chatBuilder, abortSignal, codyApiVersion)
+        
+        // Check if terminal context items exist
+        const hasTerminalContext = result.context.used.some(item => item.source === ContextItemSource.Terminal)
+        
+        if (hasTerminalContext) {
+            // Prepend a system message about tool capabilities
+            const toolCapabilityMessage: Message = {
+                speaker: 'system',
+                text: ps`You have access to terminal/shell tools and have executed commands to gather information. The terminal output is included in your context. You can reference and analyze this output in your response.`,
+            }
+            
+            result.prompt = [toolCapabilityMessage, ...result.prompt]
+        }
+        
+        return result
     }
 
     // ========================================================================
@@ -169,7 +197,7 @@ export class DeepCodyHandler extends ChatHandler implements AgentHandler {
 
                 Object.assign(DeepCodyHandler.shellConfig, {
                     instance: instanceShellContextFlag,
-                    client: Boolean(env.shell),
+                    client: Boolean(vscode.env.shell),
                 })
 
                 return DeepCodyHandler.getSettings()

--- a/vscode/webviews/chat/cells/agenticCell/ApprovalCell.tsx
+++ b/vscode/webviews/chat/cells/agenticCell/ApprovalCell.tsx
@@ -52,7 +52,7 @@ const ApprovalCell: FC<{ vscodeAPI: VSCodeWrapper }> = ({ vscodeAPI }) => {
                             <TriangleAlertIcon size={16} />{' '}
                             {a.title ? CONFIRMATION_TITLES[a.title] ?? a.title : 'Action Required'}
                         </span>
-                        <div className="tw-my-4 tw-text-xs tw-font-normal tw-bg-[var(--code-background)] tw-px-4 tw-py-2 tw-rounded-sm tw-border tw-border-border tw-font-mono">
+                        <div className="tw-my-4 tw-text-xs tw-font-normal tw-bg-[var(--code-background)] tw-px-4 tw-py-2 tw-rounded-sm tw-border tw-border-border tw-font-mono tw-text-foreground">
                             {a.content}
                         </div>
                         <div className="tw-gap-2 tw-w-full tw-inline-flex tw-justify-end">


### PR DESCRIPTION
Fix issue where DeepCody would successfully execute terminal commands during context gathering but then respond with "I can't execute commands" in the final chat response.

Changes:
- Fix shell detection in DeepCodyHandler to use `vscode.env.shell` instead of `env.shell` (which resolves to undefined) for VS Code extension compatibility
- Override buildPrompt() in DeepCodyHandler to inject system message about tool capabilities when terminal context is present
- Improve ApprovalCell styling to ensure command text is visible under light color theme with proper foreground color

The core issue was that DeepCody's context gathering phase would execute tools successfully, but the final chat model received no indication that it had tool capabilities, causing it to give standard "I can't execute commands" responses despite having terminal output in its context.


## Test plan
Tested locally against the demo instance
![Screenshot 2025-06-16 at 10 28 06 AM](https://github.com/user-attachments/assets/e28685df-12a5-40c9-a8ae-e8382d7e2dfb)
![Screenshot 2025-06-16 at 11 33 18 AM](https://github.com/user-attachments/assets/e9d08eea-23af-40b1-9409-655acf72df1c)

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
