### PR TITLE
change(chat): enabled support for image upload for models with vision capabilities

### DIFF
--- a/lib/shared/src/models/sync.ts
+++ b/lib/shared/src/models/sync.ts
@@ -254,13 +254,11 @@ export function syncModels({
                                                     )
                                                 }
 
-                                                // Enterprise instances with early access flag enabled
-                                                const isVisionSupported = !isDotComUser && hasEarlyAccess
                                                 data.primaryModels = data.primaryModels.map(m => ({
                                                     ...m,
                                                     // Gateway doesn't suppoort vision models for Google yet
                                                     tags:
-                                                        isVisionSupported && m.provider !== 'google'
+                                                        m.provider !== 'google'
                                                             ? m.tags
                                                             : m.tags.filter(t => t !== ModelTag.Vision),
                                                 }))

--- a/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/Toolbar.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/Toolbar.tsx
@@ -82,12 +82,10 @@ export const Toolbar: FunctionComponent<{
      * or is using a BYOK model with vision tag.
      */
     const isImageUploadEnabled = useMemo(() => {
-        const isDotCom = userInfo?.isDotComUser
         const selectedModel = models?.[0]
-        const isBYOK = selectedModel?.tags?.includes(ModelTag.BYOK)
         const isVision = selectedModel?.tags?.includes(ModelTag.Vision)
-        return (!isDotCom || isBYOK) && isVision
-    }, [userInfo?.isDotComUser, models?.[0]])
+        return isVision
+    }, [models?.[0]])
 
     const modelSelectorRef = useRef<{ open: () => void; close: () => void } | null>(null)
     const promptSelectorRef = useRef<{ open: () => void; close: () => void } | null>(null)


### PR DESCRIPTION


## Test plan
- Enable vision support on the sg instance
- Test for image upload or copy paste (gateway gemini models are not supported)
