### PR TITLE
Do not copy code to clipboard on the EDT thread

### DIFF
--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/ui/web/WebUIProxy.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/ui/web/WebUIProxy.kt
@@ -275,7 +275,9 @@ internal class WebUIProxy(private val host: WebUIHost, private val browser: JBCe
         if (messageObject["command"]?.asString == "copy" &&
             messageObject["text"]?.asString != null) {
           val textToCopy = messageObject["text"].asString
-          CopyPasteManager.getInstance().setContents(StringSelection(textToCopy))
+          ApplicationManager.getApplication().executeOnPooledThread {
+            CopyPasteManager.getInstance().setContents(StringSelection(textToCopy))
+          }
         } else if (messageObject["command"]?.asString == "ready") {
           onReady()
         }


### PR DESCRIPTION
## Changes

I verified that adding a sleep next to `CopyPasteManager.getInstance().setContents` call causes IDE to hang.
We do not control if that call is blocking or not, but we can run it in a background thread.

That will prevent hangs, but in case of slow `setContents` call it may cause delay in clipboard copying operation (text in the clipboard may not be available immediately).
But it is better alternative to hang, and in the majority of cases that operation is instant.

## Test plan

1. Generate some code with Cody chat
2. Click "Copy" button under the snapshot
3. Do it a few times
4. No hands should be observed


<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
