### PR TITLE
fix(smart-apply): now applies changes to file that have parents that duplicate workspace name

### DIFF
--- a/vscode/src/services/utils/edit-create-file.test.ts
+++ b/vscode/src/services/utils/edit-create-file.test.ts
@@ -47,6 +47,13 @@ describe('resolveRelativeOrAbsoluteUri', () => {
         const result = await resolveRelativeOrAbsoluteUri(undefined, uri.path, mockActiveEditorUri)
         expect(result).toEqual(mockActiveEditorUri)
     })
+
+    it('returns file URI when parent directory has same name as base directory', async () => {
+        const uri = toUri('base', 'dir', 'dir', 'file.ts')
+        vi.mocked(doesFileExist).mockResolvedValue(true)
+        const result = await resolveRelativeOrAbsoluteUri(mockBaseDirUri, uri.path)
+        expect(result).toEqual(toUri(path.sep, 'base', 'dir', 'dir', 'file.ts'))
+    })
 })
 
 describe('smartJoinPath', () => {

--- a/vscode/src/services/utils/edit-create-file.ts
+++ b/vscode/src/services/utils/edit-create-file.ts
@@ -37,6 +37,14 @@ export async function resolveRelativeOrAbsoluteUri(
         return fallbackUri
     }
 
+    // no need to smartJoinPath if the file is found even though
+    // we have path duplication, ex cli -> cli -> hello.ts
+    const filepath = path.join(baseDirUri.path, uri)
+    const hasExistingFile = await doesFileExist(vscode.Uri.file(filepath))
+    if (hasExistingFile) {
+        return vscode.Uri.file(filepath)
+    }
+
     return smartJoinPath(baseDirUri, uri)
 }
 


### PR DESCRIPTION
Fixes CODY-5064 CODY-5830 CODY-6023 


## Test plan
- Have a workspace that follows this path cli -> cli -> hello.ts
- ask any llm to make some changes to hello.ts
- hit smart apply and notice smart apply changes are added to cli/cli/hello.ts instead of cli/hello.ts