### PR TITLE
Improve Cody Console in JetBrains

### DIFF
--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/error/CodyConsole.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/error/CodyConsole.kt
@@ -1,54 +1,122 @@
 package com.sourcegraph.cody.error
 
+import com.intellij.execution.actions.ClearConsoleAction
 import com.intellij.execution.filters.TextConsoleBuilderFactory
 import com.intellij.execution.ui.ConsoleViewContentType
+import com.intellij.openapi.actionSystem.*
 import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.SimpleToolWindowPanel
 import com.intellij.openapi.wm.ToolWindowManager
-import com.intellij.ui.content.Content
 import com.sourcegraph.cody.agent.protocol_generated.DebugMessage
 import com.sourcegraph.config.ConfigUtil
 
 @Service(Service.Level.PROJECT)
-class CodyConsole(project: Project) {
+class CodyConsole(val project: Project) {
   private val logger = Logger.getInstance(CodyConsole::class.java)
-  private val consoleView = TextConsoleBuilderFactory.getInstance().createBuilder(project).console
   private val toolWindow = ToolWindowManager.getInstance(project).getToolWindow("Problems View")
-  var content: Content? = null
+  private val consoleViews = mutableMapOf<String, com.intellij.execution.ui.ConsoleView>()
+
+  private val storedMessages = mutableMapOf<String, MutableList<DebugMessage>>()
+  private val showErrorsAndWarnsOnly = mutableMapOf<String, Boolean>()
 
   fun addMessage(message: DebugMessage) {
     if (toolWindow?.isDisposed != false) return
+    storedMessages.getOrPut(message.channel) { mutableListOf() }.add(message)
+    printMessage(message, useLogger = true)
+  }
 
-    val messageText = "${message.channel}: ${message.message}\n"
-    if (message.level == "error" || message.level == "warn") {
-      runInEdt { content?.let { toolWindow.contentManager.setSelectedContent(it) } }
-      consoleView.print(messageText, ConsoleViewContentType.ERROR_OUTPUT)
-      logger.warn(messageText)
-    } else if (ConfigUtil.isCodyDebugEnabled()) {
-      consoleView.print(messageText, ConsoleViewContentType.NORMAL_OUTPUT)
-      logger.info(messageText)
+  private fun printMessage(message: DebugMessage, useLogger: Boolean = false) {
+    val channel = message.channel
+    val consoleView = getOrCreateConsoleForChannel(channel)
+
+    val isErrorOrWarn = message.level == "error" || message.level == "warn"
+    if (showErrorsAndWarnsOnly.getOrPut(channel) { false } && !isErrorOrWarn) {
+      return
     }
 
-    if (ConfigUtil.isCodyDebugEnabled() && ConfigUtil.isDevMode()) {
-      toolWindow.contentManager.getReady(this).doWhenDone {
-        if (!toolWindow.isVisible) {
-          runInEdt { toolWindow.show() }
-        }
-      }
+    val messageText = "${message.message}\n"
+    if (isErrorOrWarn) {
+      consoleView.print(messageText, ConsoleViewContentType.ERROR_OUTPUT)
+      if (useLogger) logger.warn("$channel: ${message.message}")
+    } else if (ConfigUtil.isCodyDebugEnabled() || ConfigUtil.isDevMode()) {
+      consoleView.print(messageText, ConsoleViewContentType.NORMAL_OUTPUT)
+      if (useLogger) logger.info("$channel: ${message.message}")
     }
   }
 
-  init {
+  private fun getOrCreateConsoleForChannel(channel: String): com.intellij.execution.ui.ConsoleView {
+    return consoleViews.getOrPut(channel) {
+      val consoleView = TextConsoleBuilderFactory.getInstance().createBuilder(project).console
+
+      val toggleAction =
+          object :
+              ToggleAction(
+                  { "Only Show Errors And Warnings" }, com.intellij.icons.AllIcons.General.Error) {
+            override fun isSelected(e: AnActionEvent): Boolean {
+              return showErrorsAndWarnsOnly[channel] ?: false
+            }
+
+            override fun getActionUpdateThread(): ActionUpdateThread {
+              return ActionUpdateThread.EDT
+            }
+
+            override fun setSelected(e: AnActionEvent, state: Boolean) {
+              showErrorsAndWarnsOnly[channel] = state
+              refreshConsole(channel)
+            }
+          }
+
+      val clearAction =
+          object : ClearConsoleAction() {
+            override fun actionPerformed(e: AnActionEvent) {
+              consoleView.clear()
+              storedMessages[channel]?.clear()
+            }
+
+            override fun getActionUpdateThread(): ActionUpdateThread {
+              return ActionUpdateThread.EDT
+            }
+          }
+
+      runInEdt {
+        if (toolWindow?.isDisposed != false) return@runInEdt
+
+        val component = consoleView.component
+        val factory = toolWindow.contentManager.factory
+
+        val actions = consoleView.createConsoleActions().toMutableList()
+        actions.removeIf({ it is ClearConsoleAction })
+        actions.add(clearAction)
+        actions.add(toggleAction)
+
+        val actionGroup = DefaultActionGroup(actions)
+        val toolbar =
+            ActionManager.getInstance().createActionToolbar("CodyConsole", actionGroup, false)
+        toolbar.targetComponent = component
+
+        val panel = SimpleToolWindowPanel(false, true)
+        panel.toolbar = toolbar.component
+        panel.setContent(component)
+
+        val content = factory.createContent(panel, channel, true)
+        toolWindow.contentManager.addContent(content)
+      }
+
+      consoleView
+    }
+  }
+
+  private fun refreshConsole(channel: String) {
+    val consoleView = consoleViews[channel] ?: return
+    val messages = storedMessages[channel] ?: return
+
     runInEdt {
-      if (toolWindow?.isDisposed != false) return@runInEdt
-      val factory = toolWindow.contentManager.factory
-      content =
-          factory
-              .createContent(consoleView.component, "Cody Console", true)
-              .also(toolWindow.contentManager::addContent)
+      consoleView.clear()
+      messages.forEach { message -> printMessage(message) }
     }
   }
 

--- a/lib/shared/src/telemetry-v2/cody-tier.ts
+++ b/lib/shared/src/telemetry-v2/cody-tier.ts
@@ -6,6 +6,7 @@ enum CodyTier {
     Free = 0,
     Pro = 1,
     Enterprise = 2,
+    NotAuthenticated = 3,
 }
 
 export function getTier(
@@ -13,7 +14,7 @@ export function getTier(
     sub: UserProductSubscription | null
 ): CodyTier | undefined {
     return !authStatus.authenticated
-        ? undefined
+        ? CodyTier.NotAuthenticated
         : !isDotCom(authStatus)
           ? CodyTier.Enterprise
           : !sub || sub.userCanUpgrade


### PR DESCRIPTION
# PR Summary: Improve Cody Console in JetBrains

## Overview
Enhanced the JetBrains Cody Console with multi-channel support, filtering capabilities, and improved UI.

## Key Changes

### JetBrains Console Improvements
- **Multi-channel support**: Console now creates separate tabs for different channels
- **Message filtering**: Added toggle to show only errors and warnings 
- **Custom toolbar**: Added clear and filter actions to each console tab
- **Message storage**: Console now stores messages for filtering and refreshing
- **Better error handling**: Improved message categorisation and display

### VSCode/Core Logging Fixes
- **Log level fix**: Upgraded VSCode output channels to use proper log levels
- **Telemetry logging fix**: Added `NotAuthenticated` tier to telemetry; previously serialisation failing when user was not authenticated and `tier` was `undefined`

## Test plan

1. Run `/gradlew :customRunIDE` and wait for Cody to start.
2. Open `Problems` view. You should notice two Cody tabs:

<img width="1792" height="598" alt="image" src="https://github.com/user-attachments/assets/f3ff1d46-4485-454d-b82f-8a10641a2896" />

3. You can try to generate some errors (e.g. network errors, byt disabling WiFi and asking Cody some questions) and try how the error filtering works.
