### PR TITLE
Update gradle toolchains resolver

### DIFF
--- a/jetbrains/build.gradle.kts
+++ b/jetbrains/build.gradle.kts
@@ -59,8 +59,8 @@ val skippedFailureLevels =
 plugins {
   id("java")
   id("jvm-test-suite")
-  id("org.jetbrains.kotlin.jvm") version "2.1.10"
-  id("org.jetbrains.intellij.platform") version "2.2.1"
+  id("org.jetbrains.kotlin.jvm") version "2.2.0"
+  id("org.jetbrains.intellij.platform") version "2.6.0"
   id("org.jetbrains.changelog") version "2.2.1"
   id("com.diffplug.spotless") version "7.0.2"
   id("io.sentry.jvm.gradle") version "5.2.0"
@@ -169,20 +169,6 @@ spotless {
         "src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/**",
         "src/integrationTest/resources/testProjects/**")
     toggleOffOn()
-  }
-}
-
-java {
-  toolchain {
-    languageVersion.set(JavaLanguageVersion.of(javaVersion.toInt()))
-    vendor = JvmVendorSpec.JETBRAINS
-  }
-}
-
-kotlin {
-  jvmToolchain {
-    languageVersion.set(JavaLanguageVersion.of(javaVersion.toInt()))
-    vendor = JvmVendorSpec.JETBRAINS
   }
 }
 

--- a/jetbrains/settings.gradle.kts
+++ b/jetbrains/settings.gradle.kts
@@ -1,6 +1,6 @@
 rootProject.name = "Sourcegraph"
 
-plugins { id("org.gradle.toolchains.foojay-resolver-convention") version ("0.4.0") }
+plugins { id("org.gradle.toolchains.foojay-resolver-convention") version ("1.0.0") }
 
 val isCiServer = System.getenv().containsKey("CI")
 


### PR DESCRIPTION
## Changes

This should fix the problem visible on other builds on the CI:

```
* What went wrong:
Could not determine the dependencies of task ':compileKotlin'.
> Cannot find a Java installation on your machine matching this tasks requirements: {languageVersion=17, vendor=JetBrains, implementation=vendor-specific} for LINUX on x86_64.
   > No matching toolchain could be found in the locally installed toolchains or the configured toolchain download repositories.
```

Looks like resolver we are using is too old, but I'm not sure why it started to fail just now (I guess it must be some change on the toolchains repositories side).

## Test plan

Green CI

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
