### PR TITLE
chore: add deprecation notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+> [!NOTE]
+> Cody transitioned to a private repo. This repository, `sourcegraph/cody-public-snapshot` is a publicly available copy of the `sourcegraph/cody` repository as it was just before the migration.
+
+> [!TIP]
+> If you are interested in working with the code, this [commit](https://github.com/sourcegraph/cody-public-snapshot/commit/d91e8e4a06233ddd80ad5618a313b66c1ea4ee7a) is the last one made under an Apache License.
+
+---
+
 <div align=center>
 
 # <img src="https://storage.googleapis.com/sourcegraph-assets/cody/20230417/logomark-default.svg" width="26"> Cody


### PR DESCRIPTION
This PR adds a notice to the README letting people know that Cody is now deprecated and transitioned to a private repository.

<img width="1868" height="1062" alt="CleanShot 2025-07-23 at 10 20 07@2x" src="https://github.com/user-attachments/assets/8a49f04a-1959-4db2-bc4b-cb19e00e72bb" />


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
CI
