### PR TITLE
Fix a crash on auto-edit popup disposal

### DIFF
--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/autoedit/AutoeditLineStatusMarkerPopupPanel.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/autoedit/AutoeditLineStatusMarkerPopupPanel.kt
@@ -12,6 +12,7 @@ import com.intellij.diff.util.DiffUtil
 import com.intellij.diff.util.TextDiffType
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.LogicalPosition
@@ -144,7 +145,7 @@ private constructor(val editor: Editor, private val editorComponent: JComponent)
               }
             }
           })
-      connect.subscribe(AutoeditManager.TOPIC, Runnable { hint.hide() })
+      connect.subscribe(AutoeditManager.TOPIC, Runnable { runInEdt { hint.hide() } })
 
       if (!hint.isVisible) {
         closeListener.hintHidden(EventObject(hint))


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/QA-754/jb-specific-crash-occurred-while-the-auto-edit-triggered-and-user.

## Test plan

1. Trigger auto-edit
2. Minimise the editor

---

1. Trigger auto-edit
2. Trigger auto-edit via Search Action

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
