### PR TITLE
fix(auth): only update auth status in agent context

### DIFF
--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -35,6 +35,7 @@ import { Observable, Subject, interval } from 'observable-fns'
 import * as vscode from 'vscode'
 import { serializeConfigSnapshot } from '../../uninstall/serializeConfig'
 import { type ResolvedConfigurationCredentialsOnly, validateCredentials } from '../auth/auth'
+import { isRunningInsideAgent } from '../jsonrpc/isRunningInsideAgent'
 import { logError } from '../output-channel-logger'
 import { version } from '../version'
 import { localStorage } from './LocalStorageProvider'
@@ -173,7 +174,11 @@ class AuthProvider implements vscode.Disposable {
             authStatus.subscribe(authStatus => {
                 try {
                     this.lastEndpoint = authStatus.endpoint
-                    vscode.commands.executeCommand('authStatus.update', authStatus)
+                    // Only execute authStatus.update command when running inside agent context
+                    // This command is only registered in the agent, not in the VSCode extension
+                    if (isRunningInsideAgent()) {
+                        vscode.commands.executeCommand('authStatus.update', authStatus)
+                    }
                     vscode.commands.executeCommand(
                         'setContext',
                         'cody.activated',


### PR DESCRIPTION
This commit ensures that the `authStatus.update` command is only executed when running inside the agent context. This command is exclusively registered within the agent and not in the VS Code extension itself. This prevents errors and ensures the command is only called where it is defined.


## Test plan
- Open VSCode and notice we no longer receive the error
Stack trace: Error: command 'authStatus.update' not found
    at Jze.n (vscode-file://vscode-app/Applications/Visual%20Studio%20Code%20-%20Insiders.app/Contents/Resources/app/out/vs/workbench/workbench.desktop.main.js:1243:3892)
