### PR TITLE
Improve markdown component caching

### DIFF
--- a/vscode/webviews/chat/ChatMessageContent/ChatMessageContent.tsx
+++ b/vscode/webviews/chat/ChatMessageContent/ChatMessageContent.tsx
@@ -1,7 +1,7 @@
 import type { Guardrails, PromptString } from '@sourcegraph/cody-shared'
 import { clsx } from 'clsx'
 import type React from 'react'
-import { useCallback, useMemo } from 'react'
+import { memo, useCallback, useMemo } from 'react'
 import { RichMarkdown } from '../../components/RichMarkdown'
 import { getVSCodeAPI } from '../../utils/VSCodeApi'
 import { useConfig } from '../../utils/useConfig'
@@ -51,71 +51,79 @@ interface ChatMessageContentProps {
 /**
  * A component presenting the content of a chat message.
  */
-export const ChatMessageContent: React.FunctionComponent<ChatMessageContentProps> = ({
-    displayMarkdown,
-    isMessageLoading,
-    humanMessage,
-    copyButtonOnSubmit,
-    insertButtonOnSubmit,
-    onRegenerate,
-    regeneratingCodeBlocks,
-    guardrails,
-    className,
-    smartApply,
-    isThoughtProcessOpened,
-    setThoughtProcessOpened,
-}) => {
-    const config = useConfig()
+export const ChatMessageContent: React.FunctionComponent<ChatMessageContentProps> = memo(
+    ({
+        displayMarkdown,
+        isMessageLoading,
+        humanMessage,
+        copyButtonOnSubmit,
+        insertButtonOnSubmit,
+        onRegenerate,
+        regeneratingCodeBlocks,
+        guardrails,
+        className,
+        smartApply,
+        isThoughtProcessOpened,
+        setThoughtProcessOpened,
+    }) => {
+        const config = useConfig()
 
-    const { displayContent, thinkContent, isThinking } = useMemo(
-        () => extractThinkContent(displayMarkdown),
-        [displayMarkdown]
-    )
+        const { displayContent, thinkContent, isThinking } = useMemo(
+            () => extractThinkContent(displayMarkdown),
+            [displayMarkdown]
+        )
 
-    const onInsert = config.config.hasEditCapability ? insertButtonOnSubmit : undefined
+        const onInsert = useMemo(
+            () => (config.config.hasEditCapability ? insertButtonOnSubmit : undefined),
+            [config.config.hasEditCapability, insertButtonOnSubmit]
+        )
 
-    let onExecute: ((command: string) => void) | undefined = useCallback((command: string) => {
-        // Execute command in terminal
-        const vscodeAPI = getVSCodeAPI()
-        vscodeAPI.postMessage({
-            command: 'command',
-            id: 'cody.terminal.execute',
-            arg: command.trim(),
-        })
-    }, [])
+        let onExecute: ((command: string) => void) | undefined = useCallback((command: string) => {
+            // Execute command in terminal
+            const vscodeAPI = getVSCodeAPI()
+            vscodeAPI.postMessage({
+                command: 'command',
+                id: 'cody.terminal.execute',
+                arg: command.trim(),
+            })
+        }, [])
 
-    // TODO: Replace this isVSCode check with a client capability check for
-    // terminal execution when agent/src/vscode-shim.ts implements `terminal()`
-    onExecute = config.clientCapabilities.isVSCode ? onExecute : undefined
+        // TODO: Replace this isVSCode check with a client capability check for
+        // terminal execution when agent/src/vscode-shim.ts implements `terminal()`
+        onExecute = useMemo(
+            () => (config.clientCapabilities.isVSCode ? onExecute : undefined),
+            [config.clientCapabilities.isVSCode, onExecute]
+        )
 
-    const onCopy = useCallback(
-        (code: string) => copyButtonOnSubmit?.(code, 'Button'),
-        [copyButtonOnSubmit]
-    )
+        const onCopy = useCallback(
+            (code: string) => copyButtonOnSubmit?.(code, 'Button'),
+            [copyButtonOnSubmit]
+        )
 
-    return (
-        <div data-testid="chat-message-content">
-            {setThoughtProcessOpened && thinkContent.length > 0 && (
-                <ThinkingCell
-                    isOpen={!!isThoughtProcessOpened}
-                    setIsOpen={setThoughtProcessOpened}
-                    isThinking={isMessageLoading && isThinking}
-                    thought={thinkContent}
+        return (
+            <div data-testid="chat-message-content">
+                {setThoughtProcessOpened && thinkContent.length > 0 && (
+                    <ThinkingCell
+                        isOpen={!!isThoughtProcessOpened}
+                        setIsOpen={setThoughtProcessOpened}
+                        isThinking={isMessageLoading && isThinking}
+                        thought={thinkContent}
+                    />
+                )}
+                <RichMarkdown
+                    markdown={displayContent}
+                    isMessageLoading={isMessageLoading}
+                    guardrails={guardrails}
+                    onCopy={onCopy}
+                    onInsert={onInsert}
+                    onExecute={onExecute}
+                    onRegenerate={onRegenerate}
+                    regeneratingCodeBlocks={regeneratingCodeBlocks}
+                    smartApply={smartApply}
+                    className={clsx(styles.content, className)}
+                    hasEditIntent={humanMessage?.intent === 'edit'}
                 />
-            )}
-            <RichMarkdown
-                markdown={displayContent}
-                isMessageLoading={isMessageLoading}
-                guardrails={guardrails}
-                onCopy={onCopy}
-                onInsert={onInsert}
-                onExecute={onExecute}
-                onRegenerate={onRegenerate}
-                regeneratingCodeBlocks={regeneratingCodeBlocks}
-                smartApply={smartApply}
-                className={clsx(styles.content, className)}
-                hasEditIntent={humanMessage?.intent === 'edit'}
-            />
-        </div>
-    )
-}
+            </div>
+        )
+    }
+)

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -687,7 +687,7 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
 
     const onRegenerate = useCallback(
         (code: string, language?: string) => {
-            if (assistantMessage) {
+            if (assistantMessage?.index) {
                 const id = uuid.v4()
                 regenerateCodeBlock({ id, code, language, index: assistantMessage.index })
                 setRegeneratingCodeBlocks(blocks => [
@@ -698,7 +698,7 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
                 console.warn('tried to regenerate a code block, but there is no assistant message')
             }
         },
-        [assistantMessage]
+        [assistantMessage?.index]
     )
 
     const isAgenticMode = useMemo(

--- a/vscode/webviews/components/RichMarkdown.tsx
+++ b/vscode/webviews/components/RichMarkdown.tsx
@@ -2,6 +2,7 @@ import type { Guardrails } from '@sourcegraph/cody-shared'
 import { clsx } from 'clsx'
 import type { Code, Root } from 'mdast'
 import type React from 'react'
+import { memo, useCallback, useMemo } from 'react'
 import type { Plugin } from 'unified'
 import { visit } from 'unist-util-visit'
 import type { CodeBlockActionsProps } from '../chat/ChatMessageContent/ChatMessageContent'
@@ -70,96 +71,114 @@ export const remarkAttachCompletedCodeBlocks: Plugin<[], Root> = () => {
  * which provides syntax highlighting, action buttons, and optional guardrails
  * protection.
  */
-export const RichMarkdown: React.FC<RichMarkdownProps> = ({
-    markdown,
-    isMessageLoading,
-    regeneratingCodeBlocks,
-    guardrails,
-    onCopy,
-    onInsert,
-    onExecute,
-    onRegenerate,
-    smartApply,
-    className,
-    hasEditIntent,
-}) => {
-    // Handle rendering of code blocks with our custom RichCodeBlock component
-    const components = {
-        pre({ node, inline, className, children, ...props }: any) {
-            // Don't process inline code blocks
-            if (inline) {
-                return (
-                    <code className={className} {...props}>
-                        {children}
-                    </code>
-                )
+export const RichMarkdown: React.FC<RichMarkdownProps> = memo(
+    ({
+        markdown,
+        isMessageLoading,
+        regeneratingCodeBlocks,
+        guardrails,
+        onCopy,
+        onInsert,
+        onExecute,
+        onRegenerate,
+        smartApply,
+        className,
+        hasEditIntent,
+    }) => {
+        // Memoize the extractText function to avoid recreating it every render
+        const extractText = useCallback((node: any): string => {
+            if (typeof node === 'string') return node
+            if (!node) return ''
+            if (node.type === 'text' && node.value) return node.value
+            if (node.children) {
+                return node.children.map(extractText).join('')
             }
+            return ''
+        }, [])
 
-            // Get the code node (if it exists)
-            const codeNode =
-                node.children.length === 1 && node.children[0].type === 'element'
-                    ? node.children[0]
-                    : null
+        // Handle rendering of code blocks with our custom RichCodeBlock component
+        const components = useMemo(
+            () => ({
+                pre({ node, inline, className, children, ...props }: any) {
+                    // Don't process inline code blocks
+                    if (inline) {
+                        return (
+                            <code className={className} {...props}>
+                                {children}
+                            </code>
+                        )
+                    }
 
-            // Get the cached highlighting result (if there is a key, and if the result is cached)
-            const {
-                'data-source-text': sourceText,
-                'data-is-code-complete': isThisBlockComplete,
-                'data-file-path': filePath,
-                'data-language': language,
-            } = (codeNode?.properties as TerminatedCodeData['hProperties'] | undefined) || {
-                'data-is-code-complete': false,
-            }
+                    // Get the code node (if it exists)
+                    const codeNode =
+                        node.children.length === 1 && node.children[0].type === 'element'
+                            ? node.children[0]
+                            : null
 
-            const extractText = (node: any): string => {
-                if (typeof node === 'string') return node
-                if (!node) return ''
-                if (node.type === 'text' && node.value) return node.value
-                if (node.children) {
-                    return node.children.map(extractText).join('')
-                }
-                return ''
-            }
-            const plainText = extractText(node)
+                    // Get the cached highlighting result (if there is a key, and if the result is cached)
+                    const {
+                        'data-source-text': sourceText,
+                        'data-is-code-complete': isThisBlockComplete,
+                        'data-file-path': filePath,
+                        'data-language': language,
+                    } = (codeNode?.properties as TerminatedCodeData['hProperties'] | undefined) || {
+                        'data-is-code-complete': false,
+                    }
 
-            // Determine if this is a shell command
-            const isShellCommand = language === 'bash' || language === 'sh'
+                    const plainText = extractText(node)
 
-            const regenerating = regeneratingCodeBlocks.find(
-                block => block.code === plainText && !block.error
-            )
+                    // Determine if this is a shell command
+                    const isShellCommand = language === 'bash' || language === 'sh'
 
-            // Render with our RichCodeBlock component
-            return (
-                <RichCodeBlock
-                    hasEditIntent={hasEditIntent}
-                    plainCode={plainText}
-                    markdownCode={sourceText ?? ''}
-                    language={language}
-                    fileName={filePath}
-                    isMessageLoading={isMessageLoading}
-                    isCodeComplete={!regenerating && (isThisBlockComplete || !isMessageLoading)}
-                    guardrails={guardrails}
-                    onCopy={onCopy}
-                    onInsert={onInsert}
-                    onExecute={isShellCommand ? onExecute : undefined}
-                    onRegenerate={onRegenerate}
-                    smartApply={smartApply}
+                    const regenerating = regeneratingCodeBlocks.find(
+                        block => block.code === plainText && !block.error
+                    )
+
+                    // Render with our RichCodeBlock component
+                    return (
+                        <RichCodeBlock
+                            hasEditIntent={hasEditIntent}
+                            plainCode={plainText}
+                            markdownCode={sourceText ?? ''}
+                            language={language}
+                            fileName={filePath}
+                            isMessageLoading={isMessageLoading}
+                            isCodeComplete={!regenerating && (isThisBlockComplete || !isMessageLoading)}
+                            guardrails={guardrails}
+                            onCopy={onCopy}
+                            onInsert={onInsert}
+                            onExecute={isShellCommand ? onExecute : undefined}
+                            onRegenerate={onRegenerate}
+                            smartApply={smartApply}
+                        >
+                            {children}
+                        </RichCodeBlock>
+                    )
+                },
+            }),
+            [
+                extractText,
+                hasEditIntent,
+                regeneratingCodeBlocks,
+                isMessageLoading,
+                guardrails,
+                onCopy,
+                onInsert,
+                onExecute,
+                onRegenerate,
+                smartApply,
+            ]
+        )
+
+        return (
+            <div className={clsx('markdown-content', className)}>
+                <MarkdownFromCody
+                    components={components}
+                    prefixRemarkPlugins={[remarkAttachCompletedCodeBlocks]}
                 >
-                    {children}
-                </RichCodeBlock>
-            )
-        },
+                    {markdown}
+                </MarkdownFromCody>
+            </div>
+        )
     }
-
-    return (
-        <div className={clsx('markdown-content', className)}>
-            <MarkdownFromCody
-                components={components}
-                prefixRemarkPlugins={[remarkAttachCompletedCodeBlocks]}
-            >
-                {markdown}
-            </MarkdownFromCody>
-        </div>
-    )
-}
+)


### PR DESCRIPTION
This PR is not fixing a memory leak in the DOM highlighter code but significantly reduces amount of re-computation which is done. With mocked LLM response of length of 7528 characters I get:

**Before my changes:**

Execution time: 1 min 25 s ec
Peak memory used: over 2GB
Stable memory after final GC: 833MB 

**After my changes:**

Execution time: **45 sec**
Peak memory used: over 1GB
Stable memory after final GC: 719MB 

Sop while memory usage drop was not significant there is very visible speedup in the execution speed.
Also memory usage swings were subjectively less significant.

## Test plan

I do not have good testing procedure on `main`, but I di testing using my testing PR, with some custom logging:
https://github.com/sourcegraph/cody/pull/8167
