### PR TITLE
fix(mentions): deduplicate files from overlapping workspace folders

### DIFF
--- a/vscode/test/fixtures/nested-workspaces.code-workspace
+++ b/vscode/test/fixtures/nested-workspaces.code-workspace
@@ -1,0 +1,20 @@
+{
+    "folders": [
+        {
+            "path": "workspace"
+        },
+        {
+            "path": "workspace2"
+        },
+        {
+            "path": "workspace2/subproject"
+        }
+    ],
+    "settings": {
+        // Settings that should also apply to the single-root workspace tests should also be
+        // included in fixtures\workspace\.vscode\settings.json!
+        "cody.serverEndpoint": "http://localhost:49300",
+        "cody.commandCodeLenses": true,
+        "cody.internal.unstable": true
+    }
+}

--- a/vscode/test/fixtures/workspace2/Main.java
+++ b/vscode/test/fixtures/workspace2/Main.java
@@ -1,0 +1,5 @@
+public class Main {
+    public static void main(String[] args) {
+        System.out.println("Hello from workspace2!");
+    }
+}

--- a/vscode/test/fixtures/workspace2/duplicate-test.txt
+++ b/vscode/test/fixtures/workspace2/duplicate-test.txt
@@ -1,0 +1,1 @@
+This file tests duplicate detection in workspace2 parent.

--- a/vscode/test/fixtures/workspace2/subproject/.gitignore
+++ b/vscode/test/fixtures/workspace2/subproject/.gitignore
@@ -1,0 +1,2 @@
+*.temp
+build/

--- a/vscode/test/fixtures/workspace2/subproject/Sub.java
+++ b/vscode/test/fixtures/workspace2/subproject/Sub.java
@@ -1,0 +1,5 @@
+public class Sub {
+    public static void main(String[] args) {
+        System.out.println("Hello from subproject!");
+    }
+}

--- a/vscode/test/fixtures/workspace2/subproject/duplicate-test.txt
+++ b/vscode/test/fixtures/workspace2/subproject/duplicate-test.txt
@@ -1,0 +1,1 @@
+This file tests duplicate detection in subproject.

--- a/vscode/test/fixtures/workspace2/subproject/subproject.md
+++ b/vscode/test/fixtures/workspace2/subproject/subproject.md
@@ -1,0 +1,4 @@
+# Subproject
+
+This is a nested workspace folder that should be included as a separate workspace in our tests.
+It's designed to test the scenario where one workspace contains another workspace as a subdirectory.

