### PR TITLE
fix(auth): restore accidentally removed URI handler for authentication callbacks

### DIFF
--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -45,6 +45,7 @@ import {
     requestEndpointSettingsDeliveryToSearchPlugin,
     showSignInMenu,
     showSignOutMenu,
+    tokenCallbackHandler,
 } from './auth/auth'
 import { createAutoEditsProvider } from './autoedits/create-autoedits-provider'
 import { autoeditDebugStore } from './autoedits/debug-panel/debug-store'
@@ -298,6 +299,7 @@ const register = async (
         await registerTestCommands(context, disposables)
     }
     registerDebugCommands(context, disposables)
+    registerAuthenticationHandlers(disposables)
     disposables.push(charactersLogger)
 
     // INC-267 do NOT await on this promise. This promise triggers
@@ -817,4 +819,19 @@ function registerChat(
     }
 
     return { chatsController }
+}
+
+function registerAuthenticationHandlers(disposables: vscode.Disposable[]): void {
+    disposables.push(
+        // Register URI Handler (e.g. vscode://sourcegraph.cody-ai)
+        vscode.window.registerUriHandler({
+            handleUri: async (uri: vscode.Uri) => {
+                if (uri.path === '/app-done') {
+                    // This is an old re-entrypoint from App that is a no-op now.
+                } else {
+                    void tokenCallbackHandler(uri)
+                }
+            },
+        })
+    )
 }


### PR DESCRIPTION
fixes: https://linear.app/sourcegraph/issue/QA-739/core-user-is-unable-to-login-to-cody

The handler was accidentally removed in #8095 (the method name was misleading, indicated that the handlers refer to upgrade logic only). This PR brings back that handler (and gives a proper name to the method).

## Test plan
auth with google/gitlab/github works in JB 

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
