### PR TITLE
change(smart-apply): allow apply for shell languages not just execute action

### DIFF
--- a/vscode/webviews/chat/ChatMessageContent/EditButtons.tsx
+++ b/vscode/webviews/chat/ChatMessageContent/EditButtons.tsx
@@ -186,10 +186,7 @@ function createEditButtonsSmartApply({
             {smartApplyState !== CodyTaskState.Applied && (
                 <>
                     {onExecute && isVSCode && createExecuteButton(onExecute)}
-                    {!onExecute &&
-                        smartApply &&
-                        onSmartApply &&
-                        createApplyButton(onSmartApply, smartApplyState)}
+                    {smartApply && onSmartApply && createApplyButton(onSmartApply, smartApplyState)}
                 </>
             )}
             {isVSCode && createActionsDropdown(preText)}

--- a/vscode/webviews/components/RichCodeBlock.story.tsx
+++ b/vscode/webviews/components/RichCodeBlock.story.tsx
@@ -149,7 +149,6 @@ export const ShellCommand: StoryObj<typeof meta> = {
         plainCode: 'echo "Hello, World!"',
         markdownCode: '```bash\necho "Hello, World!"\n```',
         language: 'bash',
-        isShellCommand: true,
         onExecute: cmd => console.log('Execute command:', cmd),
     },
 }

--- a/vscode/webviews/components/RichCodeBlock.tsx
+++ b/vscode/webviews/components/RichCodeBlock.tsx
@@ -21,7 +21,6 @@ interface RichCodeBlockProps {
     fileName?: string
     isMessageLoading: boolean // Whether the whole message is done loading
     isCodeComplete: boolean // Whether this code block has been completed
-    isShellCommand: boolean
     guardrails: Guardrails
     onCopy?: (code: string) => void
     onInsert?: (code: string, newFile?: boolean) => void
@@ -51,7 +50,6 @@ export const RichCodeBlock: React.FC<RichCodeBlockProps> = ({
     fileName,
     isMessageLoading,
     isCodeComplete,
-    isShellCommand,
     guardrails,
     onCopy,
     onInsert,
@@ -68,8 +66,8 @@ export const RichCodeBlock: React.FC<RichCodeBlockProps> = ({
     // Smart apply is only applicable if the code is complete. These properties
     // will be stable (undefined) until the code is complete, skipping any
     // updates caused by incomplete code as it is streamed.
-    const smartApplyCode = smartApply && isCodeComplete && !isShellCommand ? plainCode : undefined
-    const smartApplyFilename = smartApply && isCodeComplete && !isShellCommand ? fileName : undefined
+    const smartApplyCode = smartApply && isCodeComplete ? plainCode : undefined
+    const smartApplyFilename = smartApply && isCodeComplete ? fileName : undefined
     const thisTaskId = useMemo(() => {
         if (!smartApplyCode) {
             return undefined

--- a/vscode/webviews/components/RichMarkdown.tsx
+++ b/vscode/webviews/components/RichMarkdown.tsx
@@ -139,7 +139,6 @@ export const RichMarkdown: React.FC<RichMarkdownProps> = ({
                     fileName={filePath}
                     isMessageLoading={isMessageLoading}
                     isCodeComplete={!regenerating && (isThisBlockComplete || !isMessageLoading)}
-                    isShellCommand={isShellCommand}
                     guardrails={guardrails}
                     onCopy={onCopy}
                     onInsert={onInsert}


### PR DESCRIPTION
Fixes CODY-6175

The `isShellCommand` prop was originally used to prevent smart apply from being applied to shell commands. However, this distinction is no longer necessary.

## Test plan

- Ask for a change for a .sh file
- See that you can now apply changes instead of getting only the execute button
- Check that smart apply works on these .bash or .sh files.