### PR TITLE
chore(agent): bump release version to 5.5.22

### DIFF
--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -10,6 +10,12 @@ This is a log of all notable changes to the Cody command-line tool. [Unreleased]
 
 ### Changed
 
+## 5.5.22
+
+### Fixed
+
+- `cody models list` now correctly lists models that are available for the current user.
+
 ## 5.5.15
 
 ### Fixed
@@ -82,6 +88,7 @@ This is a log of all notable changes to the Cody command-line tool. [Unreleased]
 - Running `cody help` should work now. It was previously crashing about a missing keytar dependencies.
 
 ## 0.1.1
+
 ### Fixed
 
 - Running `npm install -g @sourcegraph/cody-agent` should work now. It was previously crashing about a missing keytar dependency.

--- a/agent/package.json
+++ b/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/cody",
-  "version": "5.5.21",
+  "version": "5.5.22",
   "description": "Cody CLI is the same technology that powers Cody in the IDE but available from the command-line.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Fixes CODY-6118
## Test plan
- Test that chat models lists command works if package is released