### PR TITLE
feat(chat-mention): Support multi-root workspaces in initial context

### DIFF
--- a/vscode/src/chat/initialContext.ts
+++ b/vscode/src/chat/initialContext.ts
@@ -231,86 +231,102 @@ export function getCorpusContextItemsForEditorState(): Observable<
     )
 
     return combineLatest(relevantAuthStatus, remoteReposForAllWorkspaceFolders, activeTextEditor).pipe(
-        abortableOperation(async ([authStatus, remoteReposForAllWorkspaceFolders, activeEditor], signal) => {
-            const items: ContextItem[] = []
+        abortableOperation(
+            async ([authStatus, remoteReposForAllWorkspaceFolders, activeEditor], signal) => {
+                const items: ContextItem[] = []
 
-            // Add workspace folders: current one to initial context, others to corpus context
-            const workspaceFolders = vscode.workspace.workspaceFolders
-            if (workspaceFolders) {
-                const currentWorkspaceFolder = vscode.workspace.getWorkspaceFolder(activeEditor?.document?.uri || workspaceFolders[0].uri)
+                // Add workspace folders: current one to initial context, others to corpus context
+                const workspaceFolders = vscode.workspace.workspaceFolders
+                if (workspaceFolders) {
+                    let currentWorkspaceFolder: vscode.WorkspaceFolder | undefined
 
-                for (const workspaceFolder of workspaceFolders) {
-                    const isCurrentFolder = currentWorkspaceFolder && workspaceFolder.uri.toString() === currentWorkspaceFolder.uri.toString()
+                    // check also for the first visible editor if no active editor is present
+                    // this is happening when we have editor Cody and we receive an undefined activeEditor
+                    const activeVisibleEditor: vscode.TextEditor | undefined =
+                        activeEditor || vscode.window.visibleTextEditors[0]
 
-                    items.push({
-                        type: 'tree',
-                        uri: workspaceFolder.uri,
-                        title: isCurrentFolder ? 'Current Repository' : workspaceFolder.name,
-                        name: workspaceFolder.name,
-                        description: workspaceFolder.name,
-                        isWorkspaceRoot: true,
-                        content: null,
-                        // Current folder goes to initial context (pre-filled), others go to corpus context (@ mention menu)
-                        source: isCurrentFolder ? ContextItemSource.Initial : ContextItemSource.User,
-                        icon: 'folder',
-                    } satisfies ContextItemTree)
-                }
-            }
+                    // If there's an active editor, use its workspace folder (could be undefined if outside workspace)
+                    // otherwise use the first workspace folder
+                    currentWorkspaceFolder = activeVisibleEditor
+                        ? vscode.workspace.getWorkspaceFolder(activeVisibleEditor.document?.uri)
+                        : workspaceFolders[0]
 
-            // TODO(sqs): Make this consistent between self-serve (no remote search) and enterprise (has
-            // remote search). There should be a single internal thing in Cody that lets you monitor the
-            // user's current codebase.
-            if (authStatus.allowRemoteContext) {
-                if (remoteReposForAllWorkspaceFolders === pendingOperation) {
-                    return pendingOperation
-                }
-                if (isError(remoteReposForAllWorkspaceFolders)) {
-                    throw remoteReposForAllWorkspaceFolders
-                }
-                for (const repo of remoteReposForAllWorkspaceFolders) {
-                    if (await contextFiltersProvider.isRepoNameIgnored(repo.name)) {
-                        continue
-                    }
-                    if (repo.id === undefined) {
-                        continue
-                    }
-                    items.push({
-                        ...contextItemMentionFromOpenCtxItem(
-                            await createRepositoryMention(
-                                {
-                                    id: repo.id,
-                                    name: repo.name,
-                                    url: repo.name,
-                                },
-                                REMOTE_REPOSITORY_PROVIDER_URI,
-                                authStatus
-                            )
-                        ),
-                        title: 'Current Codebase',
-                        description: repo.name,
-                        source: items.length > 0 ? ContextItemSource.Unified : ContextItemSource.Initial,
-                        icon: 'search',
-                    })
-                }
-                // CTA to index repositories should only show for Enterprise customers, see CODY-5017 & CODY-4676
-                if (authStatus.isEnterpriseUser && remoteReposForAllWorkspaceFolders.length === 0) {
-                    if (!clientCapabilities().isCodyWeb) {
+                    for (const workspaceFolder of workspaceFolders) {
+                        const isCurrentFolder =
+                            currentWorkspaceFolder &&
+                            workspaceFolder.uri.toString() === currentWorkspaceFolder.uri.toString()
+
                         items.push({
-                            type: 'open-link',
-                            title: 'Current Codebase',
-                            badge: 'Not yet available',
+                            type: 'tree',
+                            uri: workspaceFolder.uri,
+                            title: isCurrentFolder ? 'Current Repository' : workspaceFolder.name,
+                            name: workspaceFolder.name,
+                            description: workspaceFolder.name,
+                            isWorkspaceRoot: true,
                             content: null,
-                            uri: URI.parse(
-                                'https://sourcegraph.com/docs/cody/prompts-guide#indexing-your-repositories-for-context'
+                            // Current folder goes to initial context (pre-filled), others go to corpus context (@ mention menu)
+                            source: isCurrentFolder ? ContextItemSource.Initial : ContextItemSource.User,
+                            icon: 'folder',
+                        } satisfies ContextItemTree)
+                    }
+                }
+
+                // TODO(sqs): Make this consistent between self-serve (no remote search) and enterprise (has
+                // remote search). There should be a single internal thing in Cody that lets you monitor the
+                // user's current codebase.
+                if (authStatus.allowRemoteContext) {
+                    if (remoteReposForAllWorkspaceFolders === pendingOperation) {
+                        return pendingOperation
+                    }
+                    if (isError(remoteReposForAllWorkspaceFolders)) {
+                        throw remoteReposForAllWorkspaceFolders
+                    }
+                    for (const repo of remoteReposForAllWorkspaceFolders) {
+                        if (await contextFiltersProvider.isRepoNameIgnored(repo.name)) {
+                            continue
+                        }
+                        if (repo.id === undefined) {
+                            continue
+                        }
+                        items.push({
+                            ...contextItemMentionFromOpenCtxItem(
+                                await createRepositoryMention(
+                                    {
+                                        id: repo.id,
+                                        name: repo.name,
+                                        url: repo.name,
+                                    },
+                                    REMOTE_REPOSITORY_PROVIDER_URI,
+                                    authStatus
+                                )
                             ),
-                            name: '',
+                            title: 'Current Codebase',
+                            description: repo.name,
+                            source:
+                                items.length > 0 ? ContextItemSource.Unified : ContextItemSource.Initial,
                             icon: 'search',
                         })
                     }
+                    // CTA to index repositories should only show for Enterprise customers, see CODY-5017 & CODY-4676
+                    if (authStatus.isEnterpriseUser && remoteReposForAllWorkspaceFolders.length === 0) {
+                        if (!clientCapabilities().isCodyWeb) {
+                            items.push({
+                                type: 'open-link',
+                                title: 'Current Codebase',
+                                badge: 'Not yet available',
+                                content: null,
+                                uri: URI.parse(
+                                    'https://sourcegraph.com/docs/cody/prompts-guide#indexing-your-repositories-for-context'
+                                ),
+                                name: '',
+                                icon: 'search',
+                            })
+                        }
+                    }
                 }
+                return items
             }
-            return items
-        })
+        )
     )
 }
 

--- a/vscode/test/e2e/common.ts
+++ b/vscode/test/e2e/common.ts
@@ -199,12 +199,15 @@ export async function openFileInEditorTab(page: Page, filename: string): Promise
     await page.keyboard.press('F1')
     // Without the leading `>`, the input is interpreted as a filename.
     await page.getByPlaceholder('Type the name of a command to run.').fill(filename)
+    // In multi-root workspaces, the accessible name includes workspace folder info
+    // e.g., "buzz.ts workspace, file results" instead of just "buzz.ts,"
+    // So we use a more flexible pattern that matches the filename at the start
     await expect(
         page
             .getByRole('listbox', { name: /^Search files/ })
             .getByRole('option')
             .first()
-    ).toHaveAccessibleName(new RegExp(`${filename},`))
+    ).toHaveAccessibleName(new RegExp(`^${filename}\\b`))
     await page.keyboard.press('Enter')
 
     await clickEditorTab(page, filename)

--- a/vscode/test/e2e/helpers.ts
+++ b/vscode/test/e2e/helpers.ts
@@ -454,6 +454,11 @@ async function buildWorkSpaceSettings(
     workspaceDirectory: string,
     extraSettings: WorkspaceSettings
 ): Promise<void> {
+    // // Skip settings creation for .code-workspace files as they already contain settings
+    if (workspaceDirectory.endsWith('.code-workspace')) {
+        return
+    }
+
     const settings = {
         'cody.serverEndpoint': 'http://localhost:49300',
         'cody.commandCodeLenses': true,

--- a/vscode/test/e2e/initial-context.test.ts
+++ b/vscode/test/e2e/initial-context.test.ts
@@ -83,7 +83,7 @@ const testWithMultiRoot = test
         },
     })
 
-testWithMultiRoot.only('initial context - switches between multi-root workspace folders', async ({ page, sidebar, server }) => {
+testWithMultiRoot('initial context - switches between multi-root workspace folders', async ({ page, sidebar, server }) => {
     // Mock enterprise repo mapping for both workspace folders
     server.onGraphQl('RepositoryIds').replyJson({
         data: {

--- a/vscode/test/e2e/initial-context.test.ts
+++ b/vscode/test/e2e/initial-context.test.ts
@@ -13,7 +13,13 @@ import {
     selectLineRangeInEditorTab,
     sidebarSignin,
 } from './common'
-import { type DotcomUrlOverride, type WorkspaceDirectory, mockEnterpriseRepoMapping, test, testWithGitRemote } from './helpers'
+import {
+    type DotcomUrlOverride,
+    type WorkspaceDirectory,
+    mockEnterpriseRepoMapping,
+    test,
+    testWithGitRemote,
+} from './helpers'
 
 testWithGitRemote.extend<DotcomUrlOverride>({ dotcomUrl: mockServer.SERVER_URL })(
     'initial context - self-serve repo',
@@ -78,43 +84,54 @@ const testWithMultiRoot = test
             const path = require('node:path')
             const vscodeRoot = path.resolve(__dirname, '..', '..')
             // Use the multi-root.code-workspace file to load both workspace and workspace2 folders
-            const multiRootWorkspaceFile = path.join(vscodeRoot, 'test', 'fixtures', 'multi-root.code-workspace')
+            const multiRootWorkspaceFile = path.join(
+                vscodeRoot,
+                'test',
+                'fixtures',
+                'multi-root.code-workspace'
+            )
             await use(multiRootWorkspaceFile)
         },
     })
 
-testWithMultiRoot('initial context - switches between multi-root workspace folders', async ({ page, sidebar, server }) => {
-    // Mock enterprise repo mapping for both workspace folders
-    server.onGraphQl('RepositoryIds').replyJson({
-        data: {
-            repositories: [
-                { name: 'github.com/sourcegraph/workspace', id: 'workspace-id' },
-                { name: 'github.com/sourcegraph/workspace2', id: 'workspace2-id' },
-            ],
-        },
-    })
+testWithMultiRoot(
+    'initial context - switches between multi-root workspace folders',
+    async ({ page, sidebar, server }) => {
+        // Mock enterprise repo mapping for both workspace folders
+        server.onGraphQl('RepositoryIds').replyJson({
+            data: {
+                repositories: [
+                    { name: 'github.com/sourcegraph/workspace', id: 'workspace-id' },
+                    { name: 'github.com/sourcegraph/workspace2', id: 'workspace2-id' },
+                ],
+            },
+        })
 
-    await sidebarSignin(page, sidebar)
-    await openFileInEditorTab(page, 'buzz.ts')
-    const [chatFrame, lastChatInput] = await createEmptyChatPanel(page)
+        await sidebarSignin(page, sidebar)
+        await openFileInEditorTab(page, 'buzz.ts')
+        const [chatFrame, lastChatInput] = await createEmptyChatPanel(page)
 
-    await expect(chatInputMentions(lastChatInput)).toHaveText(['buzz.ts', 'workspace'])
+        await expect(chatInputMentions(lastChatInput)).toHaveText(['buzz.ts', 'workspace'])
 
-    // Switch to README.md from workspace2 and verify initial context changes
-    await selectLineRangeInEditorTab(page, 2, 4)
+        // Switch to README.md from workspace2 and verify initial context changes
+        await selectLineRangeInEditorTab(page, 2, 4)
         await openFileInEditorTab(page, 'README.md')
 
-    await expect(chatInputMentions(lastChatInput)).toHaveText(['README.md', 'workspace2'])
+        await expect(chatInputMentions(lastChatInput)).toHaveText(['README.md', 'workspace2'])
 
-    // Verify the file is open by checking the tab
-    await expect(page.getByRole('tab', { name: /README.md/ })).toBeVisible()
+        // Verify the file is open by checking the tab
+        await expect(page.getByRole('tab', { name: /README.md/ })).toBeVisible()
 
-    await lastChatInput.click()
-    await lastChatInput.fill('@')
+        await lastChatInput.click()
+        await lastChatInput.fill('@')
 
-    // Wait for @ mention menu to appear
-    await expect(mentionMenu(chatFrame)).toBeVisible()
+        // Wait for @ mention menu to appear
+        await expect(mentionMenu(chatFrame)).toBeVisible()
 
-    // Both workspace folders should be available for @ mention
-    await expect(mentionMenuItems(chatFrame)).toContainText(['workspace', 'workspace2'])
-})
+        // Both workspace folders should be available for @ mention
+        // The mention menu now includes more items, so we check that our workspaces are present
+        const mentionItems = mentionMenuItems(chatFrame)
+        await expect(mentionItems).toContainText(['workspace'])
+        await expect(mentionItems).toContainText(['workspace2'])
+    }
+)

--- a/vscode/test/e2e/initial-context.test.ts
+++ b/vscode/test/e2e/initial-context.test.ts
@@ -7,11 +7,13 @@ import {
     createEmptyChatPanel,
     getChatInputs,
     getChatSidebarPanel,
+    mentionMenu,
+    mentionMenuItems,
     openFileInEditorTab,
     selectLineRangeInEditorTab,
     sidebarSignin,
 } from './common'
-import { type DotcomUrlOverride, mockEnterpriseRepoMapping, testWithGitRemote } from './helpers'
+import { type DotcomUrlOverride, type WorkspaceDirectory, mockEnterpriseRepoMapping, test, testWithGitRemote } from './helpers'
 
 testWithGitRemote.extend<DotcomUrlOverride>({ dotcomUrl: mockServer.SERVER_URL })(
     'initial context - self-serve repo',
@@ -63,4 +65,56 @@ testWithGitRemote('initial context - file', async ({ page, sidebar, server }) =>
     await lastChatInput.press('x')
     await clickEditorTab(page, 'README.md')
     await expect(chatInputMentions(lastChatInput)).toHaveText(['main.c', 'myrepo'])
+})
+
+// Test with multi-root workspace to verify initial context switches between workspace folders
+const testWithMultiRoot = test
+    .extend<DotcomUrlOverride>({
+        dotcomUrl: mockServer.SERVER_URL,
+    })
+    .extend<WorkspaceDirectory>({
+        // biome-ignore lint/correctness/noEmptyPattern: Playwright needs empty pattern to specify "no dependencies".
+        workspaceDirectory: async ({}, use) => {
+            const path = require('node:path')
+            const vscodeRoot = path.resolve(__dirname, '..', '..')
+            // Use the multi-root.code-workspace file to load both workspace and workspace2 folders
+            const multiRootWorkspaceFile = path.join(vscodeRoot, 'test', 'fixtures', 'multi-root.code-workspace')
+            await use(multiRootWorkspaceFile)
+        },
+    })
+
+testWithMultiRoot.only('initial context - switches between multi-root workspace folders', async ({ page, sidebar, server }) => {
+    // Mock enterprise repo mapping for both workspace folders
+    server.onGraphQl('RepositoryIds').replyJson({
+        data: {
+            repositories: [
+                { name: 'github.com/sourcegraph/workspace', id: 'workspace-id' },
+                { name: 'github.com/sourcegraph/workspace2', id: 'workspace2-id' },
+            ],
+        },
+    })
+
+    await sidebarSignin(page, sidebar)
+    await openFileInEditorTab(page, 'buzz.ts')
+    const [chatFrame, lastChatInput] = await createEmptyChatPanel(page)
+
+    await expect(chatInputMentions(lastChatInput)).toHaveText(['buzz.ts', 'workspace'])
+
+    // Switch to README.md from workspace2 and verify initial context changes
+    await selectLineRangeInEditorTab(page, 2, 4)
+        await openFileInEditorTab(page, 'README.md')
+
+    await expect(chatInputMentions(lastChatInput)).toHaveText(['README.md', 'workspace2'])
+
+    // Verify the file is open by checking the tab
+    await expect(page.getByRole('tab', { name: /README.md/ })).toBeVisible()
+
+    await lastChatInput.click()
+    await lastChatInput.fill('@')
+
+    // Wait for @ mention menu to appear
+    await expect(mentionMenu(chatFrame)).toBeVisible()
+
+    // Both workspace folders should be available for @ mention
+    await expect(mentionMenuItems(chatFrame)).toContainText(['workspace', 'workspace2'])
 })

--- a/vscode/test/e2e/utils/buildCustomCommands.ts
+++ b/vscode/test/e2e/utils/buildCustomCommands.ts
@@ -8,6 +8,11 @@ import * as codyJson from './commands.json'
  * The file is written to the .vscode directory created in the buildWorkSpaceSettings step
  */
 export async function buildCustomCommandConfigFile(workspaceDirectory: string): Promise<void> {
+    // Skip custom command config creation for .code-workspace files
+    if (workspaceDirectory.endsWith('.code-workspace')) {
+        return
+    }
+
     const codyJsonPath = join(workspaceDirectory, '.vscode', 'cody.json')
     await new Promise<void>((resolve, reject) => {
         writeFile(codyJsonPath, JSON.stringify(codyJson), error => {


### PR DESCRIPTION
Refs CODY-6072 
This commit adds support for multi-root workspaces in the initial context feature.
See https://www.youtube.com/watch?v=s53bFuT0SoY for a video demo of the enhancement in action.

## Test plan
- Manually tested with a multi-root workspace to verify the initial context switches correctly between workspace folders.
