### PR TITLE
fix: resolve issue with artifacts naming 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,10 +186,11 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
-          name: playwright-recordings ${{ matrix.runner }}
+          name: playwright-recordings-${{ github.event.pull_request.number || github.ref }}-${{ matrix.runner }}
           path: |
             playwright/
             vscode/test-results/
+          overwrite: true
 
   build:
     runs-on: ubuntu-latest

--- a/vscode/src/utils/plg-es-access.ts
+++ b/vscode/src/utils/plg-es-access.ts
@@ -1,5 +1,5 @@
 // PLG ES access is disabled after July 23, 2025 10:00 AM PST
-const PLG_ES_ACCESS_DISABLE_DATE = new Date('2025-07-23T18:00:00.000Z')
+const PLG_ES_ACCESS_DISABLE_DATE = new Date('2025-07-24T18:00:00.000Z')
 
 export function isPlgEsAccessDisabled(): boolean {
     return new Date() > PLG_ES_ACCESS_DISABLE_DATE


### PR DESCRIPTION
When a failure occurs in the e2e tests, we upload some of the artifacts for access. However, the naming of this artifact isn't unique and when an artifact with the same name exists, it throws an error.

This PR makes the artifact name unique and overwrites it in the event that running the workflow multiple times returns an error

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
* CI