### PR TITLE
Fix issue where the "Skip to end" button remains when switching to a new chat window

### DIFF
--- a/vscode/webviews/chat/Transcript.test.tsx
+++ b/vscode/webviews/chat/Transcript.test.tsx
@@ -350,6 +350,14 @@ describe('Transcript', () => {
         expect(submitButtons).toHaveLength(3) // One button per editor per message.
         expect(submitButtons[0]).toBeEnabled()
     })
+
+    test('does not show ScrollDown button when transcript is empty', () => {
+        render(<Transcript {...PROPS} transcript={[]} />)
+
+        // ScrollDown should not be present in empty transcript
+        const scrollDownButton = screen.queryByText(/skip to end/i)
+        expect(scrollDownButton).not.toBeInTheDocument()
+    })
 })
 
 type EditorHTMLElement = HTMLDivElement & { dataset: { lexicalEditor: 'true' } }

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -286,7 +286,9 @@ export const Transcript: FC<TranscriptProps> = props => {
 
                     {scrollableContainer && <ScrollbarMarkers scrollContainer={scrollableContainer} />}
 
-                    {!isAtBottomDebounced && <ScrollDown onClick={scrollTotheBottom} />}
+                    {!isAtBottomDebounced && interactions.length > 1 && (
+                        <ScrollDown onClick={scrollTotheBottom} />
+                    )}
 
                     <div className="tw-bg-[var(--vscode-input-background)]">
                         {inputInteractionAtTheBottom &&


### PR DESCRIPTION
Fixes [QA-736](https://linear.app/sourcegraph/issue/QA-736/core-skip-to-end-toast-message-remains-stuck-after-clicking-new-chat)

## Test plan

Ran unit tests and integration tests. Checked the behavior locally.