### PR TITLE
fix: release canvas after use

### DIFF
--- a/vscode/src/autoedits/renderer/image-gen/canvas/draw-decorations.ts
+++ b/vscode/src/autoedits/renderer/image-gen/canvas/draw-decorations.ts
@@ -123,17 +123,7 @@ export function drawDecorationsToCanvas(
 
     // In order for us to draw to the canvas, we must first determine the correct
     // dimensions for the canvas. We can do this with a temporary Canvas that uses the same font
-    const { ctx: tempCtx } = createCanvas({ height: 10, width: 10, fontSize: config.fontSize }, context)
-
-    // Iterate through each token line, and determine the required width of the canvas (maximum line length)
-    // and the required height of the canvas (number of lines determined by their line height)
-    let tempYPos = config.padding.y
-    let requiredWidth = 0
-    for (const line of diff.lines) {
-        const measure = tempCtx.measureText(line.text)
-        requiredWidth = Math.max(requiredWidth, config.padding.x + measure.width)
-        tempYPos += config.lineHeight
-    }
+    const { requiredWidth, tempYPos } = calculateRequiredDimensions(config, context, diff)
 
     // Note: We limit the canvas width to avoid the image getting excessively large.
     // We should consider possible strategies here, such as tweaking this value or refusing
@@ -175,4 +165,19 @@ export function drawDecorationsToCanvas(
     }
 
     return canvas
+}
+function calculateRequiredDimensions(config: RenderConfig, context: RenderContext, diff: VisualDiff) {
+    const { canvas, ctx } = createCanvas({ height: 10, width: 10, fontSize: config.fontSize }, context)
+
+    // Iterate through each token line, and determine the required width of the canvas (maximum line length)
+    // and the required height of the canvas (number of lines determined by their line height)
+    let tempYPos = config.padding.y
+    let requiredWidth = 0
+    for (const line of diff.lines) {
+        const measure = ctx.measureText(line.text)
+        requiredWidth = Math.max(requiredWidth, config.padding.x + measure.width)
+        tempYPos += config.lineHeight
+    }
+    canvas.dispose()
+    return { requiredWidth, tempYPos }
 }

--- a/vscode/src/autoedits/renderer/image-gen/index.ts
+++ b/vscode/src/autoedits/renderer/image-gen/index.ts
@@ -1,6 +1,10 @@
 import { initCanvas } from './canvas'
 import { drawDecorationsToCanvas } from './canvas/draw-decorations'
-import { type UserProvidedRenderConfig, getRenderConfig } from './canvas/render-config'
+import {
+    type RenderConfig,
+    type UserProvidedRenderConfig,
+    getRenderConfig,
+} from './canvas/render-config'
 import { makeDecoratedDiff } from './decorated-diff'
 import { initSyntaxHighlighter } from './highlight'
 import type { DiffMode, VisualDiff } from './visual-diff/types'
@@ -38,12 +42,20 @@ export function generateSuggestionAsImage(options: ImageSuggestionOptions): Gene
     const renderConfig = getRenderConfig(config)
 
     return {
-        dark: drawDecorationsToCanvas(highlightedDiff.dark, 'dark', mode, renderConfig).toDataURL(
-            'image/png'
-        ),
-        light: drawDecorationsToCanvas(highlightedDiff.light, 'light', mode, renderConfig).toDataURL(
-            'image/png'
-        ),
+        dark: renderSuggestionImage(highlightedDiff.dark, 'dark', mode, renderConfig),
+        light: renderSuggestionImage(highlightedDiff.light, 'light', mode, renderConfig),
         pixelRatio: renderConfig.pixelRatio,
     }
+}
+
+function renderSuggestionImage(
+    diff: VisualDiff,
+    theme: 'dark' | 'light',
+    mode: DiffMode,
+    renderConfig: RenderConfig
+) {
+    const canvas = drawDecorationsToCanvas(diff, theme, mode, renderConfig)
+    const image = canvas.toDataURL('image/png')
+    canvas.dispose()
+    return image
 }


### PR DESCRIPTION
Call `canvas.dispose` to clean-up resources after uses. This should prevent memory leak, which may cause failures in new canvas creations.

ref: CODY-6011


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
