### PR TITLE
fix(editor): ignore file parsing to skip rules with , in them

### DIFF
--- a/vscode/src/editor/utils/findWorkspaceFiles.test.ts
+++ b/vscode/src/editor/utils/findWorkspaceFiles.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from 'vitest'
+
+// Mock vscode.workspace.fs
+vi.mock('vscode', () => ({
+    workspace: {
+        fs: {
+            readFile: vi.fn(),
+        },
+    },
+    Uri: {
+        file: vi.fn(),
+    },
+}))
+
+import * as vscode from 'vscode'
+import { readIgnoreFile } from './findWorkspaceFiles'
+
+describe('readIgnoreFile', () => {
+    it('parses basic gitignore patterns', async () => {
+        const mockData = new Uint8Array(Buffer.from('node_modules\n*.log\n.env'))
+        vi.mocked(vscode.workspace.fs.readFile).mockResolvedValue(mockData)
+
+        const result = await readIgnoreFile({} as vscode.Uri)
+
+        expect(result).toEqual({
+            '**/node_modules': true,
+            '**/*.log': true,
+            '**/.env': true,
+        })
+    })
+
+    it('handles comments and empty lines', async () => {
+        const mockData = new Uint8Array(Buffer.from('# Comment\nnode_modules\n\n*.log # inline comment\n'))
+        vi.mocked(vscode.workspace.fs.readFile).mockResolvedValue(mockData)
+
+        const result = await readIgnoreFile({} as vscode.Uri)
+
+        expect(result).toEqual({
+            '**/node_modules': true,
+            '**/*.log': true,
+        })
+    })
+
+    it('ignores negation patterns', async () => {
+        const mockData = new Uint8Array(Buffer.from('*.log\n!important.log\nnode_modules'))
+        vi.mocked(vscode.workspace.fs.readFile).mockResolvedValue(mockData)
+
+        const result = await readIgnoreFile({} as vscode.Uri)
+
+        expect(result).toEqual({
+            '**/*.log': true,
+            '**/node_modules': true,
+        })
+    })
+
+    it('handles directory patterns', async () => {
+        const mockData = new Uint8Array(Buffer.from('dist/\n/root_only\n**/deep_pattern'))
+        vi.mocked(vscode.workspace.fs.readFile).mockResolvedValue(mockData)
+
+        const result = await readIgnoreFile({} as vscode.Uri)
+
+        expect(result).toEqual({
+            '**/dist': true,
+            '/root_only': true,
+            '**/deep_pattern': true,
+        })
+    })
+
+    it('skips lines containing commas', async () => {
+        const mockData = new Uint8Array(Buffer.from('node_modules\n*,something\n*.log\n{*.js,*.ts}\nvalid_pattern'))
+        vi.mocked(vscode.workspace.fs.readFile).mockResolvedValue(mockData)
+
+        const result = await readIgnoreFile({} as vscode.Uri)
+
+        expect(result).toEqual({
+            '**/node_modules': true,
+            '**/*.log': true,
+            '**/valid_pattern': true,
+        })
+    })
+
+    it('handles file read errors gracefully', async () => {
+        vi.mocked(vscode.workspace.fs.readFile).mockRejectedValue(new Error('File not found'))
+
+        const result = await readIgnoreFile({} as vscode.Uri)
+
+        expect(result).toEqual({})
+    })
+
+    it('handles whitespace and trailing slashes', async () => {
+        const mockData = new Uint8Array(Buffer.from('  node_modules  \ndist/   \n  *.log  # comment  '))
+        vi.mocked(vscode.workspace.fs.readFile).mockResolvedValue(mockData)
+
+        const result = await readIgnoreFile({} as vscode.Uri)
+
+        expect(result).toEqual({
+            '**/node_modules': true,
+            '**/dist': true,
+            '**/*.log': true,
+        })
+    })
+})

--- a/vscode/src/editor/utils/findWorkspaceFiles.ts
+++ b/vscode/src/editor/utils/findWorkspaceFiles.ts
@@ -49,7 +49,7 @@ async function getExcludePattern(workspaceFolder: vscode.WorkspaceFolder | null)
     return `{${excludePatterns.join(',')}}`
 }
 
-async function readIgnoreFile(uri: vscode.Uri): Promise<IgnoreRecord> {
+export async function readIgnoreFile(uri: vscode.Uri): Promise<IgnoreRecord> {
     const ignore: IgnoreRecord = {}
     try {
         const data = await vscode.workspace.fs.readFile(uri)
@@ -58,10 +58,16 @@ async function readIgnoreFile(uri: vscode.Uri): Promise<IgnoreRecord> {
                 continue
             }
 
-            // Strip comment and trailing whitespace.
-            line = line.replace(/\s*(#.*)?$/, '')
+            // Strip comment and whitespace.
+            line = line.replace(/\s*(#.*)?$/, '').trim()
 
             if (line === '') {
+                continue
+            }
+
+            // Skip patterns that contain commas to avoid typos for entries such as
+            // *,something
+            if (line.includes(',')) {
                 continue
             }
 


### PR DESCRIPTION
Refs CODY-6090 fix skipping of files from the @ mention files search when .gitignore contains rules such as *,something

## Test plan
- Try to add a *,rule to .gitignore and notice that you can no longer find files previous to this fix
