### PR TITLE
update languageId -> language

### DIFF
--- a/vscode/src/autoedits/analytics-logger/analytics-logger.test.ts
+++ b/vscode/src/autoedits/analytics-logger/analytics-logger.test.ts
@@ -84,7 +84,7 @@ describe('AutoeditAnalyticsLogger', () => {
             position,
             codeToReplaceData: codeToReplace,
             payload: {
-                languageId: 'typescript',
+                language: 'typescript',
                 model: 'autoedit-model',
                 triggerKind: autoeditTriggerKind.automatic,
                 codeToRewrite: 'Code to rewrite',
@@ -267,7 +267,7 @@ describe('AutoeditAnalyticsLogger', () => {
               "gatewayLatency": undefined,
               "id": "stable-id-for-tests-2",
               "inlineCompletionStats": undefined,
-              "languageId": "typescript",
+              "language": "typescript",
               "model": "autoedit-model",
               "otherCompletionProviders": [],
               "prediction": "say("Hello from autoedit!")",

--- a/vscode/src/autoedits/analytics-logger/analytics-logger.ts
+++ b/vscode/src/autoedits/analytics-logger/analytics-logger.ts
@@ -109,7 +109,7 @@ export class AutoeditAnalyticsLogger {
         position: vscode.Position
         requestDocContext: DocumentContext
         payload: Required<
-            Pick<StartedState['payload'], 'languageId' | 'model' | 'triggerKind' | 'codeToRewrite'>
+            Pick<StartedState['payload'], 'language' | 'model' | 'triggerKind' | 'codeToRewrite'>
         >
     }): AutoeditRequestID {
         const { codeToRewrite, ...restPayload } = payload

--- a/vscode/src/autoedits/analytics-logger/types.ts
+++ b/vscode/src/autoedits/analytics-logger/types.ts
@@ -208,7 +208,7 @@ export interface StartedState extends AutoeditBaseState {
     /** Partial payload for this phase. Will be augmented with more info as we progress. */
     payload: {
         /** Document language ID (e.g., 'typescript'). */
-        languageId: string
+        language: string
 
         /** Model used by Cody client to request the autosuggestion suggestion. */
         model: string

--- a/vscode/src/autoedits/autoedits-provider.test.ts
+++ b/vscode/src/autoedits/autoedits-provider.test.ts
@@ -171,7 +171,7 @@ describe('AutoeditsProvider', () => {
                 "charCount": 2,
                 "lineCount": 2,
               },
-              "languageId": "typescript",
+              "language": "typescript",
               "model": "autoedits-deepseek-lite-default",
               "otherCompletionProviders": [],
               "prediction": "const x = 1
@@ -234,7 +234,7 @@ describe('AutoeditsProvider', () => {
                 "charCount": 2,
                 "lineCount": 2,
               },
-              "languageId": "typescript",
+              "language": "typescript",
               "model": "autoedits-deepseek-lite-default",
               "otherCompletionProviders": [],
               "prediction": "const x = 1
@@ -304,7 +304,7 @@ describe('AutoeditsProvider', () => {
                 "charCount": 2,
                 "lineCount": 2,
               },
-              "languageId": "typescript",
+              "language": "typescript",
               "model": "autoedits-deepseek-lite-default",
               "otherCompletionProviders": [],
               "prediction": "const x = 1

--- a/vscode/src/autoedits/autoedits-provider.ts
+++ b/vscode/src/autoedits/autoedits-provider.ts
@@ -408,7 +408,7 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
                 requestDocContext,
                 document,
                 payload: {
-                    languageId: document.languageId,
+                    language: document.languageId,
                     model: autoeditsProviderConfig.model,
                     codeToRewrite: requestCodeToReplaceData.codeToRewrite,
                     triggerKind,

--- a/vscode/src/autoedits/debug-panel/autoedit-data-sdk.ts
+++ b/vscode/src/autoedits/debug-panel/autoedit-data-sdk.ts
@@ -205,8 +205,8 @@ export const getDiscardReason = (entry: AutoeditRequestDebugState): string | nul
  * Gets language ID if available
  */
 export const getLanguageId = (entry: AutoeditRequestDebugState): string | null => {
-    if ('payload' in entry.state && 'languageId' in entry.state.payload) {
-        return entry.state.payload.languageId
+    if ('payload' in entry.state && 'language' in entry.state.payload) {
+        return entry.state.payload.language
     }
     return null
 }

--- a/vscode/webviews/autoedit-debug/components/AutoeditDetailView.tsx
+++ b/vscode/webviews/autoedit-debug/components/AutoeditDetailView.tsx
@@ -94,7 +94,7 @@ export const AutoeditDetailView: FC<{
                         <div className="tw-mt-8">
                             <SideBySideDiff
                                 sideBySideDiffDecorationInfo={entry.sideBySideDiffDecorationInfo}
-                                languageId={entry.state.payload.languageId}
+                                languageId={entry.state.payload.language}
                                 codeToRewrite={codeToRewrite || ''}
                                 prediction={prediction || ''}
                             />


### PR DESCRIPTION
Update the key name from `languageId` to `language` since that is the key that is allowlisted in the [backend](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/telemetry/sensitivemetadataallowlist/sensitivemetadataallowlist.go?L177-184)
## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
