### PR TITLE
Limit access for PG & ES

### DIFF
--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/auth/PlgEsAccess.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/auth/PlgEsAccess.kt
@@ -1,0 +1,30 @@
+package com.sourcegraph.cody.auth
+
+import java.util.*
+
+/**
+ * Utility to check if PLG ES access is disabled based on date.
+ * PLG ES access is disabled after July 23, 2025 10:00 AM PST
+ */
+object PlgEsAccess {
+    // July 23, 2025 10:00 AM PST (UTC-8) = July 23, 2025 18:00 UTC
+    private val PLG_ES_ACCESS_DISABLE_DATE = Calendar.getInstance(TimeZone.getTimeZone("UTC")).apply {
+        set(2025, Calendar.JULY, 23, 18, 0, 0)
+        set(Calendar.MILLISECOND, 0)
+    }.time
+
+    fun isDisabled(): Boolean {
+        return Date() > PLG_ES_ACCESS_DISABLE_DATE
+    }
+
+    fun isWorkspaceInstance(url: String): Boolean {
+        return try {
+            val host = java.net.URL(url).host.lowercase()
+            host.endsWith(".sourcegraph.app") || 
+            host.endsWith(".sourcegraphdev.app") || 
+            host.endsWith(".sourcegraphapp.test:3443")
+        } catch (e: Exception) {
+            false
+        }
+    }
+}

--- a/vscode/src/utils/plg-es-access.ts
+++ b/vscode/src/utils/plg-es-access.ts
@@ -1,0 +1,6 @@
+// PLG ES access is disabled after July 23, 2025 10:00 AM PST
+const PLG_ES_ACCESS_DISABLE_DATE = new Date('2025-07-23T18:00:00.000Z')
+
+export function isPlgEsAccessDisabled(): boolean {
+    return new Date() > PLG_ES_ACCESS_DISABLE_DATE
+}


### PR DESCRIPTION
closes: https://linear.app/sourcegraph/issue/CODY-6001/block-free-pro-and-es-users-from-using-cody-extension

This PR will after 23 July 2025:
1. Logout all dotcom and ES users and remove their auth connections. 
2. Remove Free & Pro social login options.
3. Restrict connecting to dotcom or any ES workspace instances.

## Test plan

https://www.loom.com/share/40173205ef2940bfa0b75fea147feead?sid=791b9eb1-94fc-4ce7-a129-f0cc7085c911
