### PR TITLE
fix(notices): correctly inform the cancelled free user of lack of access to Cody

### DIFF
--- a/vscode/webviews/components/Notices.tsx
+++ b/vscode/webviews/components/Notices.tsx
@@ -92,8 +92,8 @@ export const Notices: React.FC<NoticesProps> = ({ user, instanceNotices }) => {
         }
         // For free users, check if they have a subscription
         const hasSubscription =
-            user.currentUserCodySubscription && user.currentUserCodySubscription !== null
-        if (hasSubscription) {
+            user.currentUserCodySubscription !== null && user.currentUserCodySubscription !== undefined
+        if (hasSubscription && user.currentUserCodySubscription?.status !== 'CANCELED') {
             return CODY_DEPRECATION_MESSAGES.FREE_USER_WITH_CODY
         }
         return CODY_DEPRECATION_MESSAGES.FREE_USER_WITHOUT_CODY


### PR DESCRIPTION
Refs CODY-6109

<img width="712" height="326" alt="image" src="https://github.com/user-attachments/assets/4e163873-f8ae-469e-a77f-d9ea3452b459" />


## Test plan
- Test with a free user made after 25 June
- Check that the message about not having access is correctly set