--- a/vscode/test/integration/main.ts
+++ b/vscode/test/integration/main.ts
@@ -29,6 +29,7 @@ async function main(): Promise<void> {
     const testConfigs = [
         { testsFolder: 'single-root', workspace: 'workspace' },
         { testsFolder: 'multi-root', workspace: 'multi-root.code-workspace' },
+        { testsFolder: 'nested-workspaces', workspace: 'nested-workspaces.code-workspace' },
     ]
 
     let exitCode = 0

--- a/vscode/test/integration/multi-root/findWorkspaceFiles.test.ts
+++ b/vscode/test/integration/multi-root/findWorkspaceFiles.test.ts
@@ -1,0 +1,146 @@
+import * as assert from 'node:assert'
+import * as path from 'node:path'
+import * as vscode from 'vscode'
+import { findWorkspaceFiles } from '../../../src/editor/utils/findWorkspaceFiles'
+
+suite('findWorkspaceFiles Integration Tests', () => {
+    test('finds files across all workspace folders', async () => {
+        const files = await findWorkspaceFiles()
+
+        // Should return an array of URIs
+        assert.ok(Array.isArray(files))
+        assert.ok(files.length > 0)
+
+        // All results should be URIs
+        for (const file of files) {
+            assert.ok(file instanceof vscode.Uri)
+        }
+    })
+
+    test('finds files from both workspace folders', async () => {
+        const files = await findWorkspaceFiles()
+        const filePaths = files.map(uri => uri.fsPath)
+
+        const workspaceFolders = vscode.workspace.workspaceFolders!
+        assert.ok(workspaceFolders.length >= 2, 'Should have at least 2 workspace folders')
+
+        const workspace1Path = workspaceFolders[0].uri.fsPath
+        const workspace2Path = workspaceFolders[1].uri.fsPath
+
+        // Should have files from both workspace folders
+        const filesFromWorkspace1 = filePaths.filter(p => p.startsWith(workspace1Path))
+        const filesFromWorkspace2 = filePaths.filter(p => p.startsWith(workspace2Path))
+
+        assert.ok(filesFromWorkspace1.length > 0, 'Should have files from workspace1')
+        assert.ok(filesFromWorkspace2.length > 0, 'Should have files from workspace2')
+    })
+
+    test('finds Main.java files from both workspaces', async () => {
+        const files = await findWorkspaceFiles()
+        const filePaths = files.map(uri => uri.fsPath)
+
+        // Should find Main.java from both workspace folders
+        const mainJavaFiles = filePaths.filter(p => p.endsWith('Main.java'))
+        assert.strictEqual(mainJavaFiles.length, 2, 'Should find exactly 2 Main.java files')
+
+        // Verify they are from different workspaces
+        const workspaceFolders = vscode.workspace.workspaceFolders!
+        const workspace1Path = workspaceFolders[0].uri.fsPath
+        const workspace2Path = workspaceFolders[1].uri.fsPath
+
+        const mainFromWorkspace1 = mainJavaFiles.some(p => p.startsWith(workspace1Path))
+        const mainFromWorkspace2 = mainJavaFiles.some(p => p.startsWith(workspace2Path))
+
+        assert.ok(mainFromWorkspace1, 'Should find Main.java from workspace1')
+        assert.ok(mainFromWorkspace2, 'Should find Main.java from workspace2')
+    })
+
+    test('finds README.md from workspace2', async () => {
+        const files = await findWorkspaceFiles()
+        const filePaths = files.map(uri => uri.fsPath)
+
+        const readmeFiles = filePaths.filter(p => p.endsWith('README.md'))
+        assert.equal(readmeFiles.length, 1, 'Should find at least one README.md')
+
+        const workspace2Path = vscode.workspace.workspaceFolders![1].uri.fsPath
+
+        assert.ok(
+            readmeFiles.some(p => p.startsWith(workspace2Path)),
+            'Should find README.md from  workspace2'
+        )
+    })
+
+    test('does not return duplicate files', async () => {
+        const files = await findWorkspaceFiles()
+        const filePaths = files.map(uri => uri.toString())
+        const uniquePaths = new Set(filePaths)
+
+        assert.strictEqual(filePaths.length, uniquePaths.size, 'Should not have duplicate files')
+    })
+
+    test('respects gitignore patterns from workspace folders', async () => {
+        const files = await findWorkspaceFiles()
+        const filePaths = files.map(uri => uri.fsPath)
+
+        // Based on workspace/.gitignore which excludes .vscode and *.cody.html
+        const hasVscodeFolder = filePaths.some(p => p.includes('.vscode'))
+        const hasCodyHtmlFiles = filePaths.some(p => p.endsWith('.cody.html'))
+
+        // These should be excluded by gitignore
+        assert.strictEqual(hasVscodeFolder, false, '.vscode folders should be excluded by gitignore')
+        assert.strictEqual(hasCodyHtmlFiles, false, '*.cody.html files should be excluded by gitignore')
+    })
+
+    test('excludes files based on workspace configuration', async () => {
+        // Get current exclude configuration
+        const config = vscode.workspace.getConfiguration('')
+        const filesExclude = config.get<Record<string, boolean>>('files.exclude', {})
+
+        const files = await findWorkspaceFiles()
+        const filePaths = files.map(uri => uri.fsPath)
+
+        // Check that excluded patterns are not present
+        for (const [pattern, excluded] of Object.entries(filesExclude)) {
+            if (excluded && pattern.includes('node_modules')) {
+                const hasNodeModulesFiles = filePaths.some(p => p.includes('node_modules'))
+                assert.strictEqual(hasNodeModulesFiles, false, 'node_modules should be excluded')
+                break
+            }
+        }
+    })
+
+    test('finds common file types', async () => {
+        const files = await findWorkspaceFiles()
+        const extensions = files.map(uri => {
+            const path = uri.fsPath
+            const lastDot = path.lastIndexOf('.')
+            return lastDot > 0 ? path.substring(lastDot).toLowerCase() : ''
+        })
+
+        // Should find various file types commonly present in workspaces
+        const commonExtensions = ['.java', '.ts', '.md']
+        const foundExtensions = commonExtensions.filter(ext => extensions.includes(ext))
+
+        assert.ok(foundExtensions.length > 0, 'Should find common file types')
+        assert.ok(foundExtensions.includes('.java'), 'Should find .java files')
+        assert.ok(foundExtensions.includes('.md'), 'Should find .md files')
+    })
+
+    test('handles files with same names in different workspaces', async () => {
+        const files = await findWorkspaceFiles()
+        const filePaths = files.map(uri => uri.fsPath)
+
+        // Both workspace and workspace2 have duplicate-test.txt files
+        const duplicateTestFiles = filePaths.filter(p => p.endsWith('duplicate-test.txt'))
+
+        // Should find both files (they're in different directories, so not actual duplicates)
+        assert.ok(
+            duplicateTestFiles.length >= 2,
+            'Should find duplicate-test.txt from multiple workspaces'
+        )
+
+        // Verify they're from different directories
+        const uniqueDirs = new Set(duplicateTestFiles.map(p => path.dirname(p)))
+        assert.ok(uniqueDirs.size >= 2, 'duplicate-test.txt files should be in different directories')
+    })
+})

--- a/vscode/test/integration/nested-workspaces/findWorkspaceFiles.test.ts
+++ b/vscode/test/integration/nested-workspaces/findWorkspaceFiles.test.ts
@@ -1,0 +1,166 @@
+import * as assert from 'node:assert'
+import * as vscode from 'vscode'
+import { findWorkspaceFiles } from '../../../src/editor/utils/findWorkspaceFiles'
+
+suite('findWorkspaceFiles with Nested Workspaces', () => {
+    test('handles nested workspace folders without duplicates', async () => {
+        const files = await findWorkspaceFiles()
+        const filePaths = files.map(uri => uri.fsPath)
+
+        // Verify no duplicate files exist
+        const uniquePaths = new Set(filePaths)
+        assert.strictEqual(filePaths.length, uniquePaths.size, 'Should not have duplicate files')
+
+        // Log for debugging
+        console.log(`Found ${files.length} files total`)
+        console.log(`Unique files: ${uniquePaths.size}`)
+    })
+
+    test('finds files from all three workspace folders', async () => {
+        const files = await findWorkspaceFiles()
+        const filePaths = files.map(uri => uri.fsPath)
+
+        const workspaceFolders = vscode.workspace.workspaceFolders!
+        assert.strictEqual(workspaceFolders.length, 3, 'Should have exactly 3 workspace folders')
+
+        const workspace1Path = workspaceFolders[0].uri.fsPath // workspace
+        const workspace2Path = workspaceFolders[1].uri.fsPath // workspace2
+        const subprojectPath = workspaceFolders[2].uri.fsPath // workspace2/subproject
+
+        // Count files from each workspace
+        const filesFromWorkspace1 = filePaths.filter(
+            p => p.startsWith(workspace1Path) && !p.startsWith(workspace2Path)
+        )
+        const filesFromWorkspace2 = filePaths.filter(
+            p => p.startsWith(workspace2Path) && !p.startsWith(subprojectPath)
+        )
+        const filesFromSubproject = filePaths.filter(p => p.startsWith(subprojectPath))
+
+        assert.ok(filesFromWorkspace1.length > 0, 'Should have files from workspace1')
+        assert.ok(
+            filesFromWorkspace2.length > 0,
+            'Should have files from workspace2 (excluding subproject)'
+        )
+        assert.ok(filesFromSubproject.length > 0, 'Should have files from subproject')
+
+        console.log(`Files from workspace1: ${filesFromWorkspace1.length}`)
+        console.log(`Files from workspace2 (excluding subproject): ${filesFromWorkspace2.length}`)
+        console.log(`Files from subproject: ${filesFromSubproject.length}`)
+    })
+
+    test('finds specific files without duplication', async () => {
+        const files = await findWorkspaceFiles()
+        const filePaths = files.map(uri => uri.fsPath)
+
+        // Should find Main.java files from workspace1 and workspace2, but not duplicated
+        const mainJavaFiles = filePaths.filter(p => p.endsWith('Main.java'))
+        assert.strictEqual(mainJavaFiles.length, 2, 'Should find exactly 2 Main.java files')
+
+        // Should find Sub.java from subproject only once
+        const subJavaFiles = filePaths.filter(p => p.endsWith('Sub.java'))
+        assert.strictEqual(subJavaFiles.length, 1, 'Should find exactly 1 Sub.java file')
+
+        // Should find README.md from workspace2 only once (not duplicated from parent workspace)
+        const readmeFiles = filePaths.filter(p => p.endsWith('README.md'))
+        const workspace2ReadmeFiles = readmeFiles.filter(
+            p => p.includes('workspace2') && !p.includes('subproject')
+        )
+        assert.strictEqual(
+            workspace2ReadmeFiles.length,
+            1,
+            'Should find exactly 1 README.md from workspace2'
+        )
+
+        // Should find subproject.md from subproject only once
+        const subprojectMdFiles = filePaths.filter(p => p.endsWith('subproject.md'))
+        assert.strictEqual(subprojectMdFiles.length, 1, 'Should find exactly 1 subproject.md file')
+    })
+
+    test('respects gitignore from both parent and nested workspaces', async () => {
+        const files = await findWorkspaceFiles()
+        const filePaths = files.map(uri => uri.fsPath)
+
+        // Should respect .gitignore from workspace2/subproject (excludes *.temp and build/)
+        const tempFiles = filePaths.filter(p => p.endsWith('.temp'))
+        const buildDirs = filePaths.filter(p => p.includes('/build/'))
+
+        assert.strictEqual(
+            tempFiles.length,
+            0,
+            '*.temp files should be excluded by subproject gitignore'
+        )
+        assert.strictEqual(
+            buildDirs.length,
+            0,
+            'build/ directories should be excluded by subproject gitignore'
+        )
+
+        // Should also respect parent workspace gitignore (excludes .vscode and *.cody.html)
+        const vscodeFiles = filePaths.filter(p => p.includes('.vscode'))
+        const codyHtmlFiles = filePaths.filter(p => p.endsWith('.cody.html'))
+
+        assert.strictEqual(vscodeFiles.length, 0, '.vscode should be excluded by parent gitignore')
+        assert.strictEqual(codyHtmlFiles.length, 0, '*.cody.html should be excluded by parent gitignore')
+    })
+
+    test('workspace folder precedence - subproject takes priority over parent', async () => {
+        const files = await findWorkspaceFiles()
+        const filePaths = files.map(uri => uri.fsPath)
+
+        const workspaceFolders = vscode.workspace.workspaceFolders!
+        const subprojectPath = workspaceFolders[2].uri.fsPath // workspace2/subproject
+
+        // Files in the subproject directory should be attributed to the subproject workspace folder
+        // This tests that VS Code properly handles the precedence when folders overlap
+        const subprojectFiles = filePaths.filter(p => p.startsWith(subprojectPath))
+
+        // Verify subproject files exist
+        assert.ok(subprojectFiles.length > 0, 'Should find files in subproject')
+
+        // All subproject files should have the subproject path as their workspace root
+        const hasSubJava = subprojectFiles.some(p => p.endsWith('Sub.java'))
+        const hasSubprojectMd = subprojectFiles.some(p => p.endsWith('subproject.md'))
+
+        assert.ok(hasSubJava, 'Should find Sub.java in subproject files')
+        assert.ok(hasSubprojectMd, 'Should find subproject.md in subproject files')
+    })
+
+    test('verifies no duplicated files appear in multiple workspace contexts', async () => {
+        const files = await findWorkspaceFiles()
+        const filePathsSet = new Set<string>()
+        const duplicates: string[] = []
+
+        // Check for any duplicate file paths
+        for (const file of files) {
+            const filePath = file.fsPath
+            if (filePathsSet.has(filePath)) {
+                duplicates.push(filePath)
+            } else {
+                filePathsSet.add(filePath)
+            }
+        }
+
+        assert.strictEqual(duplicates.length, 0, `Found duplicate files: ${duplicates.join(', ')}`)
+    })
+
+    test('correct file counts for nested workspace scenario', async () => {
+        const files = await findWorkspaceFiles()
+        const filePaths = files.map(uri => uri.fsPath)
+
+        // Count specific file types to ensure we're getting the expected results
+        const javaFiles = filePaths.filter(p => p.endsWith('.java'))
+        const mdFiles = filePaths.filter(p => p.endsWith('.md'))
+
+        // We should have:
+        // - 3 Java files: Main.java (workspace), Main.java (workspace2), Sub.java (subproject)
+        // - At least 2 MD files: README.md (workspace2), subproject.md (subproject)
+        // - Gitignore files should be excluded from results (they're not typically included in file searches)
+
+        assert.ok(javaFiles.length >= 3, `Should find at least 3 Java files, found ${javaFiles.length}`)
+        assert.ok(mdFiles.length >= 2, `Should find at least 2 MD files, found ${mdFiles.length}`)
+
+        console.log(`Java files found: ${javaFiles.length}`)
+        console.log(`MD files found: ${mdFiles.length}`)
+        console.log(`Total files found: ${files.length}`)
+    })
+})

--- a/vscode/test/integration/nested-workspaces/index.ts
+++ b/vscode/test/integration/nested-workspaces/index.ts
@@ -1,0 +1,5 @@
+import * as runner from '../runner'
+
+export function run(): Promise<void> {
+    return runner.run(__dirname)
+}

--- a/vscode/test/integration/nested-workspaces/workspace.test.ts
+++ b/vscode/test/integration/nested-workspaces/workspace.test.ts
@@ -1,0 +1,32 @@
+import * as assert from 'node:assert'
+import * as path from 'node:path'
+import * as vscode from 'vscode'
+import type { ExtensionApi } from '../../../src/extension-api'
+
+suite('Nested Workspaces', () => {
+    test('was correctly loaded with nested workspace folders', async () => {
+        const workspaceFolderNames = vscode.workspace.workspaceFolders?.map(wf =>
+            path.basename(wf.uri.fsPath)
+        )
+        assert.deepStrictEqual(workspaceFolderNames, ['workspace', 'workspace2', 'subproject'])
+        
+        const api = vscode.extensions.getExtension<ExtensionApi>('sourcegraph.cody-ai')
+        assert.ok(api, 'extension not found')
+    })
+
+    test('workspace2 contains subproject as subdirectory', async () => {
+        const workspaceFolders = vscode.workspace.workspaceFolders!
+        assert.strictEqual(workspaceFolders.length, 3)
+
+        const workspace2 = workspaceFolders.find(wf => path.basename(wf.uri.fsPath) === 'workspace2')
+        const subproject = workspaceFolders.find(wf => path.basename(wf.uri.fsPath) === 'subproject')
+
+        assert.ok(workspace2, 'workspace2 should exist')
+        assert.ok(subproject, 'subproject should exist')
+
+        // Verify that subproject is indeed a subdirectory of workspace2
+        const subprojectPath = subproject.uri.fsPath
+        const workspace2Path = workspace2.uri.fsPath
+        assert.ok(subprojectPath.startsWith(workspace2Path), 'subproject should be within workspace2')
+    })
+})


### PR DESCRIPTION
This PR is a rework of the @ichim-david PR: https://github.com/sourcegraph/cody/pull/8126 
I think deduplication may be done a bit more efficiently, but scope of the changes (especially for e2e integration tests) was too big to make sensible suggestion in the PR so I raised a new one.

Description copied from David's PR:

-----------------

This commit introduces deduplication of files returned by `findWorkspaceFiles` when workspace folders overlap. This situation commonly occurs in monorepos or when users add subdirectories as separate workspace folders in VS Code for better Git integration.

Also contains the changes from this pr https://github.com/sourcegraph/cody/pull/8125

See this youtube video where I show what this work fixes:
https://www.youtube.com/watch?v=CzJTgUoBcLk

## Test plan

- Test on a monorepo where you have a project repository and within a certain folder, you have other packages that are cloned from other repositories
- Test that when you search for any file it is not duplicated