### PR TITLE
Fix selection issues in JetBrains

### DIFF
--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/chat/actions/BaseCommandAction.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/chat/actions/BaseCommandAction.kt
@@ -4,7 +4,6 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.application.ReadAction
-import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.project.Project
 import com.intellij.util.concurrency.AppExecutorUtil
 import com.sourcegraph.cody.agent.CodyAgentService
@@ -38,9 +37,7 @@ abstract class BaseCommandAction : DumbAwareEDTAction() {
   open fun doAction(project: Project) {
     ApplicationManager.getApplication().assertIsDispatchThread()
     CodyEditorUtil.getSelectedEditors(project).firstOrNull()?.let { editor ->
-      val file = FileDocumentManager.getInstance().getFile(editor.document)
-      val protocolFile =
-          file?.let { ProtocolTextDocumentExt.fromVirtualEditorFile(editor, it) } ?: return
+      val protocolFile = ProtocolTextDocumentExt.fromEditor(editor) ?: return
 
       ReadAction.nonBlocking(
               Callable { IgnoreOracle.getInstance(project).policyForUri(protocolFile.uri).get() })

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/listeners/CodyCaretListener.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/listeners/CodyCaretListener.kt
@@ -28,7 +28,7 @@ class CodyCaretListener(val project: Project) : CaretListener {
       return
     }
 
-    ProtocolTextDocumentExt.fromEditorWithOffsetSelection(e.editor, e)?.let { textDocument ->
+    ProtocolTextDocumentExt.fromEditor(e.editor, updateContent = false)?.let { textDocument ->
       EditorChangesBus.documentChanged(project, textDocument)
       CodyAgentService.withAgent(project) { agent: CodyAgent ->
         agent.server.textDocument_didChange(textDocument)

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/listeners/CodySelectionListener.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/listeners/CodySelectionListener.kt
@@ -22,7 +22,7 @@ class CodySelectionListener(val project: Project) : SelectionListener {
       return
     }
     val editor = event.editor
-    ProtocolTextDocumentExt.fromEditorWithRangeSelection(editor, event)?.let { textDocument ->
+    ProtocolTextDocumentExt.fromEditor(editor, updateContent = false)?.let { textDocument ->
       EditorChangesBus.documentChanged(project, textDocument)
       CodyAgentService.withAgent(project) { agent ->
         agent.server.textDocument_didChange(textDocument)

--- a/jetbrains/src/test/kotlin/com/sourcegraph/cody/agent/protocol_extensions/ProtocolTextDocumentTest.kt
+++ b/jetbrains/src/test/kotlin/com/sourcegraph/cody/agent/protocol_extensions/ProtocolTextDocumentTest.kt
@@ -42,7 +42,7 @@ class ProtocolTextDocumentTest : BasePlatformTestCase() {
   }
 
   fun test_emptySelection() {
-    val protocolTextFile = ProtocolTextDocumentExt.fromVirtualEditorFile(myFixture.editor, file)
+    val protocolTextFile = ProtocolTextDocumentExt.fromEditor(myFixture.editor)
     assert(protocolTextFile!!.uri.startsWith("file://"))
     assert(protocolTextFile.uri.contains("/cody-test"))
     assertEquals(defaultContent, protocolTextFile.content)
@@ -88,7 +88,7 @@ class ProtocolTextDocumentTest : BasePlatformTestCase() {
     myFixture.openFileInEditor(emptyFile)
     assertEquals(
         Range(Position(0, 0), Position(0, 0)),
-        ProtocolTextDocumentExt.fromVirtualEditorFile(myFixture.editor, emptyFile)?.selection)
+        ProtocolTextDocumentExt.fromEditor(myFixture.editor)?.selection)
   }
 
   fun test_selectionListener() {


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/CODY-6132/cody-document-code-placement-issue-in-intellij-idea.

This PR extends work done by @mkondratek in https://github.com/sourcegraph/cody/pull/8129

## Test plan

**Test 1**

1. Select a block of code in the editor
2. Right click within the selection (about the middle)
3. Trigger Document Code
4. Created comment should relate to the selected block (not only to the area at the caret).

**Test 2**

1. Double click on a text token
2. Check if selection changes properly in cody chat window

**Test 3**

1. Select few lines of the code
2. Move them to different position using mouse
3. Check if selection changes properly in cody chat window

**Test 4**

1. Select few text tokens using Shift + Arrow
2. Check if selection changes properly in cody chat window


<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
