### PR TITLE
[DO NOT MERGE] Auto-edit enrol testing

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/CodyAgentServer.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/CodyAgentServer.kt
@@ -186,4 +186,6 @@ interface CodyAgentServer {
   fun secrets_didChange(params: Secrets_DidChangeParams)
   @JsonNotification("window/didChangeFocus")
   fun window_didChangeFocus(params: Window_DidChangeFocusParams)
+  @JsonNotification("testing/resetAutoeditBetaEnrollment")
+  fun testing_resetAutoeditBetaEnrollment(params: Null?)
 }

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -1417,6 +1417,10 @@ export class Agent extends MessageHandler implements ExtensionClient {
             this.secretsDidChange.fire({ key })
         })
 
+        this.registerNotification('testing/resetAutoeditBetaEnrollment', () => {
+            localStorage.resetAutoeditBetaEnrollment()
+        })
+
         this.registerAuthenticatedRequest('featureFlags/getFeatureFlag', async ({ flagName }) => {
             return featureFlagProvider.evaluateFeatureFlagEphemerally(
                 FeatureFlag[flagName as keyof typeof FeatureFlag]

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/ResetAutoeditBetaEnrollment.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/ResetAutoeditBetaEnrollment.kt
@@ -1,0 +1,13 @@
+package com.sourcegraph.cody
+
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.sourcegraph.cody.agent.CodyAgentService
+import com.sourcegraph.common.ui.DumbAwareEDTAction
+
+class ResetAutoeditBetaEnrollment : DumbAwareEDTAction() {
+  override fun actionPerformed(e: AnActionEvent) {
+    CodyAgentService.withAgent(e.project!!) { agent ->
+      agent.server.testing_resetAutoeditBetaEnrollment(null)
+    }
+  }
+}

--- a/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -200,6 +200,13 @@
                     <override-text place="GoToAction" text="Cody: Export All Chats As JSON"/>
                 </action>
 
+                <action id="cody.resetAutoeditBetaEnrollment"
+                        class="com.sourcegraph.cody.ResetAutoeditBetaEnrollment"
+                        text="Reset Autoedit Beta Enrollment"
+                        description="Reset Autoedit Beta Enrollment">
+                    <override-text place="GoToAction" text="Cody: Reset Autoedit Beta Enrollment"/>
+                </action>
+
                 <action id="cody.openChat"
                         class="com.sourcegraph.cody.chat.OpenChatAction"
                         text="Open Chat"

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -378,6 +378,8 @@ export type ClientNotifications = {
     'secrets/didChange': [{ key: string }]
 
     'window/didChangeFocus': [{ focused: boolean }]
+
+    'testing/resetAutoeditBetaEnrollment': [null]
 }
 
 // ================

--- a/vscode/src/services/LocalStorageProvider.ts
+++ b/vscode/src/services/LocalStorageProvider.ts
@@ -241,6 +241,10 @@ class LocalStorage implements LocalStorageForModelPreferences {
         await this.set(this.AUTO_EDITS_BETA_ENROLLED, true)
     }
 
+    public async resetAutoeditBetaEnrollment(): Promise<void> {
+        await this.set(this.AUTO_EDITS_BETA_ENROLLED, false)
+    }
+
     public async setGitHubRepoAccessibility(data: GitHubDotComRepoMetaData[]): Promise<void> {
         await this.set(this.GIT_REPO_ACCESSIBILITY_KEY, data)
     }


### PR DESCRIPTION
This PR adds an action in JB to reset the storage entry related to auto-edit enrolment.

<!-- start git-machete generated -->

# Based on PR #8140

## Chain of upstream PRs as of 2025-07-03

* PR #8140:
  `main` ← `mkodratek/fix/ae-onboarding`

  * **PR #8141 (THIS ONE)**:
    `mkodratek/fix/ae-onboarding` ← `mkondratek/testing/autoedit-enrol`

<!-- end git-machete generated -->

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->