### PR TITLE
fix(agent): Initialize client identification headers for cody-cli

### DIFF
--- a/agent/package.json
+++ b/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/cody",
-  "version": "5.5.20",
+  "version": "5.5.21",
   "description": "Cody CLI is the same technology that powers Cody in the IDE but available from the command-line.",
   "license": "Apache-2.0",
   "repository": {

--- a/agent/src/cli/command-models.ts
+++ b/agent/src/cli/command-models.ts
@@ -1,8 +1,10 @@
-import { getClientIdentificationHeaders } from '@sourcegraph/cody-shared'
+import { getClientIdentificationHeaders, setClientNameVersion } from '@sourcegraph/cody-shared'
 import { Command } from 'commander'
+import packageJson from '../../package.json'
 import { AuthenticatedAccount } from './command-auth/AuthenticatedAccount'
 import { endpointOption } from './command-auth/command-login'
 import { accessTokenOption } from './command-auth/command-login'
+import { legacyCodyClientName } from './legacyCodyClientName'
 
 interface ListModelsOptions {
     accessToken: string
@@ -18,6 +20,14 @@ export const modelsCommand = () =>
             .action(async (options: ListModelsOptions) => {
                 const [account, spinner] =
                     await AuthenticatedAccount.fromUserSettingsOrExitProcess(options)
+
+                // Initialize client identification headers
+                setClientNameVersion({
+                    newClientName: 'cody-cli',
+                    newClientVersion: packageJson.version,
+                    newClientCompletionsStreamQueryParameterName: legacyCodyClientName,
+                })
+
                 const results = await fetch(`${account.serverEndpoint}/.api/llm/models`, {
                     headers: {
                         Authorization: `token ${account.accessToken}`,


### PR DESCRIPTION
Fixes CODY-6118 This commit initializes the client identification headers for the `cody-cli` tool. It sets the client name and version using `setClientNameVersion` from `@sourcegraph/cody-shared`. This ensures that requests from the CLI are properly identified and versioned, otherwise the command fails.

## Test plan
- run agent models list and notice it giving a reply with available models instead of error
