### PR TITLE
Do enrol to auto-edit for all clients

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/ClientCapabilities.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/ClientCapabilities.kt
@@ -9,7 +9,6 @@ data class ClientCapabilities(
   val autoedit: AutoeditEnum? = null, // Oneof: none, enabled
   val autoeditInlineDiff: AutoeditInlineDiffEnum? = null, // Oneof: none, insertions-only, deletions-only, insertions-and-deletions
   val autoeditAsideDiff: AutoeditAsideDiffEnum? = null, // Oneof: none, image, diff
-  val autoeditSuggestToEnroll: AutoeditSuggestToEnrollEnum? = null, // Oneof: none, enabled
   val chat: ChatEnum? = null, // Oneof: none, streaming
   val git: GitEnum? = null, // Oneof: none, enabled
   val progressBars: ProgressBarsEnum? = null, // Oneof: none, enabled
@@ -57,11 +56,6 @@ data class ClientCapabilities(
     @SerializedName("none") None,
     @SerializedName("image") Image,
     @SerializedName("diff") Diff,
-  }
-
-  enum class AutoeditSuggestToEnrollEnum {
-    @SerializedName("none") None,
-    @SerializedName("enabled") Enabled,
   }
 
   enum class ChatEnum {

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
@@ -192,7 +192,6 @@ class CodyAgentService(private val project: Project) : Disposable {
             autoedit = ClientCapabilities.AutoeditEnum.Enabled,
             autoeditInlineDiff = ClientCapabilities.AutoeditInlineDiffEnum.None,
             autoeditAsideDiff = ClientCapabilities.AutoeditAsideDiffEnum.Diff,
-            autoeditSuggestToEnroll = ClientCapabilities.AutoeditSuggestToEnrollEnum.Enabled,
             edit = ClientCapabilities.EditEnum.Enabled,
             editWorkspace = ClientCapabilities.EditWorkspaceEnum.Enabled,
             codeLenses = ClientCapabilities.CodeLensesEnum.Enabled,

--- a/lib/shared/src/configuration/clientCapabilities.ts
+++ b/lib/shared/src/configuration/clientCapabilities.ts
@@ -90,12 +90,6 @@ export interface ClientCapabilities {
     autoeditAsideDiff?: 'none' | 'image' | 'diff'
 
     /**
-     * This capability is responsible for displaying a notification with a suggestion to switch
-     * suggestions mode from autocomplete to autoedit if applicable.
-     */
-    autoeditSuggestToEnroll?: 'none' | 'enabled' | undefined | null
-
-    /**
      * When 'streaming', handles 'chat/updateMessageInProgress' streaming notifications.
      */
     chat?: 'none' | 'streaming' | undefined | null

--- a/vscode/src/autoedits/autoedit-onboarding.ts
+++ b/vscode/src/autoedits/autoedit-onboarding.ts
@@ -25,7 +25,7 @@ export class AutoEditBetaOnboarding implements vscode.Disposable {
     }
 
     private async enrollUserToAutoEditBeta(): Promise<void> {
-        const switchToAutocompleteText = 'Switch to autocomplete'
+        const switchToAutocompleteText = 'Switch back to autocomplete'
 
         await vscode.workspace
             .getConfiguration()

--- a/vscode/src/autoedits/autoedit-onboarding.ts
+++ b/vscode/src/autoedits/autoedit-onboarding.ts
@@ -24,34 +24,6 @@ export class AutoEditBetaOnboarding implements vscode.Disposable {
         }
     }
 
-    public async suggestToEnrollUserToAutoEditBetaIfEligible(): Promise<void> {
-        const isUserEligibleForAutoeditBeta = await this.isUserEligibleForAutoeditBetaOverride()
-        if (isUserEligibleForAutoeditBeta) {
-            vscode.window
-                .showInformationMessage(
-                    'Auto-edits are now available',
-                    {
-                        detail: '<html>An advanced mode for completions is now available. This is configured via <b>cody_settings.json</b>, give it a try now.</html>',
-                    },
-                    'Configure auto-edits',
-                    'Open cody__settings.json'
-                )
-                .then(answer => {
-                    if (answer === 'Configure auto-edits') {
-                        vscode.workspace
-                            .getConfiguration()
-                            .update(
-                                'cody.suggestions.mode',
-                                CodyAutoSuggestionMode.Autoedit,
-                                vscode.ConfigurationTarget.Global
-                            )
-                    } else if (answer === 'Open cody__settings.json') {
-                        vscode.commands.executeCommand('cody.settings.extension')
-                    }
-                })
-        }
-    }
-
     private async enrollUserToAutoEditBeta(): Promise<void> {
         const switchToAutocompleteText = 'Switch to autocomplete'
 

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -8,7 +8,6 @@ import {
     type IsIgnored,
     RateLimitError,
     authStatus,
-    clientCapabilities,
     contextFiltersProvider,
     featureFlagProvider,
     isAuthError,
@@ -145,15 +144,7 @@ export class InlineCompletionItemProvider
     }: CodyCompletionItemProviderConfig) {
         // Show the autoedit onboarding message if the user hasn't enabled autoedits
         // but is eligible to use them as an alternative to autocomplete
-        if (isRunningInsideAgent()) {
-            // We do not currently automatically opt users into auto-edit if we are running inside Agent.
-            // This is because Agent support is still experimental and is only ready for dogfooding right now.
-            if (clientCapabilities().autoeditSuggestToEnroll === 'enabled') {
-                autoeditsOnboarding.suggestToEnrollUserToAutoEditBetaIfEligible()
-            }
-        } else {
-            autoeditsOnboarding.enrollUserToAutoEditBetaIfEligible()
-        }
+        autoeditsOnboarding.enrollUserToAutoEditBetaIfEligible()
 
         // This is a static field to allow for easy access in the static `configuration` getter.
         // There must only be one instance of this class at a time.


### PR DESCRIPTION
This PR makes auto-edits the default suggestion mode for all clients. 

## Test plan
1. Having an IDE with autocompletion mode turned on (also, note that there is a local flag handled by `markUserAsAutoEditBetaEnrolled`, you may need to manually modify some code to see it working. I do not know how to clear the state of that config.)
2. Run IDE

Expected:
Cody switches to auto-edits automatically. A notification appears with an option to switch back to autocompletion mode.

<img width="410" alt="image" src="https://github.com/user-attachments/assets/b1874d20-021b-48d6-9484-14b2955455d2" />

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
