### PR TITLE
Fix NPE exception reported by Sentry

### DIFF
--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/listeners/CodyElementRefactoringListenerProvider.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/listeners/CodyElementRefactoringListenerProvider.kt
@@ -9,14 +9,23 @@ import com.sourcegraph.cody.agent.protocol_generated.TextDocument_DidRenameParam
 
 class CodyElementListenerProvider : RefactoringElementListenerProvider {
   override fun getListener(element: PsiElement): RefactoringElementListener {
-    val uriBefore = vscNormalizedUriFor(element.containingFile.virtualFile)
+
     return object : RefactoringElementListener {
+      val uriBefore = getContainingFileUri(element)
+
       override fun elementMoved(newPsiElement: PsiElement) = notifyAgent(newPsiElement)
 
       override fun elementRenamed(newPsiElement: PsiElement) = notifyAgent(newPsiElement)
 
+      private fun getContainingFileUri(element: PsiElement): String? {
+        if (element.containingFile.virtualFile == null) {
+          return null
+        }
+        return vscNormalizedUriFor(element.containingFile.virtualFile)
+      }
+
       private fun notifyAgent(newPsiElement: PsiElement) {
-        val uriAfter = vscNormalizedUriFor(newPsiElement.containingFile.virtualFile)
+        val uriAfter = getContainingFileUri(newPsiElement)
         if (uriBefore == null || uriAfter == null || uriBefore == uriAfter) {
           return
         }


### PR DESCRIPTION
## Changes

Fix for the NPE in the `CodyElementListenerProvider` reported by Sentry:

```
Cannot invoke "com.intellij.psi.PsiFile.getVirtualFile()" because the return value of "com.intellij.psi.PsiElement.getContainingFile()" is null
com.sourcegraph.cody.listeners.CodyElementListenerProvider in getListener at line 12

In App
com.intellij.refactoring.listeners.impl.RefactoringTransactionImpl in addAffectedElement at line 46
com.intellij.refactoring.listeners.impl.RefactoringTransactionImpl$MyRefactoringElementListener in <init> at line 73
(...)
```

## Test plan

I'm not sure how to replicate the issue but the source of the problem is pretty clear.

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
