### PR TITLE
Prepare cody web 0.34.0

### DIFF
--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.34.0
+- Fixes problem when client configuration updates are ignored after we create new chat
+
 ## 0.33.0
 - A lot of changes since 0.23.1 which haven't been documented well
 (please test new versions manually on the instance locally before publishing).

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.33.0
+- A lot of changes since 0.23.1 which haven't been documented well
+(please test new versions manually on the instance locally before publishing).
+- Adds a possible fix for the "Memory leak" problem (improvements in components memoization).
+- Adds a feature flag cody setting `cody.chatCodeSyntaxHighlightingEnabled` to disable code highlighting of chat code snippets. 
+
 ## 0.23.1
 - Support unicode characters in cody prompt templates @ mentions
 - Remove cody repository as default @ mention for prompt templates

--- a/web/lib/components/use-cody-agent.ts
+++ b/web/lib/components/use-cody-agent.ts
@@ -14,7 +14,7 @@ import { type AgentClient, createAgentClient } from '../agent/agent.client'
  * host sends during chat-switching. Some events should always be handled by the client
  * regardless of which active panel they came from.
  */
-const GLOBAL_MESSAGE_TYPES: Array<ExtensionMessage['type']> = ['rpc/response']
+const GLOBAL_MESSAGE_TYPES: Array<ExtensionMessage['type']> = ['rpc/response', 'clientConfig']
 
 const GLOBAL_AGENT_SHUTDOWN_TIMER = 10 * 60 * 1000 // 10 minutes
 

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/cody-web",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "description": "Cody standalone web app",
   "license": "Apache-2.0",
   "repository": {

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/cody-web",
-  "version": "0.32.12",
+  "version": "0.33.0",
   "description": "Cody standalone web app",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/SRCH-2033/model-dropdown-disappears-in-chat-under-certain-navigation-patterns

0.34.0 version includes a fix for not appearing cody model UI, This happens because in the Sourcegraph web app, we preserve the agent worker between SvelteKit routes, so when we visit the Cody Web page for the second time we skip client configuration updates and since local UI state doesn't contain any default state, we see no model picker. 

This problem is specific to the Cody Web since other cody clients don't operate with code agents like we do in the web app, and they don't need to preserve agent at all, so updates event there go as usuall, in cody web we create agent on the first run and then preserve it and on the second run we call create new chat event (to show you an empty chat page) but since agent already subscribed on the chat events from the prev call we ingored them and didn't get client config information)

Including client config event in the chat tab isolation events is ok since client config is a universal event which is the same for each code chat session.

## Test plan
- Build and link pnpm cody web
- Check that after you go to the cody web page, go somewhere else and going back you still can see cody models picker UI in the toolbar 

