### PR TITLE
Pass client name version headers with completions request

### DIFF
--- a/lib/shared/src/sourcegraph-api/client-name-version.ts
+++ b/lib/shared/src/sourcegraph-api/client-name-version.ts
@@ -46,6 +46,8 @@ export function getClientIdentificationHeaders() {
     // untrusted cross-origin request.
     if (!process.env.CODY_WEB_DEMO) {
         headers['X-Requested-With'] = `${clientName} ${clientVersion}`
+        headers['X-Sourcegraph-API-Client-Name'] = clientName
+        headers['X-Sourcegraph-API-Client-Version'] = clientVersion
     }
 
     return headers


### PR DESCRIPTION
closes: https://linear.app/sourcegraph/issue/CODY-6059/error-with-context-filters-in-cody-setup-for-client

context: https://sourcegraph.slack.com/archives/C04MSD3DP5L/p1750104540995199

> I have a client trying to use Cody context filters, but they are running into the error in the attached image. I was able to recreate the same error when I set up [context filters](https://sourcegraph.com/docs/cody/capabilities/ignore-context#context-filters) in our test instance.

<img width="759" alt="image" src="https://github.com/user-attachments/assets/12ae4f7b-eb67-4b47-a997-f03242c343a6" />


From the client as per the network request and the error message we are sending the client-name=vscode in the query params.

The issue is that the backend API only checks for `X-Sourcegraph-API-Client-Name` header field and not the `client-name` query param, but the error message says that we need to pass query param. [backend code](https://github.com/sourcegraph/sourcegraph/blob/dd29700643bac8f56bfff49e44722b4e17cccaa3/internal/requestclient/http.go#L187-L188) [error message](https://github.com/sourcegraph/sourcegraph/blob/dd29700643bac8f56bfff49e44722b4e17cccaa3/cmd/frontend/internal/httpapi/completions/handler.go#L875-L876)

And the Cody client only sends the client-name query param and not the header field.

The quicker fix is to start sending `X-Sourcegraph-API-Client-Name` header field from the Cody Client. As the Cody releases are on weekly cadence the issue will be resolved quicker.

But I will update the backend code error message separately to say that the header field is expected and not the query param.

## Test plan

- Follow the [guide](https://sourcegraph.com/docs/cody/capabilities/ignore-context#context-filters) to configure context filters on the connected sourcegraph instance. 
- Reload the Cody App
- Submit a chat mentioning a non-blocked (not filtered out) repo and make sure no error occurs. 
- Try mentioning a blocked repo, it should be disabled to do so.