### PR TITLE
Do not stringify strings in configuration update payload

### DIFF
--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -187,7 +187,12 @@ const configuration = new AgentWorkspaceConfiguration(
         if (agent && section.startsWith('cody')) {
             agent.notify('extensionConfiguration/didUpdate', {
                 key: section,
-                value: value === undefined ? undefined : JSON.stringify(value),
+                value:
+                    value === undefined
+                        ? undefined
+                        : typeof value === 'string'
+                          ? value
+                          : JSON.stringify(value),
             })
         }
     }


### PR DESCRIPTION
Before this change, when we were updating the config with a string value, the resulting payload was smth like ""auto-edit"" (not double nesting!). That caused a parsing error in JB client. Eventually, we were saving a double nested string. Weird and incorrect. This PR fixes that.

## Test plan
- Make sure that double nested strings are not saved in the config. E.g. play with auto-edit enrolment. 

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
